### PR TITLE
feat(progress-sync): structured progress comment reconciliation

### DIFF
--- a/skills/dev-backlog/scripts/progress-sync.js
+++ b/skills/dev-backlog/scripts/progress-sync.js
@@ -291,15 +291,31 @@ function fetchMergedPRsThisMonth(month, execFile) {
 
 // --- Comment I/O ---
 
+function parsePaginatedApiArray(output) {
+  const text = String(output || "").trim();
+  if (!text) return [];
+
+  try {
+    const parsed = JSON.parse(text);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {}
+
+  try {
+    const combined = `[${text.replace(/\]\s*\[/g, "],[")}]`;
+    const parsed = JSON.parse(combined);
+    return parsed.flatMap((page) => Array.isArray(page) ? page : [page]);
+  } catch {
+    return [];
+  }
+}
+
 function fetchIssueComments(issueNumber, execFile) {
   try {
     const out = execFile("gh", [
       "api", `repos/{owner}/{repo}/issues/${issueNumber}/comments`,
       "--paginate",
     ], GH_EXEC_DEFAULTS);
-    // gh api --paginate concatenates JSON arrays; flatten if needed
-    const parsed = JSON.parse(out);
-    return Array.isArray(parsed) ? parsed : [];
+    return parsePaginatedApiArray(out);
   } catch {
     return [];
   }

--- a/skills/dev-backlog/scripts/progress-sync.test.js
+++ b/skills/dev-backlog/scripts/progress-sync.test.js
@@ -1064,6 +1064,49 @@ describe("sync (comment integration)", () => {
 
     assert.deepEqual(result.comments, { created: 0, updated: 0, skipped: 0, repaired: 0 });
   });
+
+  it("parses paginated gh api comment arrays and avoids duplicate managed comments", () => {
+    const existing = {
+      number: 50,
+      title: "Progress: April 2026",
+      body: "<!-- dev-backlog:progress-issue month=2026-04 -->",
+    };
+    const calls = [];
+    let issueListCalls = 0;
+    const existingMergeComment = renderMergeComment("2026-04", { number: 10, title: "PR A" });
+    const execFile = (_cmd, args) => {
+      calls.push(args);
+      const joined = args.join(" ");
+      if (joined.includes("issue list") && joined.includes("--search")) {
+        issueListCalls += 1;
+        return issueListCalls === 1 ? JSON.stringify([existing]) : "[]";
+      }
+      if (joined.includes("pr list") && joined.includes("open")) return "[]";
+      if (joined.includes("pr list") && joined.includes("merged")) {
+        return JSON.stringify([{ number: 10, title: "PR A" }]);
+      }
+      if (joined.includes("issues/50/comments")) {
+        return [
+          JSON.stringify([{ id: 100, body: existingMergeComment }]),
+          JSON.stringify([{ id: 101, body: "Human comment" }]),
+        ].join("\n");
+      }
+      if (joined.includes("issue edit")) return "";
+      return "{}";
+    };
+
+    const result = sync({
+      month: "2026-04",
+      dryRun: false,
+      backlogDir: tmpDir,
+      execFile,
+    });
+
+    assert.equal(result.comments.created, 0);
+    assert.equal(result.comments.skipped, 1);
+    const postCalls = calls.filter((args) => args.includes("POST"));
+    assert.equal(postCalls.length, 0);
+  });
 });
 
 // --- printResult ---


### PR DESCRIPTION
## Summary
- Add idempotent, machine-managed comment reconciliation for the monthly Progress issue (#36)
- Managed comments use a hidden `<!-- dev-backlog:progress-comment id=... -->` marker distinct from the body marker, with deterministic entry keys (`month/event-type/id`)
- Reconciliation creates, updates, skips, or repairs duplicate comments while leaving human-authored comments untouched

## Design
- **Comment marker**: `<!-- dev-backlog:progress-comment id={entryId} -->` — distinct from body marker (`progress-issue`)
- **Entry keys**: `{month}/merge/pr-{n}` for merge events, `{month}/stuck/{taskFile}` for stuck alerts — deterministic and stable
- **Reconcile logic**: fetch all comments → filter by marker → index by entry id → upsert/skip/repair per desired entry
- **Extensibility**: entry key format leaves room for future `run_id` enrichment without breaking backlog-only mode
- **Isolation**: comment reconciliation is fully separate from body sync (#35) — different helpers, different marker, different lifecycle

## Event surface
- Merge events from `fetchMergedPRsThisMonth()`
- Stuck alerts from tasks with `status: "In Progress"`

## Test plan
- [x] Comment marker make/parse round-trip
- [x] Comment marker is distinct from body marker
- [x] Entry key stability and uniqueness
- [x] Rendered comment bodies are parseable back to entry ids
- [x] `parseManagedComments` filters only managed, ignores human + body markers
- [x] `reconcileComments`: create, skip, update, repair, dry-run, mixed-pass, idempotent rerun
- [x] Human comments left untouched
- [x] `sync()` integration: comment actions in result, dry-run skips writes, no-issue skips comments
- [x] All 152 tests pass, all 85 smoke tests pass

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)