### PR TITLE
enhance(sync-pull): refresh machine-managed issue bodies on --update

### DIFF
--- a/skills/dev-backlog/scripts/sync-pull.js
+++ b/skills/dev-backlog/scripts/sync-pull.js
@@ -16,6 +16,7 @@ const { execFileSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const { slugify, escapeYaml, readConfig, GH_EXEC_DEFAULTS } = require("./lib");
+const { parseMarkerMonth } = require("./progress-sync-render");
 
 const ISSUE_JSON_FIELDS = "number,title,body,labels,milestone,assignees";
 const COUNT_OPEN_ISSUES_QUERY =
@@ -180,6 +181,10 @@ function extractBodyAfterFrontmatter(content) {
   return bodyMatch ? bodyMatch[1] : null;
 }
 
+function isMachineManagedIssueBody(body) {
+  return parseMarkerMonth(body) !== null;
+}
+
 function syncIssueToTaskFile({ issue, tasksDir, prefix, update, dryRun, result }) {
   const filename = buildTaskFilename({ issue, prefix });
   const filepath = path.join(tasksDir, filename);
@@ -200,8 +205,10 @@ function syncIssueToTaskFile({ issue, tasksDir, prefix, update, dryRun, result }
 
     const existingPath = path.join(tasksDir, existing);
     const existingContent = fs.readFileSync(existingPath, "utf-8");
-    const preservedBody = extractBodyAfterFrontmatter(existingContent) || structuredBody;
-    fs.writeFileSync(existingPath, `${frontmatter}\n${preservedBody}`);
+    const nextBody = isMachineManagedIssueBody(issue.body)
+      ? structuredBody
+      : extractBodyAfterFrontmatter(existingContent) || structuredBody;
+    fs.writeFileSync(existingPath, `${frontmatter}\n${nextBody}`);
     recordOperation(result, "updated", existing);
     return existing;
   }
@@ -338,5 +345,6 @@ module.exports = {
   getOpenIssueCount,
   fetchOpenIssues,
   loadOpenIssues,
+  isMachineManagedIssueBody,
   run,
 };

--- a/skills/dev-backlog/scripts/sync-pull.test.js
+++ b/skills/dev-backlog/scripts/sync-pull.test.js
@@ -9,6 +9,7 @@ const {
   structureBody,
   parseArgs,
   loadOpenIssues,
+  isMachineManagedIssueBody,
   run,
 } = require("./sync-pull.js");
 
@@ -120,6 +121,25 @@ describe("parseArgs", () => {
 
     const invalidValue = parseArgs(["--limit", "0"], "BACK");
     assert.equal(invalidValue.error, "Invalid --limit value: 0. Expected a positive integer.");
+  });
+});
+
+describe("isMachineManagedIssueBody", () => {
+  it("returns true for the monthly progress marker", () => {
+    assert.equal(
+      isMachineManagedIssueBody("<!-- dev-backlog:progress-issue month=2026-04 -->\n\n# Progress"),
+      true
+    );
+  });
+
+  it("returns false for normal issue bodies", () => {
+    assert.equal(isMachineManagedIssueBody("Plain body"), false);
+    assert.equal(isMachineManagedIssueBody(""), false);
+    assert.equal(isMachineManagedIssueBody(null), false);
+    assert.equal(
+      isMachineManagedIssueBody("<!-- dev-backlog:progress-comment id=abc -->"),
+      false
+    );
   });
 });
 
@@ -326,6 +346,98 @@ describe("run (integration)", () => {
     // File should be unchanged
     const content = fs.readFileSync(path.join(tasksDir, "TEST-42 - oauth2-flow.md"), "utf-8");
     assert.equal(content, "---\nid: TEST-42\n---\nOld body");
+  });
+
+  it("--update refreshes the body when the GitHub issue body carries the progress marker", () => {
+    // Pre-create a stale local mirror for a machine-managed progress issue.
+    const staleBody = `
+## Description
+<!-- dev-backlog:progress-issue month=2026-04 -->
+
+# Progress: April 2026
+
+## Summary
+
+| Metric | Count |
+| --- | --- |
+| Merged PRs (month) | 9 |
+`;
+    fs.writeFileSync(
+      path.join(tasksDir, "TEST-46 - progress-april-2026.md"),
+      `---\nid: TEST-46\ntitle: 'Progress: April 2026'\nstatus: To Do\nlabels: []\npriority: medium\nmilestone: ''\ncreated_date: '2026-04-01'\n---\n${staleBody}`
+    );
+
+    const freshIssueBody = `<!-- dev-backlog:progress-issue month=2026-04 -->
+
+# Progress: April 2026
+
+## Summary
+
+| Metric | Count |
+| --- | --- |
+| Merged PRs (month) | 14 |
+`;
+
+    run({
+      issues: [makeIssue({
+        number: 46,
+        title: "Progress: April 2026",
+        body: freshIssueBody,
+      })],
+      tasksDir,
+      prefix: "TEST",
+      update: true,
+      dryRun: false,
+    });
+
+    const content = fs.readFileSync(
+      path.join(tasksDir, "TEST-46 - progress-april-2026.md"),
+      "utf-8"
+    );
+    // Frontmatter still refreshed.
+    assert.match(content, /title: 'Progress: April 2026'/);
+    // Body refreshed to the fresh GitHub value.
+    assert.match(content, /Merged PRs \(month\) \| 14/);
+    // Stale count gone.
+    assert.doesNotMatch(content, /Merged PRs \(month\) \| 9/);
+    // Marker preserved so future pulls still recognise the mirror.
+    assert.match(content, /<!-- dev-backlog:progress-issue month=2026-04 -->/);
+  });
+
+  it("--update leaves the body alone when only the local mirror carries the progress marker", () => {
+    // Local file has the marker, but the incoming GitHub body does not — we must not
+    // treat that as machine-managed and must keep respecting the local body.
+    const localBody = `
+## Description
+<!-- dev-backlog:progress-issue month=2026-04 -->
+
+Local notes the user edited by hand.
+`;
+    fs.writeFileSync(
+      path.join(tasksDir, "TEST-46 - progress-april-2026.md"),
+      `---\nid: TEST-46\ntitle: 'Progress: April 2026'\nstatus: To Do\nlabels: []\npriority: medium\nmilestone: ''\ncreated_date: '2026-04-01'\n---\n${localBody}`
+    );
+
+    run({
+      issues: [makeIssue({
+        number: 46,
+        title: "Progress: April 2026",
+        body: "Plain unstructured body without the marker",
+      })],
+      tasksDir,
+      prefix: "TEST",
+      update: true,
+      dryRun: false,
+    });
+
+    const content = fs.readFileSync(
+      path.join(tasksDir, "TEST-46 - progress-april-2026.md"),
+      "utf-8"
+    );
+    // Local body retained verbatim.
+    assert.match(content, /Local notes the user edited by hand\./);
+    // New GitHub body did NOT replace it.
+    assert.doesNotMatch(content, /Plain unstructured body without the marker/);
   });
 
   it("--update refreshes frontmatter but preserves existing body", () => {


### PR DESCRIPTION
## Summary
- `sync-pull.js --update` now refreshes the markdown body when the incoming GitHub issue body carries the `<!-- dev-backlog:progress-issue month=... -->` marker, so the monthly progress mirror (e.g. `BACK-46`) stops drifting behind GitHub.
- Normal task mirrors still preserve their existing body and local AC checkbox state — the discriminator is narrow and keys off the already-owned marker in `progress-sync-render.js`.
- CLI flags, JSON output shape, and `run()` return contract are unchanged.

Closes #57.

## Test plan
- [x] `node --test skills/dev-backlog/scripts/*.test.js` (181/181 passing, including new contract tests)
- [x] Machine-managed body: GitHub issue with progress marker triggers body refresh
- [x] Normal task: `--update` still preserves existing body (existing test kept green)
- [x] Guardrail: local mirror that has the marker but incoming body does NOT still preserves the local body

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * GitHub 이슈 동기화 시 머신 관리 콘텐츠를 자동으로 식별하여 조건부로 업데이트하는 기능 추가
  * 기존 작업 파일의 업데이트 처리 개선으로 불필요한 콘텐츠 덮어쓰기 방지

* **테스트**
  * 머신 관리 이슈 감지 및 --update 동작의 다양한 시나리오에 대한 테스트 커버리지 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->