### PR TITLE
docs: refresh root CLAUDE contract guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,12 +2,14 @@
 
 GitHub Issues + local sprint execution files for Claude Code / Codex.
 
+`README.md` is the human quick start. `skills/dev-backlog/SKILL.md` is the agent execution contract.
+
 ## Project Structure
 
 ```
 skills/
   dev-backlog/
-    SKILL.md               ← Core process (~290 lines)
+    SKILL.md               ← Agent execution contract (keep under 250 lines)
     references/            ← Detailed specs (on-demand)
     scripts/               ← Deterministic helpers (node + bash)
 ```
@@ -31,6 +33,6 @@ GitHub (what)  ↔  gh CLI  ↔  backlog/sprints/ (how + context)
 ## Working on This Project
 
 - All content in English (Korean in trigger keywords only)
-- Keep SKILL.md under 250 lines
+- Keep README focused on the human quick start; keep `SKILL.md` under 250 lines as the agent execution contract
 - Test changes by simulating real task management scenarios against GitHub repos
 - Match prompt-builder quality: practical, not ceremonial

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ GitHub Issues + local sprint execution files for Claude Code / Codex.
 
 ## Project Structure
 
-```
+```text
 skills/
   dev-backlog/
     SKILL.md               ← Agent execution contract (keep under 250 lines)


### PR DESCRIPTION
## Summary
- refresh the root CLAUDE.md instructions after the README and SKILL role split
- replace the stale SKILL line-count note with the actual size budget
- keep the root working guidance aligned with the current execution contract

## Testing
- node --test skills/dev-backlog/scripts/*.test.js

## Notes
- backlog/ remains local execution state and is intentionally not included in this PR

Closes #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 문서

* **Documentation**
  * README.md와 SKILL.md의 역할을 명확히 구분했습니다.
    * README.md: 사용자용 빠른 시작 가이드
    * SKILL.md: 에이전트 실행 계약 (250줄 이하 제한)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->