### PR TITLE
[codex] Add JSON output to JS helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,11 @@ bash /path/to/dev-backlog/skills/dev-backlog/scripts/init.sh
 # 2. Pull open GitHub issues into backlog/tasks/
 node /path/to/dev-backlog/skills/dev-backlog/scripts/sync-pull.js --dry-run
 node /path/to/dev-backlog/skills/dev-backlog/scripts/sync-pull.js
+node /path/to/dev-backlog/skills/dev-backlog/scripts/sync-pull.js --json
 
 # 3. Create an active sprint from a milestone
 node /path/to/dev-backlog/skills/dev-backlog/scripts/sprint-init.js "auth-system" --milestone "Sprint W13"
+node /path/to/dev-backlog/skills/dev-backlog/scripts/sprint-init.js "auth-system" --milestone "Sprint W13" --dry-run --json
 
 # 4. See what to do next
 bash /path/to/dev-backlog/skills/dev-backlog/scripts/next.sh
@@ -170,8 +172,8 @@ All scripts live under `skills/dev-backlog/scripts/`.
 | Script | What it does |
 |--------|--------------|
 | `init.sh [project-name]` | Create `backlog/`, `sprints/`, `tasks/`, `completed/`, and `config.yml` |
-| `sync-pull.js [PREFIX] [--update] [--dry-run]` | Pull open issues into `backlog/tasks/`; `--update` refreshes frontmatter while preserving local acceptance-criteria checkboxes |
-| `sprint-init.js "topic" [--milestone "Name"] [--dry-run]` | Create a sprint file from a GitHub milestone |
+| `sync-pull.js [PREFIX] [--update] [--dry-run] [--json]` | Pull open issues into `backlog/tasks/`; `--update` refreshes frontmatter while preserving local acceptance-criteria checkboxes; `--json` emits a machine-readable summary |
+| `sprint-init.js "topic" [--milestone "Name"] [--dry-run] [--json]` | Create a sprint file from a GitHub milestone; `--json` emits the sprint path and metadata |
 | `next.sh [backlog-dir]` | Show the next actionable batch with zero LLM cost |
 | `status.sh [backlog-dir]` | Show sprint progress, GitHub issues, local task counts, and in-flight work |
 | `context-hook.sh [backlog-dir]` | Print a one-line sprint summary for Claude Code `PreToolUse` hooks |

--- a/skills/dev-backlog/SKILL.md
+++ b/skills/dev-backlog/SKILL.md
@@ -222,7 +222,7 @@ All scripts live in `${CLAUDE_SKILL_DIR}/scripts/` (the skill's own directory, n
 - `scripts/init.sh [project-name]` — Bootstrap `backlog/` directory with config.yml
 - `scripts/next.sh` — Show next actionable batch from active sprint (zero LLM cost)
 - `scripts/status.sh` — Project status from sprint file + GitHub
-- `scripts/sync-pull.js [PREFIX] [--update]` — Pull open GitHub issues to local backlog/tasks/. PREFIX defaults to config.yml's `task_prefix`. `--update` refreshes frontmatter while preserving local AC checkboxes.
-- `scripts/sprint-init.js "auth-system" [--milestone "Name"]` — Generate sprint file skeleton
+- `scripts/sync-pull.js [PREFIX] [--update] [--dry-run] [--json]` — Pull open GitHub issues to local backlog/tasks/. PREFIX defaults to config.yml's `task_prefix`. `--update` refreshes frontmatter while preserving local AC checkboxes. `--json` emits a machine-readable summary.
+- `scripts/sprint-init.js "auth-system" [--milestone "Name"] [--dry-run] [--json]` — Generate sprint file skeleton. `--json` emits the target sprint file path plus metadata.
 - `scripts/sprint-close.sh [backlog-dir] [--dry-run] [--close-milestone]` — Close active sprint: set completed, move tasks, remind about context promotion
 - `scripts/context-hook.sh [backlog-dir]` — One-line sprint summary for Claude Code PreToolUse hook (always exits 0)

--- a/skills/dev-backlog/scripts/sprint-init.js
+++ b/skills/dev-backlog/scripts/sprint-init.js
@@ -5,6 +5,7 @@
  * Usage: ./scripts/sprint-init.js "auth-system"
  *        ./scripts/sprint-init.js "auth-system" --milestone "Sprint W13"
  *        ./scripts/sprint-init.js "auth-system" --dry-run
+ *        ./scripts/sprint-init.js "auth-system" --json
  *
  * First arg is the topic name. Milestone defaults to topic if not specified.
  * Filename: YYYY-MM-<topic>.md
@@ -15,92 +16,47 @@ const fs = require("fs");
 const path = require("path");
 const { slugify, estimateSize } = require("./lib");
 
-// --- Main execution ---
+function parseArgs(args) {
+  const dryRun = args.includes("--dry-run");
+  const json = args.includes("--json");
+  const filteredArgs = args.filter((a) => a !== "--dry-run" && a !== "--json");
 
-function main() {
-  const args = process.argv.slice(2);
-  const DRY_RUN = args.includes("--dry-run");
-  const filteredArgs = args.filter((a) => a !== "--dry-run");
   if (!filteredArgs.length) {
-    console.log('Usage: sprint-init.js "topic" [--milestone "Milestone Name"] [--dry-run]');
-    process.exit(1);
+    return { error: 'Usage: sprint-init.js "topic" [--milestone "Milestone Name"] [--dry-run] [--json]' };
   }
 
-  const TOPIC = filteredArgs[0];
-  let MILESTONE = TOPIC;
+  const topic = filteredArgs[0];
+  let milestone = topic;
   const msIdx = filteredArgs.indexOf("--milestone");
   if (msIdx !== -1 && filteredArgs[msIdx + 1]) {
-    MILESTONE = filteredArgs[msIdx + 1];
+    milestone = filteredArgs[msIdx + 1];
   }
 
-  const SPRINTS_DIR = path.join("backlog", "sprints");
-  if (!DRY_RUN) fs.mkdirSync(SPRINTS_DIR, { recursive: true });
+  return { topic, milestone, dryRun, json };
+}
 
-  const today = new Date();
-  const datePrefix = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}`;
-  const todayStr = today.toISOString().slice(0, 10);
+function buildIssueLines(issues) {
+  if (!issues.length) return ["- [ ] (add issues here)"];
 
-  function getMilestoneDue() {
-    try {
-      const out = execFileSync("gh", [
-        "api", "repos/{owner}/{repo}/milestones",
-        "--jq", '.[] | select(.title==env.MS) | .due_on'
-      ], { encoding: "utf-8", env: { ...process.env, MS: MILESTONE } }).trim();
-      return out ? out.slice(0, 10) : "TBD";
-    } catch {
-      return "TBD";
-    }
-  }
+  return issues.map((issue) => {
+    const labels = (issue.labels || []).map((l) => l.name);
+    const est = estimateSize(labels);
+    const suffix = est ? ` (${est})` : "";
+    return `- [ ] #${issue.number} ${issue.title}${suffix}`;
+  });
+}
 
-  function getMilestoneIssues() {
-    try {
-      const out = execFileSync("gh", [
-        "issue", "list", "--milestone", MILESTONE,
-        "--state", "open", "--json", "number,title,labels"
-      ], { encoding: "utf-8" });
-      return JSON.parse(out);
-    } catch {
-      return [];
-    }
-  }
+function buildSprintContent({ milestone, started, due, topic, issues }) {
+  const issueLines = buildIssueLines(issues);
 
-  const topicSlug = slugify(TOPIC) || "sprint";
-  const filepath = path.join(SPRINTS_DIR, `${datePrefix}-${topicSlug}.md`);
-
-  if (fs.existsSync(filepath)) {
-    if (DRY_RUN) {
-      console.log(`[dry-run] File already exists: ${filepath}`);
-    } else {
-      console.error(`Sprint file already exists: ${filepath}`);
-      process.exit(1);
-    }
-  }
-
-  const due = getMilestoneDue();
-  const issues = getMilestoneIssues();
-
-  if (!issues.length) {
-    console.log(`No open issues found for milestone: ${MILESTONE}`);
-    console.log("Create the milestone and assign issues first, or add issues manually.");
-  }
-
-  const issueLines = issues.length
-    ? issues.map((issue) => {
-        const labels = (issue.labels || []).map((l) => l.name);
-        const est = estimateSize(labels);
-        const suffix = est ? ` (${est})` : "";
-        return `- [ ] #${issue.number} ${issue.title}${suffix}`;
-      })
-    : ["- [ ] (add issues here)"];
-
-  const content = `---
-milestone: ${MILESTONE}
+  return `---
+milestone: ${milestone}
 status: active
-started: ${todayStr}
+started: ${started}
 due: ${due}
 ---
 
-# ${TOPIC}
+# ${topic}
 
 ## Goal
 [One sentence: what's true when this sprint is done]
@@ -116,17 +72,156 @@ ${issueLines.join("\n")}
 ## Progress
 [Timestamped log — update at end of each session/batch]
 `;
+}
 
-  if (DRY_RUN) {
-    console.log(`[dry-run] Would create: ${filepath}\n`);
-    console.log(content);
+function createSprintResult({
+  topic,
+  milestone,
+  dryRun,
+  sprintFile,
+  started,
+  due,
+  issues,
+  content,
+  existingFile,
+}) {
+  return {
+    action: "sprint-init",
+    dryRun,
+    topic,
+    milestone,
+    sprintFile,
+    started,
+    due,
+    issueCount: issues.length,
+    placeholderIssue: Boolean(content) && issues.length === 0,
+    existingFile,
+    created: !dryRun && !existingFile,
+    content,
+  };
+}
+
+function getMilestoneDue(milestone) {
+  try {
+    const out = execFileSync("gh", [
+      "api", "repos/{owner}/{repo}/milestones",
+      "--jq", '.[] | select(.title==env.MS) | .due_on'
+    ], { encoding: "utf-8", env: { ...process.env, MS: milestone } }).trim();
+    return out ? out.slice(0, 10) : "TBD";
+  } catch {
+    return "TBD";
+  }
+}
+
+function getMilestoneIssues(milestone) {
+  try {
+    const out = execFileSync("gh", [
+      "issue", "list", "--milestone", milestone,
+      "--state", "open", "--json", "number,title,labels"
+    ], { encoding: "utf-8" });
+    return JSON.parse(out);
+  } catch {
+    return [];
+  }
+}
+
+function createSprintFile({
+  topic,
+  milestone,
+  dryRun,
+  sprintsDir = path.join("backlog", "sprints"),
+  today = new Date(),
+  fileExists = fs.existsSync,
+  mkdir = (dir) => fs.mkdirSync(dir, { recursive: true }),
+  writeFile = fs.writeFileSync,
+  getDue = getMilestoneDue,
+  getIssues = getMilestoneIssues,
+}) {
+  if (!dryRun) mkdir(sprintsDir);
+
+  const datePrefix = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}`;
+  const started = today.toISOString().slice(0, 10);
+  const topicSlug = slugify(topic) || "sprint";
+  const sprintFile = path.join(sprintsDir, `${datePrefix}-${topicSlug}.md`);
+  const existingFile = fileExists(sprintFile);
+
+  if (existingFile && !dryRun) {
+    throw new Error(`Sprint file already exists: ${sprintFile}`);
+  }
+
+  const due = getDue(milestone);
+  const issues = getIssues(milestone);
+  const content = existingFile
+    ? null
+    : buildSprintContent({ milestone, started, due, topic, issues });
+
+  if (!dryRun && !existingFile) {
+    writeFile(sprintFile, content);
+  }
+
+  return createSprintResult({
+    topic,
+    milestone,
+    dryRun,
+    sprintFile,
+    started,
+    due,
+    issues,
+    content,
+    existingFile,
+  });
+}
+
+function printResult(result) {
+  if (result.existingFile && result.dryRun) {
+    console.log(`[dry-run] File already exists: ${result.sprintFile}`);
+    return;
+  }
+
+  if (result.placeholderIssue) {
+    console.log(`No open issues found for milestone: ${result.milestone}`);
+    console.log("Create the milestone and assign issues first, or add issues manually.");
+  }
+
+  if (result.dryRun) {
+    console.log(`[dry-run] Would create: ${result.sprintFile}\n`);
   } else {
-    fs.writeFileSync(filepath, content);
-    console.log(`Created: ${filepath}\n`);
-    console.log(content);
+    console.log(`Created: ${result.sprintFile}\n`);
+  }
+
+  console.log(result.content);
+}
+
+// --- Main execution ---
+
+function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+  if (parsed.error) {
+    console.log(parsed.error);
+    process.exit(1);
+  }
+
+  try {
+    const result = createSprintFile(parsed);
+
+    if (parsed.json) {
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
+
+    printResult(result);
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
   }
 }
 
 if (require.main === module) main();
 
-module.exports = {};
+module.exports = {
+  parseArgs,
+  buildIssueLines,
+  buildSprintContent,
+  createSprintFile,
+  printResult,
+};

--- a/skills/dev-backlog/scripts/sprint-init.test.js
+++ b/skills/dev-backlog/scripts/sprint-init.test.js
@@ -1,12 +1,164 @@
-const { describe, it } = require("node:test");
+const { describe, it, beforeEach, afterEach } = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const {
+  parseArgs,
+  buildIssueLines,
+  buildSprintContent,
+  createSprintFile,
+} = require("./sprint-init.js");
 
-// sprint-init.js no longer exports pure functions — they moved to lib.js.
-// This file is kept as a placeholder for future sprint-init-specific tests
-// (e.g., main() integration tests with gh CLI mock).
+describe("parseArgs", () => {
+  it("parses topic, milestone, dry-run, and json flags", () => {
+    const parsed = parseArgs(["auth-system", "--milestone", "Sprint W13", "--dry-run", "--json"]);
+    assert.deepEqual(parsed, {
+      topic: "auth-system",
+      milestone: "Sprint W13",
+      dryRun: true,
+      json: true,
+    });
+  });
 
-describe("sprint-init", () => {
-  it("module loads without error", () => {
-    require("./sprint-init.js");
+  it("defaults milestone to topic", () => {
+    const parsed = parseArgs(["auth-system"]);
+    assert.equal(parsed.topic, "auth-system");
+    assert.equal(parsed.milestone, "auth-system");
+    assert.equal(parsed.dryRun, false);
+    assert.equal(parsed.json, false);
+  });
+
+  it("returns usage error when topic is missing", () => {
+    const parsed = parseArgs(["--json"]);
+    assert.match(parsed.error, /Usage: sprint-init\.js/);
+  });
+});
+
+describe("buildIssueLines", () => {
+  it("adds estimate suffixes from labels", () => {
+    const lines = buildIssueLines([
+      { number: 42, title: "OAuth2 flow", labels: [{ name: "feature" }] },
+      { number: 43, title: "Docs", labels: [{ name: "documentation" }] },
+    ]);
+
+    assert.deepEqual(lines, [
+      "- [ ] #42 OAuth2 flow (~1hr)",
+      "- [ ] #43 Docs (~20min)",
+    ]);
+  });
+
+  it("returns placeholder when there are no issues", () => {
+    assert.deepEqual(buildIssueLines([]), ["- [ ] (add issues here)"]);
+  });
+});
+
+describe("buildSprintContent", () => {
+  it("renders sprint markdown with issues", () => {
+    const content = buildSprintContent({
+      milestone: "Sprint W13",
+      started: "2026-04-05",
+      due: "2026-04-12",
+      topic: "auth-system",
+      issues: [{ number: 42, title: "OAuth2 flow", labels: [{ name: "feature" }] }],
+    });
+
+    assert.match(content, /^---\n/);
+    assert.match(content, /milestone: Sprint W13/);
+    assert.match(content, /started: 2026-04-05/);
+    assert.match(content, /due: 2026-04-12/);
+    assert.match(content, /# auth-system/);
+    assert.match(content, /- \[ \] #42 OAuth2 flow \(~1hr\)/);
+  });
+});
+
+describe("createSprintFile", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sprint-init-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes sprint file and returns structured result", () => {
+    const result = createSprintFile({
+      topic: "auth-system",
+      milestone: "Sprint W13",
+      dryRun: false,
+      sprintsDir: tmpDir,
+      today: new Date("2026-04-05T09:00:00Z"),
+      getDue: () => "2026-04-12",
+      getIssues: () => [{ number: 42, title: "OAuth2 flow", labels: [{ name: "feature" }] }],
+    });
+
+    assert.equal(result.action, "sprint-init");
+    assert.equal(result.created, true);
+    assert.equal(result.existingFile, false);
+    assert.equal(result.dryRun, false);
+    assert.equal(result.issueCount, 1);
+    assert.equal(result.placeholderIssue, false);
+    assert.equal(result.sprintFile, path.join(tmpDir, "2026-04-auth-system.md"));
+    assert.match(result.content, /OAuth2 flow/);
+
+    const written = fs.readFileSync(result.sprintFile, "utf-8");
+    assert.equal(written, result.content);
+  });
+
+  it("returns placeholder metadata on dry-run when milestone has no issues", () => {
+    const result = createSprintFile({
+      topic: "misc",
+      milestone: "Sprint W14",
+      dryRun: true,
+      sprintsDir: tmpDir,
+      today: new Date("2026-04-05T09:00:00Z"),
+      getDue: () => "TBD",
+      getIssues: () => [],
+    });
+
+    assert.equal(result.created, false);
+    assert.equal(result.placeholderIssue, true);
+    assert.equal(result.issueCount, 0);
+    assert.equal(fs.existsSync(result.sprintFile), false);
+    assert.match(result.content, /\(add issues here\)/);
+  });
+
+  it("reports existing file during dry-run without overwriting it", () => {
+    const sprintFile = path.join(tmpDir, "2026-04-auth-system.md");
+    fs.writeFileSync(sprintFile, "existing content");
+
+    const result = createSprintFile({
+      topic: "auth-system",
+      milestone: "Sprint W13",
+      dryRun: true,
+      sprintsDir: tmpDir,
+      today: new Date("2026-04-05T09:00:00Z"),
+      getDue: () => "2026-04-12",
+      getIssues: () => [{ number: 42, title: "OAuth2 flow", labels: [] }],
+    });
+
+    assert.equal(result.existingFile, true);
+    assert.equal(result.created, false);
+    assert.equal(result.placeholderIssue, false);
+    assert.equal(result.content, null);
+    assert.equal(fs.readFileSync(sprintFile, "utf-8"), "existing content");
+  });
+
+  it("throws when target sprint file already exists outside dry-run", () => {
+    fs.writeFileSync(path.join(tmpDir, "2026-04-auth-system.md"), "existing content");
+
+    assert.throws(() => {
+      createSprintFile({
+        topic: "auth-system",
+        milestone: "Sprint W13",
+        dryRun: false,
+        sprintsDir: tmpDir,
+        today: new Date("2026-04-05T09:00:00Z"),
+        getDue: () => "2026-04-12",
+        getIssues: () => [],
+      });
+    }, /Sprint file already exists/);
   });
 });

--- a/skills/dev-backlog/scripts/sync-pull.js
+++ b/skills/dev-backlog/scripts/sync-pull.js
@@ -8,6 +8,7 @@
  * Options:
  *   --update    Update existing files (frontmatter only; preserves local AC checkboxes)
  *   --dry-run   Show what would be created/updated without writing files
+ *   --json      Print machine-readable summary to stdout
  */
 
 const { execFileSync } = require("child_process");
@@ -35,10 +36,65 @@ function structureBody(body) {
   return "\n## Description\n" + body + "\n";
 }
 
+function parseArgs(args, defaultPrefix) {
+  return {
+    prefix: args.find((a) => !a.startsWith("-")) || defaultPrefix,
+    update: args.includes("--update"),
+    dryRun: args.includes("--dry-run"),
+    json: args.includes("--json"),
+  };
+}
+
+function makeResult({ tasksDir, prefix, update, dryRun, issueCount }) {
+  return {
+    action: "sync-pull",
+    dryRun,
+    update,
+    prefix,
+    tasksDir,
+    issueCount,
+    counts: {
+      created: 0,
+      updated: 0,
+      skipped: 0,
+    },
+    createdFiles: [],
+    updatedFiles: [],
+    skippedFiles: [],
+    operations: [],
+  };
+}
+
+function recordOperation(result, type, file) {
+  result.counts[type] += 1;
+  result.operations.push({ type, file });
+  if (type === "created") result.createdFiles.push(file);
+  if (type === "updated") result.updatedFiles.push(file);
+  if (type === "skipped") result.skippedFiles.push(file);
+}
+
+function printResult(result) {
+  const label = result.dryRun ? "[dry-run] " : "";
+  console.log(`${label}Found ${result.issueCount} open issues. Syncing to ${result.tasksDir}/`);
+
+  for (const op of result.operations) {
+    if (op.type === "created") {
+      console.log(result.dryRun ? `  would create: ${op.file}` : `  pull: ${op.file}`);
+    } else if (op.type === "updated") {
+      console.log(result.dryRun ? `  would update: ${op.file}` : `  update: ${op.file}`);
+    } else {
+      console.log(`  skip: ${op.file} (exists, use --update to refresh)`);
+    }
+  }
+
+  console.log("Done.");
+}
+
 // --- Core logic (testable) ---
 
 function run({ issues, tasksDir, prefix, update, dryRun }) {
   if (!dryRun) fs.mkdirSync(tasksDir, { recursive: true });
+  const result = makeResult({ tasksDir, prefix, update, dryRun, issueCount: issues.length });
 
   function findExistingFile(num) {
     const pfx = `${prefix}-${num} - `;
@@ -81,12 +137,12 @@ created_date: '${today}'
     const existing = findExistingFile(num);
     if (existing) {
       if (!update) {
-        console.log(`  skip: ${existing} (exists, use --update to refresh)`);
-        return;
+        recordOperation(result, "skipped", existing);
+        return existing;
       }
       if (dryRun) {
-        console.log(`  would update: ${existing}`);
-        return;
+        recordOperation(result, "updated", existing);
+        return existing;
       }
       const existingPath = path.join(tasksDir, existing);
       const content = fs.readFileSync(existingPath, "utf-8");
@@ -94,23 +150,22 @@ created_date: '${today}'
       const existingBody = bodyMatch ? bodyMatch[1] : structureBody(body);
       const newContent = buildFrontmatter(issue, labelNames) + "\n" + existingBody;
       fs.writeFileSync(existingPath, newContent);
-      console.log(`  update: ${existing}`);
-      return;
+      recordOperation(result, "updated", existing);
+      return existing;
     }
 
     if (dryRun) {
-      console.log(`  would create: ${filename}`);
-      return;
+      recordOperation(result, "created", filename);
+      return filename;
     }
     const content = buildFrontmatter(issue, labelNames) + structureBody(body);
     fs.writeFileSync(filepath, content);
-    console.log(`  pull: ${filename}`);
+    recordOperation(result, "created", filename);
+    return filename;
   }
 
-  const label = dryRun ? "[dry-run] " : "";
-  console.log(`${label}Found ${issues.length} open issues. Syncing to ${tasksDir}/`);
   issues.forEach(writeTaskFile);
-  console.log("Done.");
+  return result;
 }
 
 // --- CLI entry point ---
@@ -118,6 +173,7 @@ created_date: '${today}'
 function main() {
   const args = process.argv.slice(2);
   const config = readConfig();
+  const options = parseArgs(args, config.task_prefix);
 
   let issues;
   try {
@@ -135,19 +191,44 @@ function main() {
     console.warn("Warning: 100 issues fetched (limit). Some issues may be missing.");
   }
   if (!issues.length) {
-    console.log("No open issues found.");
+    if (options.json) {
+      console.log(JSON.stringify(makeResult({
+        tasksDir: path.join("backlog", "tasks"),
+        prefix: options.prefix,
+        update: options.update,
+        dryRun: options.dryRun,
+        issueCount: 0,
+      }), null, 2));
+    } else {
+      console.log("No open issues found.");
+    }
     process.exit(0);
   }
 
-  run({
+  const result = run({
     issues,
     tasksDir: path.join("backlog", "tasks"),
-    prefix: args.find((a) => !a.startsWith("-")) || config.task_prefix,
-    update: args.includes("--update"),
-    dryRun: args.includes("--dry-run"),
+    prefix: options.prefix,
+    update: options.update,
+    dryRun: options.dryRun,
   });
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  printResult(result);
 }
 
 if (require.main === module) main();
 
-module.exports = { statusFromLabels, priorityFromLabels, structureBody, run };
+module.exports = {
+  statusFromLabels,
+  priorityFromLabels,
+  structureBody,
+  parseArgs,
+  makeResult,
+  printResult,
+  run,
+};

--- a/skills/dev-backlog/scripts/sync-pull.test.js
+++ b/skills/dev-backlog/scripts/sync-pull.test.js
@@ -3,7 +3,7 @@ const assert = require("node:assert/strict");
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
-const { statusFromLabels, priorityFromLabels, structureBody, run } = require("./sync-pull.js");
+const { statusFromLabels, priorityFromLabels, structureBody, parseArgs, run } = require("./sync-pull.js");
 
 describe("statusFromLabels", () => {
   it("returns In Progress for status:in-progress", () => {
@@ -72,6 +72,24 @@ describe("structureBody", () => {
   });
 });
 
+describe("parseArgs", () => {
+  it("parses prefix and flags", () => {
+    const parsed = parseArgs(["TEST", "--update", "--dry-run", "--json"], "BACK");
+    assert.deepEqual(parsed, {
+      prefix: "TEST",
+      update: true,
+      dryRun: true,
+      json: true,
+    });
+  });
+
+  it("falls back to config prefix", () => {
+    const parsed = parseArgs(["--json"], "BACK");
+    assert.equal(parsed.prefix, "BACK");
+    assert.equal(parsed.json, true);
+  });
+});
+
 // --- Integration tests for run() ---
 
 describe("run (integration)", () => {
@@ -96,7 +114,7 @@ describe("run (integration)", () => {
   });
 
   it("creates task file with correct name and content", () => {
-    run({
+    const result = run({
       issues: [makeIssue()],
       tasksDir,
       prefix: "TEST",
@@ -115,6 +133,12 @@ describe("run (integration)", () => {
     assert.match(content, /status: To Do/);
     assert.match(content, /priority: medium/);
     assert.match(content, /## Description\nImplement OAuth2/);
+
+    assert.deepEqual(result.counts, { created: 1, updated: 0, skipped: 0 });
+    assert.deepEqual(result.createdFiles, ["TEST-42 - oauth2-flow.md"]);
+    assert.deepEqual(result.operations, [
+      { type: "created", file: "TEST-42 - oauth2-flow.md" },
+    ]);
   });
 
   it("applies labels to frontmatter correctly", () => {
@@ -223,6 +247,39 @@ Original description
     assert.match(content, /\[x\] Valid credentials return JWT/);
     assert.match(content, /\[ \] Test coverage > 90%/);
     assert.match(content, /AC:BEGIN/);
+  });
+
+  it("returns structured summary for mixed operations", () => {
+    fs.writeFileSync(
+      path.join(tasksDir, "TEST-2 - existing.md"),
+      "---\nid: TEST-2\n---\nExisting"
+    );
+    fs.writeFileSync(
+      path.join(tasksDir, "TEST-3 - keep.md"),
+      "---\nid: TEST-3\n---\nKeep"
+    );
+
+    const result = run({
+      issues: [
+        makeIssue({ number: 1, title: "Create me" }),
+        makeIssue({ number: 2, title: "Existing", body: "Refresh me" }),
+        makeIssue({ number: 3, title: "Keep", body: "Skip me" }),
+      ],
+      tasksDir,
+      prefix: "TEST",
+      update: true,
+      dryRun: true,
+    });
+
+    assert.deepEqual(result.counts, { created: 1, updated: 2, skipped: 0 });
+    assert.deepEqual(result.createdFiles, ["TEST-1 - create-me.md"]);
+    assert.deepEqual(result.updatedFiles, ["TEST-2 - existing.md", "TEST-3 - keep.md"]);
+    assert.deepEqual(result.skippedFiles, []);
+    assert.deepEqual(result.operations, [
+      { type: "created", file: "TEST-1 - create-me.md" },
+      { type: "updated", file: "TEST-2 - existing.md" },
+      { type: "updated", file: "TEST-3 - keep.md" },
+    ]);
   });
 
   it("--dry-run does not create files", () => {


### PR DESCRIPTION
## Summary
- add `--json` output to `sync-pull.js` with stable operation counts and file lists
- refactor `sprint-init.js` to return structured results and support `--json`
- add and expand tests for both scripts, plus document the new flag in README and SKILL docs

## Why
Wrappers and other tools need machine-readable output from the JS entrypoints without parsing human-oriented logs.

## Validation
- node --test skills/dev-backlog/scripts/*.test.js
- bash skills/dev-backlog/scripts/smoke-test.sh
- node skills/dev-backlog/scripts/sync-pull.js --dry-run --json
- node skills/dev-backlog/scripts/sprint-init.js "json-demo" --milestone "No Such Milestone" --dry-run --json

Fixes #2