### PR TITLE
[codex] Clarify README contract and Codex workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ Then use the skill during your coding session:
 /dev-backlog sync
 ```
 
+Important if you use `dev-relay`: sprint files are not fully freeform markdown.
+These details are load-bearing for automation:
+
+- section headings such as `## Plan`, `## Running Context`, `## Progress`
+- checkbox states `- [ ]`, `- [~]`, `- [x]`
+
+If you change those shapes casually, relay automation can stop reading or updating the sprint correctly. Full contract: [references/integration-contract.md](skills/dev-backlog/references/integration-contract.md).
+
 ## A Sprint File Looks Like This
 
 ```markdown
@@ -190,6 +198,36 @@ All scripts live under `skills/dev-backlog/scripts/`.
   }
 }
 ```
+
+</details>
+
+<details>
+<summary>Codex workflow example</summary>
+
+`dev-backlog` works well with Codex when the sprint file stays the shared execution state instead of extra chat context.
+
+Start with the cheap deterministic commands:
+
+```bash
+bash /path/to/dev-backlog/skills/dev-backlog/scripts/status.sh
+bash /path/to/dev-backlog/skills/dev-backlog/scripts/next.sh
+```
+
+Then hand Codex the active sprint as the source of truth:
+
+```text
+Read backlog/sprints/_context.md and the active sprint file first.
+Tell me the next batch, implement #42, and keep the sprint file updated.
+Update Running Context and Progress before you stop.
+```
+
+When GitHub issue metadata changed during the session, refresh the local mirror:
+
+```bash
+node /path/to/dev-backlog/skills/dev-backlog/scripts/sync-pull.js --update
+```
+
+This keeps Codex focused on one execution file, not ten browser tabs and stale issue context.
 
 </details>
 


### PR DESCRIPTION
## Summary

This PR finishes the two remaining README follow-ups by surfacing the sprint file format contract earlier and adding a concrete Codex workflow example.

## What Changed

- add an early warning after Quick Start that sprint files are not fully freeform when `dev-relay` automation is in play
- call out the load-bearing section headings and checkbox states explicitly
- link readers to the integration contract from the primary usage path
- add a Codex-specific workflow example that shows status/next commands plus the expected sprint-file-first prompt style

## Why

The README already mentioned these ideas, but not where readers needed them:
- the format constraint warning was buried in `Contributing`
- Codex was listed as supported, but the concrete example was still Claude Code heavy

This makes both points discoverable from the main usage path.

## Validation

- inspected README diff for placement and wording
- no code or behavior changes

Closes #42
Closes #43