### PR TITLE
fix: fetch all open issues in sync-pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ bash /path/to/dev-backlog/skills/dev-backlog/scripts/init.sh
 node /path/to/dev-backlog/skills/dev-backlog/scripts/sync-pull.js --dry-run
 node /path/to/dev-backlog/skills/dev-backlog/scripts/sync-pull.js
 node /path/to/dev-backlog/skills/dev-backlog/scripts/sync-pull.js --json
+node /path/to/dev-backlog/skills/dev-backlog/scripts/sync-pull.js --limit 50
 
 # 3. Create an active sprint from a milestone
 node /path/to/dev-backlog/skills/dev-backlog/scripts/sprint-init.js "auth-system" --milestone "Sprint W13"
@@ -172,7 +173,7 @@ All scripts live under `skills/dev-backlog/scripts/`.
 | Script | What it does |
 |--------|--------------|
 | `init.sh [project-name]` | Create `backlog/`, `sprints/`, `tasks/`, `completed/`, and `config.yml` |
-| `sync-pull.js [PREFIX] [--update] [--dry-run] [--json]` | Pull open issues into `backlog/tasks/`; `--update` refreshes frontmatter while preserving local acceptance-criteria checkboxes; `--json` emits a machine-readable summary |
+| `sync-pull.js [PREFIX] [--update] [--dry-run] [--json] [--limit N]` | Pull open issues into `backlog/tasks/`; defaults to all open issues, `--limit N` caps the fetch size, `--update` refreshes frontmatter while preserving local acceptance-criteria checkboxes, and `--json` emits a machine-readable summary |
 | `sprint-init.js "topic" [--milestone "Name"] [--dry-run] [--json]` | Create a sprint file from a GitHub milestone; `--json` emits the sprint path and metadata |
 | `next.sh [backlog-dir]` | Show the next actionable batch with zero LLM cost |
 | `status.sh [backlog-dir]` | Show sprint progress, GitHub issues, local task counts, and in-flight work |

--- a/skills/dev-backlog/SKILL.md
+++ b/skills/dev-backlog/SKILL.md
@@ -222,7 +222,7 @@ All scripts live in `${CLAUDE_SKILL_DIR}/scripts/` (the skill's own directory, n
 - `scripts/init.sh [project-name]` — Bootstrap `backlog/` directory with config.yml
 - `scripts/next.sh` — Show next actionable batch from active sprint (zero LLM cost)
 - `scripts/status.sh` — Project status from sprint file + GitHub
-- `scripts/sync-pull.js [PREFIX] [--update] [--dry-run] [--json]` — Pull open GitHub issues to local backlog/tasks/. PREFIX defaults to config.yml's `task_prefix`. `--update` refreshes frontmatter while preserving local AC checkboxes. `--json` emits a machine-readable summary.
+- `scripts/sync-pull.js [PREFIX] [--update] [--dry-run] [--json] [--limit N]` — Pull open GitHub issues to local backlog/tasks/. By default it fetches all open issues; `--limit N` caps the fetch size. PREFIX defaults to config.yml's `task_prefix`. `--update` refreshes frontmatter while preserving local AC checkboxes. `--json` emits a machine-readable summary.
 - `scripts/sprint-init.js "auth-system" [--milestone "Name"] [--dry-run] [--json]` — Generate sprint file skeleton. `--json` emits the target sprint file path plus metadata.
 - `scripts/sprint-close.sh [backlog-dir] [--dry-run] [--close-milestone]` — Close active sprint: set completed, move tasks, remind about context promotion
 - `scripts/context-hook.sh [backlog-dir]` — One-line sprint summary for Claude Code PreToolUse hook (always exits 0)

--- a/skills/dev-backlog/references/github-sync.md
+++ b/skills/dev-backlog/references/github-sync.md
@@ -46,7 +46,11 @@ gh issue list --state open --json number,title,body,labels,milestone,assignees
 gh issue view 42 --json number,title,body,labels,milestone,assignees,comments
 
 # Pull all open issues (script pattern)
-gh issue list --state open --limit 100 --json number,title,body,labels,milestone,assignees | \
+TOTAL=$(gh api graphql -F owner={owner} -F name={repo} \
+  -f query='query($owner: String!, $name: String!) { repository(owner: $owner, name: $name) { issues(states: OPEN) { totalCount } } }' \
+  --jq '.data.repository.issues.totalCount')
+
+gh issue list --state open --limit "$TOTAL" --json number,title,body,labels,milestone,assignees | \
   jq -c '.[]' | while read -r issue; do
     num=$(echo "$issue" | jq -r '.number')
     title=$(echo "$issue" | jq -r '.title')

--- a/skills/dev-backlog/scripts/sync-pull.js
+++ b/skills/dev-backlog/scripts/sync-pull.js
@@ -9,12 +9,21 @@
  *   --update    Update existing files (frontmatter only; preserves local AC checkboxes)
  *   --dry-run   Show what would be created/updated without writing files
  *   --json      Print machine-readable summary to stdout
+ *   --limit N   Fetch at most N open issues (defaults to all open issues)
  */
 
 const { execFileSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const { slugify, escapeYaml, readConfig } = require("./lib");
+
+const ISSUE_JSON_FIELDS = "number,title,body,labels,milestone,assignees";
+const COUNT_OPEN_ISSUES_QUERY =
+  "query($owner: String!, $name: String!) { repository(owner: $owner, name: $name) { issues(states: OPEN) { totalCount } } }";
+const GH_EXEC_OPTIONS = {
+  encoding: "utf-8",
+  maxBuffer: 50 * 1024 * 1024,
+};
 
 function statusFromLabels(labels) {
   if (labels.includes("status:in-progress")) return "In Progress";
@@ -36,13 +45,76 @@ function structureBody(body) {
   return "\n## Description\n" + body + "\n";
 }
 
+function parseLimitValue(value) {
+  if (!/^\d+$/.test(value)) {
+    return { error: `Invalid --limit value: ${value}. Expected a positive integer.` };
+  }
+
+  const limit = Number(value);
+  if (!Number.isSafeInteger(limit) || limit < 1) {
+    return { error: `Invalid --limit value: ${value}. Expected a positive integer.` };
+  }
+
+  return { limit };
+}
+
 function parseArgs(args, defaultPrefix) {
-  return {
-    prefix: args.find((a) => !a.startsWith("-")) || defaultPrefix,
-    update: args.includes("--update"),
-    dryRun: args.includes("--dry-run"),
-    json: args.includes("--json"),
+  const options = {
+    prefix: defaultPrefix,
+    update: false,
+    dryRun: false,
+    json: false,
+    limit: undefined,
   };
+  let prefixSet = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === "--update") {
+      options.update = true;
+      continue;
+    }
+
+    if (arg === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+
+    if (arg === "--limit") {
+      const nextValue = args[index + 1];
+      if (!nextValue) {
+        return { ...options, error: "Missing value for --limit. Expected a positive integer." };
+      }
+
+      const parsed = parseLimitValue(nextValue);
+      if (parsed.error) return { ...options, error: parsed.error };
+
+      options.limit = parsed.limit;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--limit=")) {
+      const parsed = parseLimitValue(arg.slice("--limit=".length));
+      if (parsed.error) return { ...options, error: parsed.error };
+
+      options.limit = parsed.limit;
+      continue;
+    }
+
+    if (!arg.startsWith("-") && !prefixSet) {
+      options.prefix = arg;
+      prefixSet = true;
+    }
+  }
+
+  return options;
 }
 
 function makeResult({ tasksDir, prefix, update, dryRun, issueCount }) {
@@ -170,26 +242,55 @@ created_date: '${today}'
 
 // --- CLI entry point ---
 
+function getOpenIssueCount(execFile = execFileSync) {
+  const out = execFile("gh", [
+    "api", "graphql",
+    "-F", "owner={owner}",
+    "-F", "name={repo}",
+    "-f", `query=${COUNT_OPEN_ISSUES_QUERY}`,
+    "--jq", ".data.repository.issues.totalCount",
+  ], GH_EXEC_OPTIONS).trim();
+  const count = Number.parseInt(out, 10);
+
+  if (!Number.isInteger(count) || count < 0) {
+    throw new Error(`Invalid issue count from gh: ${out}`);
+  }
+
+  return count;
+}
+
+function fetchOpenIssues(limit, execFile = execFileSync) {
+  const out = execFile("gh", [
+    "issue", "list", "--state", "open", "--limit", String(limit),
+    "--json", ISSUE_JSON_FIELDS,
+  ], GH_EXEC_OPTIONS);
+
+  return JSON.parse(out);
+}
+
+function loadOpenIssues({ limit, execFile = execFileSync } = {}) {
+  const resolvedLimit = limit ?? getOpenIssueCount(execFile);
+  if (resolvedLimit === 0) return [];
+  return fetchOpenIssues(resolvedLimit, execFile);
+}
+
 function main() {
   const args = process.argv.slice(2);
   const config = readConfig();
   const options = parseArgs(args, config.task_prefix);
+  if (options.error) {
+    console.error(options.error);
+    process.exit(1);
+  }
 
   let issues;
   try {
-    const out = execFileSync("gh", [
-      "issue", "list", "--state", "open", "--limit", "100",
-      "--json", "number,title,body,labels,milestone,assignees"
-    ], { encoding: "utf-8" });
-    issues = JSON.parse(out);
+    issues = loadOpenIssues({ limit: options.limit });
   } catch (e) {
     console.error(`gh error: ${e.message}`);
     process.exit(1);
   }
 
-  if (issues.length >= 100) {
-    console.warn("Warning: 100 issues fetched (limit). Some issues may be missing.");
-  }
   if (!issues.length) {
     if (options.json) {
       console.log(JSON.stringify(makeResult({
@@ -230,5 +331,8 @@ module.exports = {
   parseArgs,
   makeResult,
   printResult,
+  getOpenIssueCount,
+  fetchOpenIssues,
+  loadOpenIssues,
   run,
 };

--- a/skills/dev-backlog/scripts/sync-pull.test.js
+++ b/skills/dev-backlog/scripts/sync-pull.test.js
@@ -3,7 +3,14 @@ const assert = require("node:assert/strict");
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
-const { statusFromLabels, priorityFromLabels, structureBody, parseArgs, run } = require("./sync-pull.js");
+const {
+  statusFromLabels,
+  priorityFromLabels,
+  structureBody,
+  parseArgs,
+  loadOpenIssues,
+  run,
+} = require("./sync-pull.js");
 
 describe("statusFromLabels", () => {
   it("returns In Progress for status:in-progress", () => {
@@ -80,6 +87,7 @@ describe("parseArgs", () => {
       update: true,
       dryRun: true,
       json: true,
+      limit: undefined,
     });
   });
 
@@ -87,6 +95,116 @@ describe("parseArgs", () => {
     const parsed = parseArgs(["--json"], "BACK");
     assert.equal(parsed.prefix, "BACK");
     assert.equal(parsed.json, true);
+  });
+
+  it("parses --limit without treating the value as prefix", () => {
+    const parsed = parseArgs(["--limit", "250", "TEST"], "BACK");
+    assert.deepEqual(parsed, {
+      prefix: "TEST",
+      update: false,
+      dryRun: false,
+      json: false,
+      limit: 250,
+    });
+  });
+
+  it("parses --limit=N form", () => {
+    const parsed = parseArgs(["TEST", "--limit=25"], "BACK");
+    assert.equal(parsed.prefix, "TEST");
+    assert.equal(parsed.limit, 25);
+  });
+
+  it("returns an error for invalid --limit values", () => {
+    const missingValue = parseArgs(["--limit"], "BACK");
+    assert.equal(missingValue.error, "Missing value for --limit. Expected a positive integer.");
+
+    const invalidValue = parseArgs(["--limit", "0"], "BACK");
+    assert.equal(invalidValue.error, "Invalid --limit value: 0. Expected a positive integer.");
+  });
+});
+
+describe("loadOpenIssues", () => {
+  it("uses the explicit limit when provided", () => {
+    const calls = [];
+    const execFile = (command, args, options) => {
+      calls.push({ command, args, options });
+      return JSON.stringify([{ number: 1, title: "One" }]);
+    };
+
+    const issues = loadOpenIssues({ limit: 12, execFile });
+
+    assert.deepEqual(issues, [{ number: 1, title: "One" }]);
+    assert.deepEqual(calls, [{
+      command: "gh",
+      args: [
+        "issue", "list", "--state", "open", "--limit", "12",
+        "--json", "number,title,body,labels,milestone,assignees",
+      ],
+      options: {
+        encoding: "utf-8",
+        maxBuffer: 50 * 1024 * 1024,
+      },
+    }]);
+  });
+
+  it("fetches all open issues by first reading totalCount", () => {
+    const calls = [];
+    const execFile = (command, args, options) => {
+      calls.push({ command, args, options });
+
+      if (args[0] === "api") return "125\n";
+      if (args[0] === "issue") return JSON.stringify([{ number: 1 }, { number: 2 }]);
+
+      throw new Error(`Unexpected gh args: ${args.join(" ")}`);
+    };
+
+    const issues = loadOpenIssues({ execFile });
+
+    assert.deepEqual(issues, [{ number: 1 }, { number: 2 }]);
+    assert.equal(calls.length, 2);
+    assert.deepEqual(calls[0], {
+      command: "gh",
+      args: [
+        "api", "graphql",
+        "-F", "owner={owner}",
+        "-F", "name={repo}",
+        "-f", "query=query($owner: String!, $name: String!) { repository(owner: $owner, name: $name) { issues(states: OPEN) { totalCount } } }",
+        "--jq", ".data.repository.issues.totalCount",
+      ],
+      options: {
+        encoding: "utf-8",
+        maxBuffer: 50 * 1024 * 1024,
+      },
+    });
+    assert.deepEqual(calls[1], {
+      command: "gh",
+      args: [
+        "issue", "list", "--state", "open", "--limit", "125",
+        "--json", "number,title,body,labels,milestone,assignees",
+      ],
+      options: {
+        encoding: "utf-8",
+        maxBuffer: 50 * 1024 * 1024,
+      },
+    });
+  });
+
+  it("skips issue listing when the repo has no open issues", () => {
+    const calls = [];
+    const execFile = (command, args, options) => {
+      calls.push({ command, args, options });
+      return "0\n";
+    };
+
+    const issues = loadOpenIssues({ execFile });
+
+    assert.deepEqual(issues, []);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].args[0], "api");
+    assert.deepEqual(calls[0].options, {
+      encoding: "utf-8",
+      maxBuffer: 50 * 1024 * 1024,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- default `sync-pull.js` to all open issues by resolving the repo open-issue count first
- add `--limit N` / `--limit=N` override support and validation
- raise `gh` exec buffer for large repos and update tests/docs

## Testing
- node --test skills/dev-backlog/scripts/*.test.js
- bash skills/dev-backlog/scripts/smoke-test.sh
- node skills/dev-backlog/scripts/sync-pull.js --dry-run --json
- GH_REPO=cli/cli node -e 'const { loadOpenIssues } = require("./skills/dev-backlog/scripts/sync-pull.js"); const issues = loadOpenIssues(); console.log(issues.length);'

Fixes #16