### PR TITLE
Refactor progress-sync and sync-pull maintenance flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ dev-backlog adds a local sprint file that carries the plan, decisions, and progr
 
 No new server. No hidden state. No need to abandon GitHub Issues.
 
+README.md is the product overview and human quick start. The agent execution contract, sprint-file rules, and full script reference live in [skills/dev-backlog/SKILL.md](skills/dev-backlog/SKILL.md).
+
 ```text
 GitHub Issues (source of truth)
         |
@@ -92,6 +94,8 @@ Then use the skill during your coding session:
 /dev-backlog sync
 ```
 
+For the detailed sprint contract, section semantics, and full script inventory, see [skills/dev-backlog/SKILL.md](skills/dev-backlog/SKILL.md).
+
 Important if you use `dev-relay`: sprint files are not fully freeform markdown.
 These details are load-bearing for automation:
 
@@ -169,19 +173,10 @@ The `[~]` state makes in-flight work visible to everyone, and `Running Context` 
 
 The contract for that integration lives in [references/integration-contract.md](skills/dev-backlog/references/integration-contract.md).
 
-## Deterministic Scripts
+## Script Entry Points
 
-All scripts live under `skills/dev-backlog/scripts/`.
-
-| Script | What it does |
-|--------|--------------|
-| `init.sh [project-name]` | Create `backlog/`, `sprints/`, `tasks/`, `completed/`, and `config.yml` |
-| `sync-pull.js [PREFIX] [--update] [--dry-run] [--json] [--limit N]` | Pull open issues into `backlog/tasks/`; defaults to all open issues, `--limit N` caps the fetch size, `--update` refreshes frontmatter while preserving local acceptance-criteria checkboxes, and `--json` emits a machine-readable summary |
-| `sprint-init.js "topic" [--milestone "Name"] [--dry-run] [--json]` | Create a sprint file from a GitHub milestone; `--json` emits the sprint path and metadata |
-| `next.sh [backlog-dir]` | Show the next actionable batch with zero LLM cost |
-| `status.sh [backlog-dir]` | Show sprint progress, GitHub issues, local task counts, and in-flight work |
-| `context-hook.sh [backlog-dir]` | Print a one-line sprint summary for Claude Code `PreToolUse` hooks |
-| `sprint-close.sh [backlog-dir] [--dry-run] [--close-milestone]` | Mark the sprint complete, move finished tasks, and optionally close the GitHub milestone |
+All deterministic helpers live under `skills/dev-backlog/scripts/`.
+Use the commands in Quick Start for the common path, and use [skills/dev-backlog/SKILL.md](skills/dev-backlog/SKILL.md) as the canonical script/flag reference when you need the full execution contract.
 
 <details>
 <summary>Claude Code hook example</summary>
@@ -252,7 +247,7 @@ This keeps Codex focused on one execution file, not ten browser tabs and stale i
 
 ## Docs
 
-- [Core skill prompt](skills/dev-backlog/SKILL.md)
+- [Agent execution contract](skills/dev-backlog/SKILL.md)
 - [Process guide](skills/dev-backlog/references/process.md)
 - [File format and config](skills/dev-backlog/references/file-format.md)
 - [GitHub sync patterns](skills/dev-backlog/references/github-sync.md)

--- a/skills/dev-backlog/SKILL.md
+++ b/skills/dev-backlog/SKILL.md
@@ -9,6 +9,8 @@ metadata:
 
 # Dev Backlog
 
+README covers install and human quick start. This skill file is the execution contract for agents: file roles, sprint structure, process, and script behavior.
+
 Two layers, each with a clear job:
 
 ```

--- a/skills/dev-backlog/scripts/progress-sync-github.js
+++ b/skills/dev-backlog/scripts/progress-sync-github.js
@@ -1,0 +1,217 @@
+const { GH_EXEC_DEFAULTS } = require("./lib");
+const {
+  makeMarker,
+  monthTitle,
+  parseManagedComments,
+  buildDesiredCommentEntries,
+} = require("./progress-sync-render");
+
+function searchProgressIssues(month, execFile) {
+  const title = monthTitle(month);
+  const out = execFile("gh", [
+    "issue", "list", "--state", "all", "--search", `"${title}" in:title`,
+    "--json", "number,title,body", "--limit", "50",
+  ], GH_EXEC_DEFAULTS);
+  return JSON.parse(out);
+}
+
+function findMonthIssue(month, execFile) {
+  const issues = searchProgressIssues(month, execFile);
+  const marker = makeMarker(month);
+  const markerMatch = issues.find((issue) => issue.body && issue.body.includes(marker));
+  if (markerMatch) return markerMatch;
+  const title = monthTitle(month);
+  return issues.find((issue) => issue.title === title) || null;
+}
+
+function createIssue(title, body, execFile) {
+  const out = execFile("gh", [
+    "issue", "create", "--title", title, "--body", body,
+  ], GH_EXEC_DEFAULTS);
+  const match = out.trim().match(/\/issues\/(\d+)\s*$/);
+  if (!match) {
+    throw new Error(`Failed to parse issue number from gh output: ${out.trim()}`);
+  }
+  return { number: Number(match[1]) };
+}
+
+function updateIssueBody(number, body, execFile) {
+  execFile("gh", [
+    "issue", "edit", String(number), "--body", body,
+  ], GH_EXEC_DEFAULTS);
+}
+
+function closeIssue(number, execFile) {
+  execFile("gh", [
+    "api", `repos/{owner}/{repo}/issues/${number}`,
+    "--method", "PATCH",
+    "--field", "state=closed",
+  ], GH_EXEC_DEFAULTS);
+}
+
+function fetchOpenPRs(execFile) {
+  try {
+    const out = execFile("gh", [
+      "pr", "list", "--state", "open", "--json", "number,title",
+      "--limit", "100",
+    ], GH_EXEC_DEFAULTS);
+    return JSON.parse(out);
+  } catch {
+    return [];
+  }
+}
+
+function fetchMergedPRsThisMonth(month, execFile) {
+  const [y, m] = month.split("-");
+  const start = `${y}-${m}-01`;
+  const nextM = Number(m) === 12 ? 1 : Number(m) + 1;
+  const nextY = Number(m) === 12 ? Number(y) + 1 : Number(y);
+  const end = `${nextY}-${String(nextM).padStart(2, "0")}-01`;
+  try {
+    const out = execFile("gh", [
+      "pr", "list", "--state", "merged",
+      "--search", `merged:>=${start} merged:<${end}`,
+      "--json", "number,title",
+      "--limit", "200",
+    ], GH_EXEC_DEFAULTS);
+    return JSON.parse(out);
+  } catch {
+    return [];
+  }
+}
+
+function parsePaginatedApiArray(output) {
+  const text = String(output || "").trim();
+  if (!text) return [];
+
+  try {
+    const parsed = JSON.parse(text);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {}
+
+  try {
+    const combined = `[${text.replace(/\]\s*\[/g, "],[")}]`;
+    const parsed = JSON.parse(combined);
+    return parsed.flatMap((page) => Array.isArray(page) ? page : [page]);
+  } catch {
+    return [];
+  }
+}
+
+function fetchIssueComments(issueNumber, execFile) {
+  try {
+    const out = execFile("gh", [
+      "api", `repos/{owner}/{repo}/issues/${issueNumber}/comments`,
+      "--paginate",
+    ], GH_EXEC_DEFAULTS);
+    return parsePaginatedApiArray(out);
+  } catch {
+    return [];
+  }
+}
+
+function createIssueComment(issueNumber, body, execFile) {
+  execFile("gh", [
+    "api", `repos/{owner}/{repo}/issues/${issueNumber}/comments`,
+    "--method", "POST", "--field", `body=${body}`,
+  ], GH_EXEC_DEFAULTS);
+}
+
+function updateIssueComment(commentId, body, execFile) {
+  execFile("gh", [
+    "api", `repos/{owner}/{repo}/issues/comments/${commentId}`,
+    "--method", "PATCH", "--field", `body=${body}`,
+  ], GH_EXEC_DEFAULTS);
+}
+
+function deleteIssueComment(commentId, execFile) {
+  execFile("gh", [
+    "api", `repos/{owner}/{repo}/issues/comments/${commentId}`,
+    "--method", "DELETE",
+  ], GH_EXEC_DEFAULTS);
+}
+
+function matchingManagedComments(byEntryId, entry) {
+  const unique = new Map();
+  const entryIds = [entry.entryId, ...(entry.aliasIds || [])];
+
+  for (const entryId of entryIds) {
+    const matches = byEntryId.get(entryId) || [];
+    for (const match of matches) {
+      unique.set(match.id, match);
+    }
+  }
+
+  return Array.from(unique.values());
+}
+
+function selectPrimaryManagedComment(existing, canonicalEntryId) {
+  return existing.find((comment) => comment.entryId === canonicalEntryId) || existing[0];
+}
+
+function reconcileComments({
+  issueNumber,
+  mergedPRs,
+  stuckTasks,
+  month,
+  relayMetadata = null,
+  dryRun,
+  execFile,
+  fetchComments = fetchIssueComments,
+}) {
+  const allComments = fetchComments(issueNumber, execFile);
+  const managed = parseManagedComments(allComments);
+
+  const byEntryId = new Map();
+  for (const comment of managed) {
+    if (!byEntryId.has(comment.entryId)) byEntryId.set(comment.entryId, []);
+    byEntryId.get(comment.entryId).push(comment);
+  }
+
+  const desired = buildDesiredCommentEntries({ mergedPRs, stuckTasks, month, relayMetadata });
+  const actions = { created: 0, updated: 0, skipped: 0, repaired: 0 };
+
+  for (const entry of desired) {
+    const existing = matchingManagedComments(byEntryId, entry);
+
+    if (existing.length === 0) {
+      if (!dryRun) createIssueComment(issueNumber, entry.body, execFile);
+      actions.created++;
+    } else if (existing.length === 1) {
+      if (existing[0].body === entry.body && existing[0].entryId === entry.entryId) {
+        actions.skipped++;
+      } else {
+        if (!dryRun) updateIssueComment(existing[0].id, entry.body, execFile);
+        actions.updated++;
+      }
+    } else {
+      const primary = selectPrimaryManagedComment(existing, entry.entryId);
+      const duplicates = existing.filter((comment) => comment.id !== primary.id);
+      if (!dryRun) {
+        updateIssueComment(primary.id, entry.body, execFile);
+        for (const duplicate of duplicates) {
+          deleteIssueComment(duplicate.id, execFile);
+        }
+      }
+      actions.repaired++;
+    }
+
+    byEntryId.delete(entry.entryId);
+    for (const aliasId of entry.aliasIds || []) {
+      byEntryId.delete(aliasId);
+    }
+  }
+
+  return actions;
+}
+
+module.exports = {
+  findMonthIssue,
+  createIssue,
+  updateIssueBody,
+  closeIssue,
+  fetchOpenPRs,
+  fetchMergedPRsThisMonth,
+  fetchIssueComments,
+  reconcileComments,
+};

--- a/skills/dev-backlog/scripts/progress-sync-relay.js
+++ b/skills/dev-backlog/scripts/progress-sync-relay.js
@@ -1,0 +1,146 @@
+const fs = require("fs");
+const path = require("path");
+
+function normalizeRelayField(value) {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed || trimmed === "unknown" || trimmed === "null") return null;
+    return trimmed;
+  }
+  return value;
+}
+
+function parseFrontmatterScalar(value) {
+  if (value === "null") return null;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  if (/^-?\d+(?:\.\d+)?$/.test(value)) return Number(value);
+  if (value.startsWith("'") && value.endsWith("'")) {
+    return value.slice(1, -1).replace(/''/g, "'");
+  }
+  if (value.startsWith("\"") && value.endsWith("\"")) {
+    return JSON.parse(value);
+  }
+  return value;
+}
+
+function parseFrontmatter(text) {
+  const lines = text.replace(/\r\n/g, "\n").split("\n");
+  if (lines[0] !== "---") {
+    return {};
+  }
+
+  const closingIndex = lines.indexOf("---", 1);
+  if (closingIndex === -1) {
+    throw new Error("Invalid relay manifest: missing closing frontmatter marker");
+  }
+
+  const frontmatterLines = lines.slice(1, closingIndex);
+
+  function parseBlock(startIndex, indent) {
+    const data = {};
+    let index = startIndex;
+
+    while (index < frontmatterLines.length) {
+      const raw = frontmatterLines[index];
+      if (!raw.trim()) {
+        index++;
+        continue;
+      }
+
+      const currentIndent = raw.match(/^ */)[0].length;
+      if (currentIndent < indent) break;
+      if (currentIndent > indent) {
+        throw new Error(`Invalid relay manifest indentation on line ${index + 2}`);
+      }
+
+      const trimmed = raw.trim();
+      const separator = trimmed.indexOf(":");
+      if (separator === -1) {
+        throw new Error(`Invalid relay manifest entry on line ${index + 2}`);
+      }
+
+      const key = trimmed.slice(0, separator).trim();
+      const rest = trimmed.slice(separator + 1).trim();
+
+      if (!rest) {
+        const nested = parseBlock(index + 1, indent + 2);
+        data[key] = nested.data;
+        index = nested.index;
+        continue;
+      }
+
+      data[key] = parseFrontmatterScalar(rest);
+      index++;
+    }
+
+    return { data, index };
+  }
+
+  return parseBlock(0, 0).data;
+}
+
+function relayEventsPath(relayManifestPath, runId) {
+  return path.join(path.dirname(relayManifestPath), runId, "events.jsonl");
+}
+
+function readRelayManifestMetadata(relayManifestPath) {
+  const resolved = path.resolve(relayManifestPath);
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`Relay manifest not found: ${resolved}`);
+  }
+
+  const text = fs.readFileSync(resolved, "utf-8");
+  const data = parseFrontmatter(text);
+  const runId = normalizeRelayField(data.run_id) || path.basename(resolved, path.extname(resolved));
+
+  return {
+    manifestPath: resolved,
+    runId,
+    state: normalizeRelayField(data.state),
+    nextAction: normalizeRelayField(data.next_action),
+    issueNumber: Number.isFinite(data.issue?.number) ? data.issue.number : null,
+    prNumber: Number.isFinite(data.git?.pr_number) ? data.git.pr_number : null,
+    executor: normalizeRelayField(data.roles?.executor),
+    reviewer: normalizeRelayField(data.roles?.reviewer),
+    actor: normalizeRelayField(data.roles?.actor) || normalizeRelayField(data.roles?.orchestrator),
+    rounds: Number.isFinite(data.review?.rounds) ? data.review.rounds : null,
+  };
+}
+
+function readRelayGrade(eventsPath) {
+  if (!fs.existsSync(eventsPath)) return null;
+
+  let grade = null;
+  const lines = fs.readFileSync(eventsPath, "utf-8")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  for (const line of lines) {
+    const record = JSON.parse(line);
+    if (record.event === "rubric_quality" && typeof record.grade === "string" && record.grade.trim()) {
+      grade = record.grade.trim();
+    }
+  }
+
+  return grade;
+}
+
+function loadRelayMetadata(relayManifestPath) {
+  if (!relayManifestPath) return null;
+
+  const metadata = readRelayManifestMetadata(relayManifestPath);
+  return {
+    ...metadata,
+    eventsPath: relayEventsPath(metadata.manifestPath, metadata.runId),
+    grade: readRelayGrade(relayEventsPath(metadata.manifestPath, metadata.runId)),
+  };
+}
+
+module.exports = {
+  readRelayManifestMetadata,
+  readRelayGrade,
+  loadRelayMetadata,
+};

--- a/skills/dev-backlog/scripts/progress-sync-render.js
+++ b/skills/dev-backlog/scripts/progress-sync-render.js
@@ -1,0 +1,198 @@
+const MARKER_PREFIX = "<!-- dev-backlog:progress-issue month=";
+const MARKER_SUFFIX = " -->";
+const COMMENT_MARKER_PREFIX = "<!-- dev-backlog:progress-comment id=";
+const COMMENT_MARKER_SUFFIX = " -->";
+
+function makeMarker(month) {
+  return `${MARKER_PREFIX}${month}${MARKER_SUFFIX}`;
+}
+
+function parseMarkerMonth(body) {
+  if (!body) return null;
+  const idx = body.indexOf(MARKER_PREFIX);
+  if (idx === -1) return null;
+  const start = idx + MARKER_PREFIX.length;
+  const end = body.indexOf(MARKER_SUFFIX, start);
+  if (end === -1) return null;
+  return body.slice(start, end).trim();
+}
+
+function makeCommentMarker(entryId) {
+  return `${COMMENT_MARKER_PREFIX}${entryId}${COMMENT_MARKER_SUFFIX}`;
+}
+
+function parseCommentEntryId(body) {
+  if (!body) return null;
+  const idx = body.indexOf(COMMENT_MARKER_PREFIX);
+  if (idx === -1) return null;
+  const start = idx + COMMENT_MARKER_PREFIX.length;
+  const end = body.indexOf(COMMENT_MARKER_SUFFIX, start);
+  if (end === -1) return null;
+  return body.slice(start, end).trim() || null;
+}
+
+function mergeEntryKey(month, prNumber) {
+  return `${month}/merge/pr-${prNumber}`;
+}
+
+function stuckEntryKey(month, taskFile) {
+  return `${month}/stuck/${taskFile}`;
+}
+
+function relayMergeEntryKey(runId) {
+  return `run/${runId}/merge`;
+}
+
+function relayStuckEntryKey(runId) {
+  return `run/${runId}/stuck`;
+}
+
+function parseTaskIssueNumber(taskFile) {
+  const match = String(taskFile || "").match(/^[A-Za-z]+-(\d+)\b/);
+  return match ? Number(match[1]) : null;
+}
+
+function monthTitle(month) {
+  const [y, m] = month.split("-");
+  const names = [
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December",
+  ];
+  return `Progress: ${names[Number(m) - 1]} ${y}`;
+}
+
+function renderBody({ month, summary, prevIssueNumber, nextIssueNumber }) {
+  const marker = makeMarker(month);
+  const lines = [marker, "", `# ${monthTitle(month)}`, ""];
+
+  lines.push("## Summary", "");
+  lines.push(`| Metric | Count |`);
+  lines.push(`| --- | --- |`);
+  lines.push(`| Merged PRs (month) | ${summary.merged} |`);
+  lines.push(`| In-flight (open PRs) | ${summary.inFlight} |`);
+  lines.push(`| Stuck candidates | ${summary.stuckCandidates} |`);
+  lines.push("");
+
+  if (summary.finalizedAt) {
+    lines.push("## Month End", "");
+    lines.push(`- Finalized on: ${summary.finalizedAt}`);
+    lines.push("- State: closed");
+    lines.push("");
+  }
+
+  if (summary.sprint) {
+    const s = summary.sprint;
+    lines.push("## Active Sprint", "");
+    lines.push(`**${s.file}** — ${s.done}/${s.total} done, ${s.inflight} in-flight, ${s.todo} remaining`);
+    lines.push("");
+  } else {
+    lines.push("## Active Sprint", "");
+    lines.push("_No active sprint._");
+    lines.push("");
+  }
+
+  if (prevIssueNumber) {
+    lines.push("## Previous", "");
+    lines.push(`- #${prevIssueNumber}`);
+    lines.push("");
+  }
+
+  if (nextIssueNumber) {
+    lines.push("## Next", "");
+    lines.push(`- #${nextIssueNumber}`);
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+function relayDetailLine(relay, { includeState = false } = {}) {
+  if (!relay?.runId) return null;
+
+  const parts = [`run \`${relay.runId}\``];
+  if (relay.grade) parts.push(`grade ${relay.grade}`);
+  if (typeof relay.rounds === "number") parts.push(`rounds ${relay.rounds}`);
+  if (relay.executor) parts.push(`executor ${relay.executor}`);
+  if (relay.reviewer) parts.push(`reviewer ${relay.reviewer}`);
+  if (relay.actor) parts.push(`actor ${relay.actor}`);
+  if (includeState && relay.state) parts.push(`state ${relay.state}`);
+  if (includeState && relay.nextAction) parts.push(`next ${relay.nextAction}`);
+
+  return parts.length ? `**Relay:** ${parts.join(" · ")}` : null;
+}
+
+function renderMergeComment(month, pr, relay = null) {
+  const entryId = relay?.runId ? relayMergeEntryKey(relay.runId) : mergeEntryKey(month, pr.number);
+  const marker = makeCommentMarker(entryId);
+  const lines = [marker, `**Merged:** #${pr.number} — ${pr.title}`];
+  const relayLine = relayDetailLine(relay);
+  if (relayLine) {
+    lines.push("", relayLine);
+  }
+  return lines.join("\n");
+}
+
+function renderStuckComment(month, task, relay = null) {
+  const entryId = relay?.runId ? relayStuckEntryKey(relay.runId) : stuckEntryKey(month, task.file);
+  const marker = makeCommentMarker(entryId);
+  const lines = [marker, `**Stuck candidate:** ${task.file} (status: ${task.status})`];
+  const relayLine = relayDetailLine(relay, { includeState: true });
+  if (relayLine) {
+    lines.push("", relayLine);
+  }
+  return lines.join("\n");
+}
+
+function parseManagedComments(comments) {
+  const managed = [];
+  for (const comment of comments) {
+    const entryId = parseCommentEntryId(comment.body);
+    if (entryId) {
+      managed.push({ id: comment.id, entryId, body: comment.body });
+    }
+  }
+  return managed;
+}
+
+function buildDesiredCommentEntries({ mergedPRs, stuckTasks, month, relayMetadata }) {
+  const desired = [];
+
+  for (const pr of mergedPRs) {
+    const relay = relayMetadata?.runId && relayMetadata.prNumber === pr.number ? relayMetadata : null;
+    desired.push({
+      entryId: relay ? relayMergeEntryKey(relay.runId) : mergeEntryKey(month, pr.number),
+      aliasIds: relay ? [mergeEntryKey(month, pr.number)] : [],
+      body: renderMergeComment(month, pr, relay),
+    });
+  }
+
+  for (const task of stuckTasks) {
+    const taskIssueNumber = task.issueNumber ?? parseTaskIssueNumber(task.file);
+    const relay = relayMetadata?.runId && relayMetadata.issueNumber === taskIssueNumber ? relayMetadata : null;
+    desired.push({
+      entryId: relay ? relayStuckEntryKey(relay.runId) : stuckEntryKey(month, task.file),
+      aliasIds: relay ? [stuckEntryKey(month, task.file)] : [],
+      body: renderStuckComment(month, task, relay),
+    });
+  }
+
+  return desired;
+}
+
+module.exports = {
+  makeMarker,
+  parseMarkerMonth,
+  makeCommentMarker,
+  parseCommentEntryId,
+  mergeEntryKey,
+  stuckEntryKey,
+  relayMergeEntryKey,
+  relayStuckEntryKey,
+  parseTaskIssueNumber,
+  monthTitle,
+  renderBody,
+  renderMergeComment,
+  renderStuckComment,
+  parseManagedComments,
+  buildDesiredCommentEntries,
+};

--- a/skills/dev-backlog/scripts/progress-sync.cli.test.js
+++ b/skills/dev-backlog/scripts/progress-sync.cli.test.js
@@ -1,0 +1,101 @@
+const { describe, it, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const SCRIPT_PATH = path.join(__dirname, "progress-sync.js");
+const tempDirs = [];
+
+function makeWorkspace() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "progress-sync-cli-"));
+  tempDirs.push(dir);
+  fs.mkdirSync(path.join(dir, "backlog", "tasks"), { recursive: true });
+  fs.mkdirSync(path.join(dir, "backlog", "sprints"), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "backlog", "tasks", "BACK-5 - sync.md"),
+    "---\nstatus: In Progress\n---\n"
+  );
+  fs.writeFileSync(
+    path.join(dir, "backlog", "sprints", "2026-04-maintenance.md"),
+    [
+      "---",
+      "status: active",
+      "---",
+      "## Plan",
+      "- [x] #49 Done",
+      "- [~] #50 In-flight",
+      "- [ ] #51 Todo",
+    ].join("\n")
+  );
+  return dir;
+}
+
+function writeMockGh(binDir) {
+  const ghPath = path.join(binDir, "gh");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(ghPath, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+const joined = args.join(" ");
+
+if (joined.includes("issue list")) {
+  process.stdout.write("[]");
+  process.exit(0);
+}
+
+if (joined.includes("pr list") && joined.includes("open")) {
+  process.stdout.write(JSON.stringify([{ number: 20, title: "Open PR" }]));
+  process.exit(0);
+}
+
+if (joined.includes("pr list") && joined.includes("merged")) {
+  process.stdout.write(JSON.stringify([{ number: 21, title: "Merged PR" }]));
+  process.exit(0);
+}
+
+process.stdout.write("{}");
+`);
+  fs.chmodSync(ghPath, 0o755);
+}
+
+describe("progress-sync CLI", () => {
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
+    }
+  });
+
+  it("runs the real command with a mocked gh binary", () => {
+    const workspaceDir = makeWorkspace();
+    const binDir = path.join(workspaceDir, "bin");
+    writeMockGh(binDir);
+
+    const result = spawnSync(
+      process.execPath,
+      [SCRIPT_PATH, "--dry-run", "--json", "--month", "2026-04"],
+      {
+        cwd: workspaceDir,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH || ""}`,
+        },
+      }
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stderr, "");
+
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.action, "progress-sync");
+    assert.equal(payload.dryRun, true);
+    assert.equal(payload.month, "2026-04");
+    assert.equal(payload.summary.merged, 1);
+    assert.equal(payload.summary.inFlight, 1);
+    assert.equal(payload.summary.stuckCandidates, 1);
+    assert.equal(payload.summary.sprint.file, "2026-04-maintenance.md");
+    assert.equal(payload.comments.created, 0);
+    assert.ok(payload.body.includes("| Merged PRs (month) | 1 |"));
+  });
+});

--- a/skills/dev-backlog/scripts/progress-sync.js
+++ b/skills/dev-backlog/scripts/progress-sync.js
@@ -17,79 +17,43 @@
 const { execFileSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
-const { GH_EXEC_DEFAULTS } = require("./lib");
-
-// --- Machine marker (body) ---
-
-const MARKER_PREFIX = "<!-- dev-backlog:progress-issue month=";
-const MARKER_SUFFIX = " -->";
-
-function makeMarker(month) {
-  return `${MARKER_PREFIX}${month}${MARKER_SUFFIX}`;
-}
-
-function parseMarkerMonth(body) {
-  if (!body) return null;
-  const idx = body.indexOf(MARKER_PREFIX);
-  if (idx === -1) return null;
-  const start = idx + MARKER_PREFIX.length;
-  const end = body.indexOf(MARKER_SUFFIX, start);
-  if (end === -1) return null;
-  return body.slice(start, end).trim();
-}
-
-// --- Machine marker (comment) ---
-
-const COMMENT_MARKER_PREFIX = "<!-- dev-backlog:progress-comment id=";
-const COMMENT_MARKER_SUFFIX = " -->";
-
-function makeCommentMarker(entryId) {
-  return `${COMMENT_MARKER_PREFIX}${entryId}${COMMENT_MARKER_SUFFIX}`;
-}
-
-function parseCommentEntryId(body) {
-  if (!body) return null;
-  const idx = body.indexOf(COMMENT_MARKER_PREFIX);
-  if (idx === -1) return null;
-  const start = idx + COMMENT_MARKER_PREFIX.length;
-  const end = body.indexOf(COMMENT_MARKER_SUFFIX, start);
-  if (end === -1) return null;
-  return body.slice(start, end).trim() || null;
-}
-
-// --- Entry key derivation ---
-
-function mergeEntryKey(month, prNumber) {
-  return `${month}/merge/pr-${prNumber}`;
-}
-
-function stuckEntryKey(month, taskFile) {
-  return `${month}/stuck/${taskFile}`;
-}
-
-function relayMergeEntryKey(runId) {
-  return `run/${runId}/merge`;
-}
-
-function relayStuckEntryKey(runId) {
-  return `run/${runId}/stuck`;
-}
-
-// --- Month helpers ---
+const {
+  makeMarker,
+  parseMarkerMonth,
+  makeCommentMarker,
+  parseCommentEntryId,
+  mergeEntryKey,
+  stuckEntryKey,
+  relayMergeEntryKey,
+  relayStuckEntryKey,
+  parseTaskIssueNumber,
+  monthTitle,
+  renderBody,
+  renderMergeComment,
+  renderStuckComment,
+  parseManagedComments,
+  buildDesiredCommentEntries,
+} = require("./progress-sync-render");
+const {
+  readRelayManifestMetadata,
+  readRelayGrade,
+  loadRelayMetadata,
+} = require("./progress-sync-relay");
+const {
+  findMonthIssue,
+  createIssue,
+  updateIssueBody,
+  closeIssue,
+  fetchOpenPRs,
+  fetchMergedPRsThisMonth,
+  fetchIssueComments,
+  reconcileComments,
+} = require("./progress-sync-github");
 
 function monthKey(date) {
   const y = date.getFullYear();
   const m = String(date.getMonth() + 1).padStart(2, "0");
   return `${y}-${m}`;
-}
-
-function monthTitle(month) {
-  const [y, m] = month.split("-");
-  const names = [
-    "January", "February", "March", "April", "May", "June",
-    "July", "August", "September", "October", "November", "December",
-  ];
-  return `Progress: ${names[Number(m) - 1]} ${y}`;
 }
 
 function prevMonth(month) {
@@ -167,11 +131,6 @@ function parseArgs(args) {
 
 // --- Local data readers ---
 
-function parseTaskIssueNumber(taskFile) {
-  const match = String(taskFile || "").match(/^[A-Za-z]+-(\d+)\b/);
-  return match ? Number(match[1]) : null;
-}
-
 function readTaskFiles(tasksDir) {
   if (!fs.existsSync(tasksDir)) return [];
   return fs.readdirSync(tasksDir)
@@ -187,11 +146,6 @@ function readTaskFiles(tasksDir) {
         status: statusMatch ? statusMatch[1].trim() : "unknown",
       };
     });
-}
-
-function readCompletedCount(completedDir) {
-  if (!fs.existsSync(completedDir)) return 0;
-  return fs.readdirSync(completedDir).filter((f) => f.endsWith(".md")).length;
 }
 
 function readActiveSprintSummary(sprintsDir) {
@@ -226,485 +180,6 @@ function computeSummary({ tasks, sprint, openPRs, mergedPRs }) {
 
 // --- Body rendering ---
 
-function renderBody({ month, summary, prevIssueNumber, nextIssueNumber }) {
-  const marker = makeMarker(month);
-  const lines = [marker, "", `# ${monthTitle(month)}`, ""];
-
-  // Counts
-  lines.push("## Summary", "");
-  lines.push(`| Metric | Count |`);
-  lines.push(`| --- | --- |`);
-  lines.push(`| Merged / completed | ${summary.merged} |`);
-  lines.push(`| In-flight (open PRs) | ${summary.inFlight} |`);
-  lines.push(`| Stuck candidates | ${summary.stuckCandidates} |`);
-  lines.push("");
-
-  if (summary.finalizedAt) {
-    lines.push("## Month End", "");
-    lines.push(`- Finalized on: ${summary.finalizedAt}`);
-    lines.push("- State: closed");
-    lines.push("");
-  }
-
-  // Sprint snapshot
-  if (summary.sprint) {
-    const s = summary.sprint;
-    lines.push("## Active Sprint", "");
-    lines.push(`**${s.file}** — ${s.done}/${s.total} done, ${s.inflight} in-flight, ${s.todo} remaining`);
-    lines.push("");
-  } else {
-    lines.push("## Active Sprint", "");
-    lines.push("_No active sprint._");
-    lines.push("");
-  }
-
-  // Previous month link
-  if (prevIssueNumber) {
-    lines.push("## Previous", "");
-    lines.push(`- #${prevIssueNumber}`);
-    lines.push("");
-  }
-
-  if (nextIssueNumber) {
-    lines.push("## Next", "");
-    lines.push(`- #${nextIssueNumber}`);
-    lines.push("");
-  }
-
-  return lines.join("\n");
-}
-
-// --- Comment rendering ---
-
-function normalizeRelayField(value) {
-  if (value === null || value === undefined) return null;
-  if (typeof value === "string") {
-    const trimmed = value.trim();
-    if (!trimmed || trimmed === "unknown" || trimmed === "null") return null;
-    return trimmed;
-  }
-  return value;
-}
-
-function parseFrontmatterScalar(value) {
-  if (value === "null") return null;
-  if (value === "true") return true;
-  if (value === "false") return false;
-  if (/^-?\d+(?:\.\d+)?$/.test(value)) return Number(value);
-  if (value.startsWith("'") && value.endsWith("'")) {
-    return value.slice(1, -1).replace(/''/g, "'");
-  }
-  if (value.startsWith("\"") && value.endsWith("\"")) {
-    return JSON.parse(value);
-  }
-  return value;
-}
-
-function parseFrontmatter(text) {
-  const lines = text.replace(/\r\n/g, "\n").split("\n");
-  if (lines[0] !== "---") {
-    return {};
-  }
-
-  const closingIndex = lines.indexOf("---", 1);
-  if (closingIndex === -1) {
-    throw new Error("Invalid relay manifest: missing closing frontmatter marker");
-  }
-
-  const frontmatterLines = lines.slice(1, closingIndex);
-
-  function parseBlock(startIndex, indent) {
-    const data = {};
-    let index = startIndex;
-
-    while (index < frontmatterLines.length) {
-      const raw = frontmatterLines[index];
-      if (!raw.trim()) {
-        index++;
-        continue;
-      }
-
-      const currentIndent = raw.match(/^ */)[0].length;
-      if (currentIndent < indent) break;
-      if (currentIndent > indent) {
-        throw new Error(`Invalid relay manifest indentation on line ${index + 2}`);
-      }
-
-      const trimmed = raw.trim();
-      const separator = trimmed.indexOf(":");
-      if (separator === -1) {
-        throw new Error(`Invalid relay manifest entry on line ${index + 2}`);
-      }
-
-      const key = trimmed.slice(0, separator).trim();
-      const rest = trimmed.slice(separator + 1).trim();
-
-      if (!rest) {
-        const nested = parseBlock(index + 1, indent + 2);
-        data[key] = nested.data;
-        index = nested.index;
-        continue;
-      }
-
-      data[key] = parseFrontmatterScalar(rest);
-      index++;
-    }
-
-    return { data, index };
-  }
-
-  return parseBlock(0, 0).data;
-}
-
-function relayEventsPath(relayManifestPath, runId) {
-  return path.join(path.dirname(relayManifestPath), runId, "events.jsonl");
-}
-
-function readRelayManifestMetadata(relayManifestPath) {
-  const resolved = path.resolve(relayManifestPath);
-  if (!fs.existsSync(resolved)) {
-    throw new Error(`Relay manifest not found: ${resolved}`);
-  }
-
-  const text = fs.readFileSync(resolved, "utf-8");
-  const data = parseFrontmatter(text);
-  const runId = normalizeRelayField(data.run_id) || path.basename(resolved, path.extname(resolved));
-
-  return {
-    manifestPath: resolved,
-    runId,
-    state: normalizeRelayField(data.state),
-    nextAction: normalizeRelayField(data.next_action),
-    issueNumber: Number.isFinite(data.issue?.number) ? data.issue.number : null,
-    prNumber: Number.isFinite(data.git?.pr_number) ? data.git.pr_number : null,
-    executor: normalizeRelayField(data.roles?.executor),
-    reviewer: normalizeRelayField(data.roles?.reviewer),
-    actor: normalizeRelayField(data.roles?.actor) || normalizeRelayField(data.roles?.orchestrator),
-    rounds: Number.isFinite(data.review?.rounds) ? data.review.rounds : null,
-  };
-}
-
-function readRelayGrade(eventsPath) {
-  if (!fs.existsSync(eventsPath)) return null;
-
-  let grade = null;
-  const lines = fs.readFileSync(eventsPath, "utf-8")
-    .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean);
-
-  for (const line of lines) {
-    const record = JSON.parse(line);
-    if (record.event === "rubric_quality" && typeof record.grade === "string" && record.grade.trim()) {
-      grade = record.grade.trim();
-    }
-  }
-
-  return grade;
-}
-
-function loadRelayMetadata(relayManifestPath) {
-  if (!relayManifestPath) return null;
-
-  const metadata = readRelayManifestMetadata(relayManifestPath);
-  return {
-    ...metadata,
-    eventsPath: relayEventsPath(metadata.manifestPath, metadata.runId),
-    grade: readRelayGrade(relayEventsPath(metadata.manifestPath, metadata.runId)),
-  };
-}
-
-function relayDetailLine(relay, { includeState = false } = {}) {
-  if (!relay?.runId) return null;
-
-  const parts = [`run \`${relay.runId}\``];
-  if (relay.grade) parts.push(`grade ${relay.grade}`);
-  if (typeof relay.rounds === "number") parts.push(`rounds ${relay.rounds}`);
-  if (relay.executor) parts.push(`executor ${relay.executor}`);
-  if (relay.reviewer) parts.push(`reviewer ${relay.reviewer}`);
-  if (relay.actor) parts.push(`actor ${relay.actor}`);
-  if (includeState && relay.state) parts.push(`state ${relay.state}`);
-  if (includeState && relay.nextAction) parts.push(`next ${relay.nextAction}`);
-
-  return parts.length ? `**Relay:** ${parts.join(" · ")}` : null;
-}
-
-function renderMergeComment(month, pr, relay = null) {
-  const entryId = relay?.runId ? relayMergeEntryKey(relay.runId) : mergeEntryKey(month, pr.number);
-  const marker = makeCommentMarker(entryId);
-  const lines = [marker, `**Merged:** #${pr.number} — ${pr.title}`];
-  const relayLine = relayDetailLine(relay);
-  if (relayLine) {
-    lines.push("", relayLine);
-  }
-  return lines.join("\n");
-}
-
-function renderStuckComment(month, task, relay = null) {
-  const entryId = relay?.runId ? relayStuckEntryKey(relay.runId) : stuckEntryKey(month, task.file);
-  const marker = makeCommentMarker(entryId);
-  const lines = [marker, `**Stuck candidate:** ${task.file} (status: ${task.status})`];
-  const relayLine = relayDetailLine(relay, { includeState: true });
-  if (relayLine) {
-    lines.push("", relayLine);
-  }
-  return lines.join("\n");
-}
-
-// --- GitHub I/O ---
-
-function searchProgressIssues(month, execFile) {
-  const title = monthTitle(month);
-  const out = execFile("gh", [
-    "issue", "list", "--state", "all", "--search", `"${title}" in:title`,
-    "--json", "number,title,body", "--limit", "50",
-  ], GH_EXEC_DEFAULTS);
-  return JSON.parse(out);
-}
-
-function findMonthIssue(month, execFile) {
-  const issues = searchProgressIssues(month, execFile);
-  const marker = makeMarker(month);
-  // Trust marker first
-  const markerMatch = issues.find((i) => i.body && i.body.includes(marker));
-  if (markerMatch) return markerMatch;
-  // Fallback: exact title match
-  const title = monthTitle(month);
-  return issues.find((i) => i.title === title) || null;
-}
-
-function createIssue(title, body, execFile) {
-  const out = execFile("gh", [
-    "issue", "create", "--title", title, "--body", body,
-  ], GH_EXEC_DEFAULTS);
-  // gh issue create prints the issue URL, e.g. https://github.com/owner/repo/issues/123
-  const match = out.trim().match(/\/issues\/(\d+)\s*$/);
-  if (!match) {
-    throw new Error(`Failed to parse issue number from gh output: ${out.trim()}`);
-  }
-  return { number: Number(match[1]) };
-}
-
-function updateIssueBody(number, body, execFile) {
-  execFile("gh", [
-    "issue", "edit", String(number), "--body", body,
-  ], GH_EXEC_DEFAULTS);
-}
-
-function closeIssue(number, execFile) {
-  execFile("gh", [
-    "api", `repos/{owner}/{repo}/issues/${number}`,
-    "--method", "PATCH",
-    "--field", "state=closed",
-  ], GH_EXEC_DEFAULTS);
-}
-
-function fetchOpenPRs(execFile) {
-  try {
-    const out = execFile("gh", [
-      "pr", "list", "--state", "open", "--json", "number,title",
-      "--limit", "100",
-    ], GH_EXEC_DEFAULTS);
-    return JSON.parse(out);
-  } catch {
-    return [];
-  }
-}
-
-function fetchMergedPRsThisMonth(month, execFile) {
-  const [y, m] = month.split("-");
-  const start = `${y}-${m}-01`;
-  // Approximate end of month
-  const nextM = Number(m) === 12 ? 1 : Number(m) + 1;
-  const nextY = Number(m) === 12 ? Number(y) + 1 : Number(y);
-  const end = `${nextY}-${String(nextM).padStart(2, "0")}-01`;
-  try {
-    const out = execFile("gh", [
-      "pr", "list", "--state", "merged",
-      "--search", `merged:>=${start} merged:<${end}`,
-      "--json", "number,title",
-      "--limit", "200",
-    ], GH_EXEC_DEFAULTS);
-    return JSON.parse(out);
-  } catch {
-    return [];
-  }
-}
-
-// --- Comment I/O ---
-
-function parsePaginatedApiArray(output) {
-  const text = String(output || "").trim();
-  if (!text) return [];
-
-  try {
-    const parsed = JSON.parse(text);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {}
-
-  try {
-    const combined = `[${text.replace(/\]\s*\[/g, "],[")}]`;
-    const parsed = JSON.parse(combined);
-    return parsed.flatMap((page) => Array.isArray(page) ? page : [page]);
-  } catch {
-    return [];
-  }
-}
-
-function fetchIssueComments(issueNumber, execFile) {
-  try {
-    const out = execFile("gh", [
-      "api", `repos/{owner}/{repo}/issues/${issueNumber}/comments`,
-      "--paginate",
-    ], GH_EXEC_DEFAULTS);
-    return parsePaginatedApiArray(out);
-  } catch {
-    return [];
-  }
-}
-
-function createIssueComment(issueNumber, body, execFile) {
-  execFile("gh", [
-    "api", `repos/{owner}/{repo}/issues/${issueNumber}/comments`,
-    "--method", "POST", "--field", `body=${body}`,
-  ], GH_EXEC_DEFAULTS);
-}
-
-function updateIssueComment(commentId, body, execFile) {
-  execFile("gh", [
-    "api", `repos/{owner}/{repo}/issues/comments/${commentId}`,
-    "--method", "PATCH", "--field", `body=${body}`,
-  ], GH_EXEC_DEFAULTS);
-}
-
-function deleteIssueComment(commentId, execFile) {
-  execFile("gh", [
-    "api", `repos/{owner}/{repo}/issues/comments/${commentId}`,
-    "--method", "DELETE",
-  ], GH_EXEC_DEFAULTS);
-}
-
-// --- Comment reconciliation ---
-
-function parseManagedComments(comments) {
-  const managed = [];
-  for (const c of comments) {
-    const entryId = parseCommentEntryId(c.body);
-    if (entryId) {
-      managed.push({ id: c.id, entryId, body: c.body });
-    }
-  }
-  return managed;
-}
-
-function buildDesiredCommentEntries({ mergedPRs, stuckTasks, month, relayMetadata }) {
-  const desired = [];
-
-  for (const pr of mergedPRs) {
-    const relay = relayMetadata?.runId && relayMetadata.prNumber === pr.number ? relayMetadata : null;
-    desired.push({
-      entryId: relay ? relayMergeEntryKey(relay.runId) : mergeEntryKey(month, pr.number),
-      aliasIds: relay ? [mergeEntryKey(month, pr.number)] : [],
-      body: renderMergeComment(month, pr, relay),
-    });
-  }
-
-  for (const task of stuckTasks) {
-    const taskIssueNumber = task.issueNumber ?? parseTaskIssueNumber(task.file);
-    const relay = relayMetadata?.runId && relayMetadata.issueNumber === taskIssueNumber ? relayMetadata : null;
-    desired.push({
-      entryId: relay ? relayStuckEntryKey(relay.runId) : stuckEntryKey(month, task.file),
-      aliasIds: relay ? [stuckEntryKey(month, task.file)] : [],
-      body: renderStuckComment(month, task, relay),
-    });
-  }
-
-  return desired;
-}
-
-function matchingManagedComments(byEntryId, entry) {
-  const unique = new Map();
-  const entryIds = [entry.entryId, ...(entry.aliasIds || [])];
-
-  for (const entryId of entryIds) {
-    const matches = byEntryId.get(entryId) || [];
-    for (const match of matches) {
-      unique.set(match.id, match);
-    }
-  }
-
-  return Array.from(unique.values());
-}
-
-function selectPrimaryManagedComment(existing, canonicalEntryId) {
-  return existing.find((comment) => comment.entryId === canonicalEntryId) || existing[0];
-}
-
-function reconcileComments({
-  issueNumber,
-  mergedPRs,
-  stuckTasks,
-  month,
-  relayMetadata = null,
-  dryRun,
-  execFile,
-  fetchComments = fetchIssueComments,
-}) {
-  const allComments = fetchComments(issueNumber, execFile);
-  const managed = parseManagedComments(allComments);
-
-  // Build index: entryId → [managed comments]
-  const byEntryId = new Map();
-  for (const mc of managed) {
-    if (!byEntryId.has(mc.entryId)) byEntryId.set(mc.entryId, []);
-    byEntryId.get(mc.entryId).push(mc);
-  }
-
-  const desired = buildDesiredCommentEntries({ mergedPRs, stuckTasks, month, relayMetadata });
-
-  const actions = { created: 0, updated: 0, skipped: 0, repaired: 0 };
-
-  for (const entry of desired) {
-    const existing = matchingManagedComments(byEntryId, entry);
-
-    if (existing.length === 0) {
-      // Create new comment
-      if (!dryRun) createIssueComment(issueNumber, entry.body, execFile);
-      actions.created++;
-    } else if (existing.length === 1) {
-      // Single existing — update if body differs, skip if identical
-      if (existing[0].body === entry.body && existing[0].entryId === entry.entryId) {
-        actions.skipped++;
-      } else {
-        if (!dryRun) updateIssueComment(existing[0].id, entry.body, execFile);
-        actions.updated++;
-      }
-    } else {
-      // Duplicate repair: keep the first, update it, delete the rest
-      const primary = selectPrimaryManagedComment(existing, entry.entryId);
-      const duplicates = existing.filter((comment) => comment.id !== primary.id);
-      if (!dryRun) {
-        updateIssueComment(primary.id, entry.body, execFile);
-        for (const duplicate of duplicates) {
-          deleteIssueComment(duplicate.id, execFile);
-        }
-      }
-      actions.repaired++;
-    }
-
-    // Remove processed entry from index so we don't revisit
-    byEntryId.delete(entry.entryId);
-    for (const aliasId of entry.aliasIds || []) {
-      byEntryId.delete(aliasId);
-    }
-  }
-
-  // Remaining managed comments with entry ids not in desired set are left as-is
-  // (they may be from a previous month or an entry type we no longer emit)
-
-  return actions;
-}
-
 // --- Core sync logic ---
 
 function sync({
@@ -715,11 +190,10 @@ function sync({
   relayManifestPath = null,
   now = new Date(),
   execFile = execFileSync,
-  readFs = { readTaskFiles, readCompletedCount, readActiveSprintSummary },
+  readFs = { readTaskFiles, readActiveSprintSummary },
   fetchComments = fetchIssueComments,
 }) {
   const tasksDir = path.join(backlogDir, "tasks");
-  const completedDir = path.join(backlogDir, "completed");
   const sprintsDir = path.join(backlogDir, "sprints");
 
   // Gather source data
@@ -846,7 +320,7 @@ function printResult(result) {
   }
 
   const s = result.summary;
-  console.log(`  merged/completed: ${s.merged}, in-flight: ${s.inFlight}, stuck candidates: ${s.stuckCandidates}`);
+  console.log(`  merged PRs (month): ${s.merged}, in-flight: ${s.inFlight}, stuck candidates: ${s.stuckCandidates}`);
 
   if (s.sprint) {
     console.log(`  sprint: ${s.sprint.file} (${s.sprint.done}/${s.sprint.total} done)`);
@@ -941,7 +415,6 @@ module.exports = {
   parseFinalizedDate,
   parseArgs,
   readTaskFiles,
-  readCompletedCount,
   readActiveSprintSummary,
   computeSummary,
   renderBody,

--- a/skills/dev-backlog/scripts/progress-sync.test.js
+++ b/skills/dev-backlog/scripts/progress-sync.test.js
@@ -29,7 +29,6 @@ const {
   parseFinalizedDate,
   parseArgs,
   readTaskFiles,
-  readCompletedCount,
   readActiveSprintSummary,
   computeSummary,
   renderBody,
@@ -207,23 +206,6 @@ describe("parseTaskIssueNumber", () => {
   });
 });
 
-describe("readCompletedCount", () => {
-  let tmpDir;
-
-  beforeEach(() => { tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ps-comp-")); });
-  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
-
-  it("counts .md files", () => {
-    fs.writeFileSync(path.join(tmpDir, "BACK-1.md"), "done");
-    fs.writeFileSync(path.join(tmpDir, "BACK-2.md"), "done");
-    assert.equal(readCompletedCount(tmpDir), 2);
-  });
-
-  it("returns 0 for missing dir", () => {
-    assert.equal(readCompletedCount("/nonexistent/path"), 0);
-  });
-});
-
 describe("readActiveSprintSummary", () => {
   let tmpDir;
 
@@ -314,7 +296,7 @@ describe("renderBody", () => {
 
     assert.ok(body.includes("<!-- dev-backlog:progress-issue month=2026-04 -->"));
     assert.ok(body.includes("# Progress: April 2026"));
-    assert.ok(body.includes("| Merged / completed | 5 |"));
+    assert.ok(body.includes("| Merged PRs (month) | 5 |"));
     assert.ok(body.includes("| In-flight (open PRs) | 2 |"));
     assert.ok(body.includes("| Stuck candidates | 1 |"));
     assert.ok(body.includes("2026-04-auth.md"));
@@ -624,8 +606,6 @@ describe("sync", () => {
     // Write task files
     fs.writeFileSync(path.join(tmpDir, "tasks", "BACK-1 - foo.md"), "---\nstatus: In Progress\n---\n");
     fs.writeFileSync(path.join(tmpDir, "tasks", "BACK-2 - bar.md"), "---\nstatus: To Do\n---\n");
-    // Write completed
-    fs.writeFileSync(path.join(tmpDir, "completed", "BACK-0.md"), "done");
     // Write active sprint
     fs.writeFileSync(path.join(tmpDir, "sprints", "2026-04-auth.md"), [
       "---", "status: active", "---",
@@ -656,7 +636,7 @@ describe("sync", () => {
   });
 
   it("handles sparse data gracefully", () => {
-    // Empty backlog dir — no tasks, no completed, no sprints
+    // Empty backlog dir — no tasks or sprints
     const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), "ps-empty-"));
     const { execFile } = makeExecFile({
       createdIssueNumber: 99,
@@ -682,7 +662,7 @@ describe("sync", () => {
     const staleBody = "<!-- dev-backlog:progress-issue month=2026-04 -->\nold stale content";
     const existing = { number: 50, title: "Progress: April 2026", body: staleBody };
 
-    // Write fresh local data
+    // Completed backlog files are ignored for the merged summary.
     fs.writeFileSync(path.join(tmpDir, "completed", "BACK-1.md"), "done");
     fs.writeFileSync(path.join(tmpDir, "completed", "BACK-2.md"), "done");
     fs.writeFileSync(path.join(tmpDir, "completed", "BACK-3.md"), "done");
@@ -699,12 +679,10 @@ describe("sync", () => {
     // Body must not contain stale text
     assert.ok(!result.body.includes("old stale content"));
     // Body is freshly rendered — merged count is from month-scoped PRs only (0 here)
-    assert.ok(result.body.includes("| Merged / completed | 0 |"));
+    assert.ok(result.body.includes("| Merged PRs (month) | 0 |"));
   });
 
   it("idempotent: same output for same inputs", () => {
-    fs.writeFileSync(path.join(tmpDir, "completed", "BACK-1.md"), "done");
-
     const existing = {
       number: 50,
       title: "Progress: April 2026",
@@ -716,6 +694,34 @@ describe("sync", () => {
     const r2 = sync({ month: "2026-04", dryRun: true, backlogDir: tmpDir, execFile: makeExec() });
 
     assert.equal(r1.body, r2.body);
+  });
+
+  it("ignores completed backlog readers when computing merged summary", () => {
+    fs.writeFileSync(path.join(tmpDir, "completed", "BACK-1.md"), "done");
+    fs.writeFileSync(path.join(tmpDir, "completed", "BACK-2.md"), "done");
+
+    const { execFile } = makeExecFile({
+      mergedPRs: [{ number: 11, title: "PR" }],
+      createdIssueNumber: 99,
+    });
+
+    const result = sync({
+      month: "2026-04",
+      dryRun: false,
+      backlogDir: tmpDir,
+      execFile,
+      readFs: {
+        readTaskFiles,
+        readCompletedCount: () => {
+          throw new Error("completed backlog should not be read");
+        },
+        readActiveSprintSummary,
+      },
+      fetchComments: () => [],
+    });
+
+    assert.equal(result.summary.merged, 1);
+    assert.ok(result.body.includes("| Merged PRs (month) | 1 |"));
   });
 
   it("finalize renders a month-end block and closes the issue", () => {
@@ -1534,6 +1540,29 @@ describe("sync (comment integration)", () => {
 // --- printResult ---
 
 describe("printResult", () => {
+  it("prints the merged metric with month-scoped wording", () => {
+    const log = console.log;
+    const lines = [];
+    console.log = (...args) => { lines.push(args.join(" ")); };
+
+    try {
+      printResult({
+        action: "progress-sync",
+        month: "2026-04",
+        dryRun: false,
+        created: true,
+        updated: false,
+        issueNumber: 99,
+        summary: { merged: 1, inFlight: 0, stuckCandidates: 0, sprint: null },
+        prevIssueNumber: null,
+      });
+    } finally {
+      console.log = log;
+    }
+
+    assert.ok(lines.some((line) => line.includes("merged PRs (month): 1, in-flight: 0, stuck candidates: 0")));
+  });
+
   it("does not throw for created result", () => {
     assert.doesNotThrow(() => {
       // Suppress console output during test

--- a/skills/dev-backlog/scripts/sync-pull.js
+++ b/skills/dev-backlog/scripts/sync-pull.js
@@ -21,7 +21,6 @@ const ISSUE_JSON_FIELDS = "number,title,body,labels,milestone,assignees";
 const COUNT_OPEN_ISSUES_QUERY =
   "query($owner: String!, $name: String!) { repository(owner: $owner, name: $name) { issues(states: OPEN) { totalCount } } }";
 
-
 function statusFromLabels(labels) {
   if (labels.includes("status:in-progress")) return "In Progress";
   if (labels.includes("status:blocked")) return "Blocked";
@@ -142,6 +141,81 @@ function recordOperation(result, type, file) {
   if (type === "skipped") result.skippedFiles.push(file);
 }
 
+function findExistingTaskFile({ tasksDir, prefix, issueNumber }) {
+  const prefixMatch = `${prefix}-${issueNumber} - `;
+  if (!fs.existsSync(tasksDir)) return undefined;
+  return fs.readdirSync(tasksDir).find((file) => file.startsWith(prefixMatch) && file.endsWith(".md"));
+}
+
+function buildTaskFilename({ issue, prefix }) {
+  const slug = slugify(issue.title) || String(issue.number);
+  return `${prefix}-${issue.number} - ${slug}.md`;
+}
+
+function buildTaskFrontmatter({ issue, prefix, today = new Date().toISOString().slice(0, 10) }) {
+  const labelNames = (issue.labels || []).map((label) => label.name);
+  const milestone = issue.milestone?.title || "";
+  const status = statusFromLabels(labelNames);
+  const priority = priorityFromLabels(labelNames);
+  const displayLabels = labelNames.filter(
+    (label) => !label.startsWith("status:") && !label.startsWith("priority:")
+  );
+  const labelsYaml = displayLabels.length
+    ? "\n" + displayLabels.map((label) => `  - ${label}`).join("\n")
+    : " []";
+
+  return `---
+id: ${prefix}-${issue.number}
+title: ${escapeYaml(issue.title)}
+status: ${status}
+labels:${labelsYaml}
+priority: ${priority}
+milestone: ${escapeYaml(milestone)}
+created_date: '${today}'
+---`;
+}
+
+function extractBodyAfterFrontmatter(content) {
+  const bodyMatch = content.match(/^---\n[\s\S]*?\n---\n([\s\S]*)$/);
+  return bodyMatch ? bodyMatch[1] : null;
+}
+
+function syncIssueToTaskFile({ issue, tasksDir, prefix, update, dryRun, result }) {
+  const filename = buildTaskFilename({ issue, prefix });
+  const filepath = path.join(tasksDir, filename);
+  const existing = findExistingTaskFile({ tasksDir, prefix, issueNumber: issue.number });
+  const frontmatter = buildTaskFrontmatter({ issue, prefix });
+  const structuredBody = structureBody(issue.body || "");
+
+  if (existing) {
+    if (!update) {
+      recordOperation(result, "skipped", existing);
+      return existing;
+    }
+
+    if (dryRun) {
+      recordOperation(result, "updated", existing);
+      return existing;
+    }
+
+    const existingPath = path.join(tasksDir, existing);
+    const existingContent = fs.readFileSync(existingPath, "utf-8");
+    const preservedBody = extractBodyAfterFrontmatter(existingContent) || structuredBody;
+    fs.writeFileSync(existingPath, `${frontmatter}\n${preservedBody}`);
+    recordOperation(result, "updated", existing);
+    return existing;
+  }
+
+  if (dryRun) {
+    recordOperation(result, "created", filename);
+    return filename;
+  }
+
+  fs.writeFileSync(filepath, frontmatter + structuredBody);
+  recordOperation(result, "created", filename);
+  return filename;
+}
+
 function printResult(result) {
   const label = result.dryRun ? "[dry-run] " : "";
   console.log(`${label}Found ${result.issueCount} open issues. Syncing to ${result.tasksDir}/`);
@@ -164,76 +238,9 @@ function printResult(result) {
 function run({ issues, tasksDir, prefix, update, dryRun }) {
   if (!dryRun) fs.mkdirSync(tasksDir, { recursive: true });
   const result = makeResult({ tasksDir, prefix, update, dryRun, issueCount: issues.length });
-
-  function findExistingFile(num) {
-    const pfx = `${prefix}-${num} - `;
-    if (!fs.existsSync(tasksDir)) return undefined;
-    const files = fs.readdirSync(tasksDir);
-    return files.find((f) => f.startsWith(pfx) && f.endsWith(".md"));
-  }
-
-  function buildFrontmatter(issue, labelNames) {
-    const milestone = issue.milestone?.title || "";
-    const status = statusFromLabels(labelNames);
-    const priority = priorityFromLabels(labelNames);
-    const displayLabels = labelNames.filter(
-      (l) => !l.startsWith("status:") && !l.startsWith("priority:")
-    );
-    const labelsYaml = displayLabels.length
-      ? "\n" + displayLabels.map((l) => `  - ${l}`).join("\n")
-      : " []";
-    const today = new Date().toISOString().slice(0, 10);
-
-    return `---
-id: ${prefix}-${issue.number}
-title: ${escapeYaml(issue.title)}
-status: ${status}
-labels:${labelsYaml}
-priority: ${priority}
-milestone: ${escapeYaml(milestone)}
-created_date: '${today}'
----`;
-  }
-
-  function writeTaskFile(issue) {
-    const num = issue.number;
-    const slug = slugify(issue.title) || String(num);
-    const filename = `${prefix}-${num} - ${slug}.md`;
-    const filepath = path.join(tasksDir, filename);
-    const labelNames = (issue.labels || []).map((l) => l.name);
-    const body = issue.body || "";
-
-    const existing = findExistingFile(num);
-    if (existing) {
-      if (!update) {
-        recordOperation(result, "skipped", existing);
-        return existing;
-      }
-      if (dryRun) {
-        recordOperation(result, "updated", existing);
-        return existing;
-      }
-      const existingPath = path.join(tasksDir, existing);
-      const content = fs.readFileSync(existingPath, "utf-8");
-      const bodyMatch = content.match(/^---\n[\s\S]*?\n---\n([\s\S]*)$/);
-      const existingBody = bodyMatch ? bodyMatch[1] : structureBody(body);
-      const newContent = buildFrontmatter(issue, labelNames) + "\n" + existingBody;
-      fs.writeFileSync(existingPath, newContent);
-      recordOperation(result, "updated", existing);
-      return existing;
-    }
-
-    if (dryRun) {
-      recordOperation(result, "created", filename);
-      return filename;
-    }
-    const content = buildFrontmatter(issue, labelNames) + structureBody(body);
-    fs.writeFileSync(filepath, content);
-    recordOperation(result, "created", filename);
-    return filename;
-  }
-
-  issues.forEach(writeTaskFile);
+  issues.forEach((issue) => {
+    syncIssueToTaskFile({ issue, tasksDir, prefix, update, dryRun, result });
+  });
   return result;
 }
 


### PR DESCRIPTION
## Summary
- align progress-sync summary semantics with the actual merged-PR metric and remove dead completed-state paths
- split progress-sync into focused GitHub, relay, and rendering modules while keeping the CLI entrypoint and test surface stable
- flatten sync-pull task-file sync flow and reduce README/SKILL duplication by separating quick start from agent contract docs

## Testing
- node --test skills/dev-backlog/scripts/*.test.js

## Notes
- backlog/ remains local execution state and is intentionally not included in this PR

Closes #49
Closes #50
Closes #51