### PR TITLE
Fix [~] in-flight state for dev-relay interop

### DIFF
--- a/skills/dev-backlog/SKILL.md
+++ b/skills/dev-backlog/SKILL.md
@@ -79,7 +79,7 @@ Ordered batches. Small tasks grouped into one session.
 - [x] #39 Seed data script (~10min)
 
 ### Batch 2 — Core auth
-- [ ] #42 OAuth2 flow (~2hr)
+- [~] #42 OAuth2 flow (~2hr) → PR #87 (reviewing)
 
 ### Batch 3 — Hardening (one session)
 - [ ] #43 Rate limiting (~30min)
@@ -100,6 +100,14 @@ Carries across all tasks in this sprint. Add entries as you learn things.
 - 2026-03-22 PM: #42 started. 3/5 AC done. Token refresh logic remaining.
 - 2026-03-23 AM: #42 complete. Started Batch 3.
 ```
+
+### Plan checkbox states
+
+| Marker | Meaning | Set by |
+|--------|---------|--------|
+| `[ ]` | Not started | sprint-init.js or manual |
+| `[~]` | In-flight — dispatched, PR under review | dev-relay (after dispatch) |
+| `[x]` | Done — merged or completed | Manual or dev-relay (after merge) |
 
 ### What each section does
 

--- a/skills/dev-backlog/references/file-format.md
+++ b/skills/dev-backlog/references/file-format.md
@@ -69,17 +69,22 @@ Task files are thin GitHub mirrors. Notes, decisions, and context go in the **sp
 
 ```markdown
 ## Description
-[Synced from GitHub issue body]
+[Synced from GitHub issue body — includes any checkboxes from the issue]
+```
 
+`sync-pull.js` wraps the raw GitHub issue body in `## Description`. Acceptance criteria checkboxes from the issue body appear here as-is. dev-relay and other tools read AC from whatever structure the issue body provides.
+
+For manual task files or Backlog.md CLI compatibility, you can optionally add structured AC markers:
+
+```markdown
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [ ] Condition 1
 - [x] Condition 2 (checked off during work)
-- [ ] Condition 3
 <!-- AC:END -->
 ```
 
-The `<!-- AC:BEGIN -->` and `<!-- AC:END -->` markers are optional but enable machine parsing by Backlog.md CLI. Without them, acceptance criteria still work as plain checkboxes — the file reads fine either way.
+The `<!-- AC:BEGIN/END -->` markers enable machine parsing by the Backlog.md CLI. Without them, acceptance criteria still work as plain checkboxes — the file reads fine either way.
 
 Only AC checkboxes get updated in task files during work. Everything else (notes, technical decisions, running context) lives in the sprint file.
 

--- a/skills/dev-backlog/scripts/next.sh
+++ b/skills/dev-backlog/scripts/next.sh
@@ -35,16 +35,30 @@ if [ -n "$GOAL" ]; then
 fi
 
 # Count progress
-TOTAL=$(grep -c '^\- \[.\] #' "$ACTIVE" 2>/dev/null || echo 0)
-DONE=$(grep -c '^\- \[x\] #' "$ACTIVE" 2>/dev/null || echo 0)
-TODO=$((TOTAL - DONE))
-echo "Progress: $DONE/$TOTAL done ($TODO remaining)"
+TOTAL=$(grep -c '^\- \[.\] #' "$ACTIVE" 2>/dev/null) || TOTAL=0
+DONE=$(grep -c '^\- \[x\] #' "$ACTIVE" 2>/dev/null) || DONE=0
+IN_FLIGHT=$(grep -c '^\- \[~\] #' "$ACTIVE" 2>/dev/null) || IN_FLIGHT=0
+TODO=$((TOTAL - DONE - IN_FLIGHT))
+if [ "$IN_FLIGHT" -gt 0 ]; then
+  echo "Progress: $DONE/$TOTAL done ($IN_FLIGHT in-flight, $TODO remaining)"
+else
+  echo "Progress: $DONE/$TOTAL done ($TODO remaining)"
+fi
 echo ""
 
 # All done?
-if [ "$TODO" -eq 0 ] && [ "$TOTAL" -gt 0 ]; then
+if [ "$TODO" -eq 0 ] && [ "$IN_FLIGHT" -eq 0 ] && [ "$TOTAL" -gt 0 ]; then
   echo "All items checked! Ready to close sprint."
   exit 0
+fi
+
+# Show in-flight items (dispatched via dev-relay, marked [~])
+if [ "$IN_FLIGHT" -gt 0 ]; then
+  echo "In flight:"
+  grep '^\- \[~\] #' "$ACTIVE" | while IFS= read -r line; do
+    echo "  $line"
+  done
+  echo ""
 fi
 
 # Find current batch (first batch with unchecked items)

--- a/skills/dev-backlog/scripts/smoke-test.sh
+++ b/skills/dev-backlog/scripts/smoke-test.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+set -euo pipefail
+# Smoke tests for next.sh and status.sh.
+# Verifies [ ], [x], and [~] checkbox states are parsed correctly.
+#
+# Usage: bash scripts/smoke-test.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+  local label="$1" output="$2" expected="$3"
+  if echo "$output" | grep -qF "$expected"; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected to contain: $expected"
+    echo "  got: $output"
+  fi
+}
+
+assert_not_contains() {
+  local label="$1" output="$2" unexpected="$3"
+  if echo "$output" | grep -qF "$unexpected"; then
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected NOT to contain: $unexpected"
+    echo "  got: $output"
+  else
+    PASS=$((PASS + 1))
+  fi
+}
+
+# --- Test 1: Mixed states ([ ], [x], [~]) ---
+mkdir -p "$TMPDIR/backlog/sprints"
+cat > "$TMPDIR/backlog/sprints/2026-03-test.md" << 'EOF'
+---
+milestone: Test Sprint
+status: active
+started: 2026-03-30
+due: 2026-04-05
+---
+
+# Test Sprint
+
+## Goal
+Test the checkbox parsing.
+
+## Plan
+### Batch 1 — Done
+- [x] #1 Setup DB (~15min)
+- [x] #2 Seed data (~10min)
+
+### Batch 2 — In flight
+- [~] #3 OAuth2 flow (~2hr) → PR #87 (reviewing)
+
+### Batch 3 — Remaining
+- [ ] #4 Rate limiting (~30min)
+- [ ] #5 Input validation (~20min)
+
+## Running Context
+- Test context entry
+
+## Progress
+- 2026-03-30: Batch 1 done.
+EOF
+
+OUT=$(bash "$SCRIPT_DIR/next.sh" "$TMPDIR/backlog")
+assert_contains "next: progress count" "$OUT" "2/5 done"
+assert_contains "next: in-flight count" "$OUT" "1 in-flight"
+assert_contains "next: remaining count" "$OUT" "2 remaining"
+assert_contains "next: shows in-flight item" "$OUT" "[~] #3"
+assert_contains "next: shows next batch item" "$OUT" "[ ] #4"
+assert_not_contains "next: does not show done items as next" "$OUT" "[ ] #1"
+
+OUT=$(bash "$SCRIPT_DIR/status.sh" "$TMPDIR/backlog")
+assert_contains "status: shows in-flight" "$OUT" "1 in-flight"
+assert_contains "status: shows in-flight item" "$OUT" "[~] #3"
+assert_contains "status: shows next up" "$OUT" "Next up:"
+
+# --- Test 2: All done ---
+cat > "$TMPDIR/backlog/sprints/2026-03-test.md" << 'EOF'
+---
+milestone: Test Sprint
+status: active
+started: 2026-03-30
+due: 2026-04-05
+---
+
+# Test Sprint
+
+## Goal
+All done test.
+
+## Plan
+- [x] #1 Task A
+- [x] #2 Task B
+
+## Running Context
+
+## Progress
+EOF
+
+OUT=$(bash "$SCRIPT_DIR/next.sh" "$TMPDIR/backlog")
+assert_contains "all-done: ready to close" "$OUT" "All items checked"
+assert_contains "all-done: 2/2" "$OUT" "2/2 done"
+
+# --- Test 3: All in-flight (nothing to show as "next") ---
+cat > "$TMPDIR/backlog/sprints/2026-03-test.md" << 'EOF'
+---
+milestone: Test Sprint
+status: active
+started: 2026-03-30
+due: 2026-04-05
+---
+
+# Test Sprint
+
+## Goal
+All dispatched.
+
+## Plan
+- [~] #1 Task A → PR #10 (reviewing)
+- [~] #2 Task B → PR #11 (reviewing)
+
+## Running Context
+
+## Progress
+EOF
+
+OUT=$(bash "$SCRIPT_DIR/next.sh" "$TMPDIR/backlog")
+assert_contains "all-inflight: shows in-flight" "$OUT" "2 in-flight"
+assert_contains "all-inflight: 0 remaining" "$OUT" "0 remaining"
+assert_not_contains "all-inflight: not ready to close" "$OUT" "All items checked"
+
+# --- Test 4: No batch headers (flat plan) ---
+cat > "$TMPDIR/backlog/sprints/2026-03-test.md" << 'EOF'
+---
+milestone: Test Sprint
+status: active
+started: 2026-03-30
+due: 2026-04-05
+---
+
+# Test Sprint
+
+## Goal
+Flat plan.
+
+## Plan
+- [x] #1 Done task
+- [~] #2 In-flight task → PR #20
+- [ ] #3 Remaining task
+
+## Running Context
+
+## Progress
+EOF
+
+OUT=$(bash "$SCRIPT_DIR/next.sh" "$TMPDIR/backlog")
+assert_contains "flat: counts correct" "$OUT" "1/3 done"
+assert_contains "flat: in-flight" "$OUT" "1 in-flight"
+assert_contains "flat: remaining" "$OUT" "1 remaining"
+assert_contains "flat: shows in-flight item" "$OUT" "[~] #2"
+assert_contains "flat: shows next item" "$OUT" "[ ] #3"
+
+# --- Results ---
+echo ""
+TOTAL=$((PASS + FAIL))
+echo "$TOTAL tests: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/skills/dev-backlog/scripts/status.sh
+++ b/skills/dev-backlog/scripts/status.sh
@@ -12,17 +12,30 @@ if [ -d "$SPRINTS_DIR" ]; then
   ACTIVE=$(find "$SPRINTS_DIR" -maxdepth 1 -name "*.md" ! -name "_context.md" -exec grep -l "^status: active" {} \; 2>/dev/null | head -1)
   if [ -n "$ACTIVE" ]; then
     SPRINT_NAME=$(basename "$ACTIVE" .md)
-    TOTAL=$(grep -c '^\- \[.\] #' "$ACTIVE" 2>/dev/null || echo 0)
-    DONE=$(grep -c '^\- \[x\] #' "$ACTIVE" 2>/dev/null || echo 0)
-    TODO=$((TOTAL - DONE))
+    TOTAL=$(grep -c '^\- \[.\] #' "$ACTIVE" 2>/dev/null) || TOTAL=0
+    DONE=$(grep -c '^\- \[x\] #' "$ACTIVE" 2>/dev/null) || DONE=0
+    IN_FLIGHT=$(grep -c '^\- \[~\] #' "$ACTIVE" 2>/dev/null) || IN_FLIGHT=0
+    TODO=$((TOTAL - DONE - IN_FLIGHT))
     if [ "$TOTAL" -gt 0 ]; then
       PCT=$((DONE * 100 / TOTAL))
     else
       PCT=0
     fi
-    echo "$SPRINT_NAME: $DONE/$TOTAL tasks ($PCT%)"
+    if [ "$IN_FLIGHT" -gt 0 ]; then
+      echo "$SPRINT_NAME: $DONE/$TOTAL tasks ($PCT%) — $IN_FLIGHT in-flight"
+    else
+      echo "$SPRINT_NAME: $DONE/$TOTAL tasks ($PCT%)"
+    fi
 
-    # Show in-progress (unchecked items in completed batches, or first unchecked batch)
+    # Show in-flight items (dispatched via dev-relay)
+    IN_FLIGHT_ITEMS=$(grep '^\- \[~\] #' "$ACTIVE" | head -3)
+    if [ -n "$IN_FLIGHT_ITEMS" ]; then
+      echo ""
+      echo "In flight:"
+      echo "$IN_FLIGHT_ITEMS" | while IFS= read -r line; do echo "  $line"; done
+    fi
+
+    # Show next unchecked items
     NEXT_ITEMS=$(grep '^\- \[ \] #' "$ACTIVE" | head -3)
     if [ -n "$NEXT_ITEMS" ]; then
       echo ""
@@ -30,7 +43,7 @@ if [ -d "$SPRINTS_DIR" ]; then
       echo "$NEXT_ITEMS" | while IFS= read -r line; do echo "  $line"; done
     fi
 
-    if [ "$TODO" -eq 0 ] && [ "$TOTAL" -gt 0 ]; then
+    if [ "$TODO" -eq 0 ] && [ "$IN_FLIGHT" -eq 0 ] && [ "$TOTAL" -gt 0 ]; then
       echo ""
       echo ">> All items done — ready to close sprint"
     fi


### PR DESCRIPTION
## Summary
- **Bug fix**: `next.sh` and `status.sh` now recognize `[~]` (in-flight) checkbox state written by dev-relay — shows correct progress counts and separate in-flight display
- **Bug fix**: Fixed latent `grep -c || echo 0` pattern that produced `0\n0` when no matches found
- **Docs**: Added `[~]` lifecycle table to SKILL.md sprint format, clarified AC markers as optional in file-format.md
- **Tests**: Added `smoke-test.sh` with 19 test cases covering `[ ]`, `[x]`, `[~]` states across 4 scenarios

## Test plan
- [x] 19 shell smoke tests pass (`bash scripts/smoke-test.sh`)
- [x] 40 JS tests pass (`node --test scripts/*.test.js`)
- [ ] Manual: create sprint file with `[~]` items, verify `next.sh` and `status.sh` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)