### PR TITLE
feat(backlog-triage): scaffold skill with two-phase execution contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,21 @@ The `[~]` state makes in-flight work visible to everyone, and `Running Context` 
 
 The contract for that integration lives in [references/integration-contract.md](skills/dev-backlog/references/integration-contract.md).
 
+## Backlog Triage (sibling skill)
+
+`dev-backlog` runs the sprint. [`backlog-triage`](skills/backlog-triage/SKILL.md) grooms the open-issue pile that feeds into it — classification, relationships, stale / obsolete flags, priority proposals. It produces one markdown report under `backlog/triage/YYYY-MM-DD-report.md` that you review, check accepted proposals on, and apply behind an explicit `--apply`.
+
+```bash
+# Review phase (read-only, default)
+node /path/to/dev-backlog/skills/backlog-triage/scripts/triage-collect.js
+node /path/to/dev-backlog/skills/backlog-triage/scripts/triage-report.js --snapshot backlog/triage/.cache/<ts>.json
+
+# Apply phase (opt-in)
+node /path/to/dev-backlog/skills/backlog-triage/scripts/triage-apply.js backlog/triage/<date>-report.md --apply
+```
+
+Use `dev-backlog` when you know what to work on; use `backlog-triage` when the open-issue list has grown faster than your attention.
+
 ## Script Entry Points
 
 All deterministic helpers live under `skills/dev-backlog/scripts/`.
@@ -253,6 +268,7 @@ This keeps Codex focused on one execution file, not ten browser tabs and stale i
 - [GitHub sync patterns](skills/dev-backlog/references/github-sync.md)
 - [Workflow patterns](skills/dev-backlog/references/workflow-patterns.md)
 - [dev-relay integration contract](skills/dev-backlog/references/integration-contract.md)
+- [Backlog triage (sibling skill)](skills/backlog-triage/SKILL.md)
 
 ## Contributing
 

--- a/skills/backlog-triage/SKILL.md
+++ b/skills/backlog-triage/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: backlog-triage
+argument-hint: "[collect|relate|stale|report|apply] [options]"
+description: Interactive backlog grooming for open GitHub Issues. Classifies, relates, flags stale/obsolete, and proposes priorities — produces a markdown triage report you review before applying. Advisory by default; mutations require explicit --apply. Use for backlog review, issue grooming, stale cleanup, priority re-ranking, 백로그 정리, 이슈 검토, 트리아지, 정리.
+compatibility: Requires gh CLI and git. Works on Claude Code and Codex.
+metadata:
+  related-skills: "dev-backlog, relay, relay-plan"
+---
+
+# Backlog Triage
+
+Open-issue grooming as a two-phase loop:
+
+```
+Phase 1 — Report (advisory)          Phase 2 — Apply (explicit)
+  collect → relate → stale              review report → --apply
+      ↓                                       ↓
+  single markdown report                gh mutations via anchors
+```
+
+Sibling skill to dev-backlog, not a replacement. dev-backlog is the execution hub (sprints, progress, milestones). backlog-triage is advisory: it inspects the open issue set and proposes changes. You decide; it applies only what you've approved.
+
+---
+
+## Two-Phase Model
+
+### Phase 1 — Report (default, no mutations)
+
+1. **Collect** open issues → snapshot JSON (one `gh` fetch per run)
+2. **Analyze** — classification, relationships, stale/obsolete signals
+3. **Render** — one markdown report with anchored proposals
+
+Every script in this phase is read-only. Running any number of times is safe. The snapshot is the canonical artifact; all downstream analysis consumes it via `--snapshot PATH` (no re-fetch).
+
+### Phase 2 — Apply (opt-in, explicit)
+
+Humans review the report and mark accepted proposals (flip `[ ]` → `[x]`). Then:
+
+```bash
+node scripts/triage-apply.js backlog/triage/YYYY-MM-DD-report.md               # dry-run
+node scripts/triage-apply.js backlog/triage/YYYY-MM-DD-report.md --apply       # with confirmation
+node scripts/triage-apply.js backlog/triage/YYYY-MM-DD-report.md --apply --yes # CI-safe
+```
+
+Default is **dry-run**. `--apply` requires confirmation unless `--yes`. Idempotent: re-running after a partial apply emits `already-applied` log entries for actions already executed.
+
+---
+
+## Directory Layout
+
+```
+backlog/
+├── triage/
+│   ├── .cache/                       # Snapshots (downstream scripts read from here)
+│   │   └── 2026-04-18T01-30-00Z.json
+│   ├── 2026-04-18-report.md          # Triage report (human entry point)
+│   └── 2026-04-18-apply.log          # JSONL audit trail of apply run
+└── triage-config.yml                 # Thresholds, theme keywords, weights
+```
+
+The triage report is a **derived artifact**. GitHub Issues remain the source of truth. Regenerating from the snapshot must reproduce the same proposals.
+
+---
+
+## Anchor-Comment Apply Contract
+
+Every actionable proposal in the report carries a stable anchor comment paired with a visible checkbox:
+
+```markdown
+<!-- triage:close #42 reason="merged PR #87 already exists" -->
+- [ ] close #42 — merged PR #87 already exists
+```
+
+- The **anchor comment** is the machine contract.
+- The **checkbox** is the human confirmation surface.
+- An action is accepted when **both** the anchor exists AND its paired checkbox is `[x]`.
+
+This mirrors dev-backlog's `<!-- AC:BEGIN --><!-- AC:END -->` convention and survives markdown reformatting, so a human editing the report cannot silently break the parse.
+
+See `references/apply.md` for the full anchor grammar, parse rules, and audit-log schema.
+
+---
+
+## Report Shape
+
+```markdown
+---
+generated: 2026-04-18
+repo: owner/name
+snapshot: backlog/triage/.cache/2026-04-18T01-30-00Z.json
+open_issues: 12
+---
+
+# Backlog Triage — 2026-04-18
+
+## Classification
+By theme / label / age — grouped tables.
+
+## Relationships
+Edges list (mentions, blocks, depends-on, duplicate candidates).
+
+## Obsolete Candidates
+anchor + checkbox + evidence per item.
+
+## Priority Proposals
+anchor + checkbox + rationale per item.
+
+## Milestone Suggestions
+Unplanned issues grouped into candidate next sprints.
+
+## Apply Checklist
+Summary of every anchored action. This is the surface the apply step reads.
+```
+
+---
+
+## Relationship to dev-backlog
+
+| Concern | Owner |
+|---------|-------|
+| Sprint files, execution plan, Running Context | dev-backlog |
+| Milestone lifecycle, monthly progress issue | dev-backlog |
+| AC checkboxes inside issue bodies (`AC:BEGIN`/`END`) | dev-backlog |
+| Open-issue classification, relationships, stale flags | backlog-triage |
+| Priority / milestone **proposals** | backlog-triage (report) |
+| Priority / milestone **mutations** | backlog-triage (`--apply`) |
+| Post-triage sprint planning | dev-backlog (reads report, edits sprint file) |
+
+Recommended cadence: run backlog-triage weekly or bi-weekly. Feed the report's Milestone Suggestions into the next dev-backlog sprint.
+
+---
+
+## Process
+
+**Collect → Analyze → Report.** One `gh` fetch, one snapshot, downstream scripts consume it via `--snapshot`. Re-fetching in each script is a bug — it creates drift across signals.
+
+**Review the report.** Read each proposal. Check the ones you accept (flip `[ ]` → `[x]`). Leave rejected ones unchecked. Do not delete anchor comments; unchecked anchors are ignored by apply.
+
+**Apply (opt-in).** Run dry-run first, confirm the pseudo-`gh` commands match intent, then `--apply`. The apply log is append-only JSONL; keep it alongside the report in git for audit.
+
+**Re-run safely.** A second `--apply` on the same report is idempotent — already-applied actions log `already-applied` and no duplicate mutation hits GitHub.
+
+---
+
+## Config
+
+`backlog/triage-config.yml` (YAML, config-as-data — docs live in `references/classification.md`):
+
+```yaml
+theme_keywords:
+  auth: [auth, oauth, token, session]
+  docs: [docs, readme, guide]
+activity_days:
+  warm: 14
+  cold: 60
+stale_days: 60
+duplicate_threshold: 0.75
+```
+
+Flags on individual scripts override config.
+
+---
+
+## References (load on demand)
+
+- `references/classification.md` — bucketing rules (label, theme, age, activity) + YAML schema
+- `references/relationships.md` — mention / blocks / depends-on / duplicate heuristics, evidence format
+- `references/stale.md` — obsolescence signals, thresholds, suggested-action grammar
+- `references/apply.md` — anchor grammar, parse rules, idempotency contract, apply-log schema
+
+---
+
+## Scripts (deterministic, no LLM needed)
+
+All scripts live in `${CLAUDE_SKILL_DIR}/scripts/` and run from the target project root. Every script emits `--json` for composition.
+
+- `scripts/triage-collect.js [--repo OWNER/REPO] [--limit N] [--json] [--dry-run]` — fetch open issues, write snapshot to `backlog/triage/.cache/<ISO-timestamp>.json`. Read-only.
+- `scripts/triage-relate.js --snapshot PATH [--json]` — detect mentions / blocks / depends-on / duplicates. Errors if snapshot missing or malformed.
+- `scripts/triage-stale.js --snapshot PATH [--since N] [--json]` — flag stale / obsolete candidates with evidence.
+- `scripts/triage-report.js --snapshot PATH [--relate PATH] [--stale PATH] [--out PATH] [--json]` — render the markdown report with anchor comments. Re-runnable; creates `.bak` on overwrite.
+- `scripts/triage-apply.js <report.md> [--apply] [--yes] [--json]` — parse anchor+checkbox pairs, execute accepted actions via `gh`. Default dry-run. Idempotent. Appends to `backlog/triage/<date>-apply.log` (JSONL).
+
+Scripts land in #61–#65; this file is the contract they must honor.

--- a/skills/backlog-triage/SKILL.md
+++ b/skills/backlog-triage/SKILL.md
@@ -37,9 +37,10 @@ Every script in this phase is read-only. Running any number of times is safe. Th
 Humans review the report and mark accepted proposals (flip `[ ]` → `[x]`). Then:
 
 ```bash
-node scripts/triage-apply.js backlog/triage/YYYY-MM-DD-report.md               # dry-run
-node scripts/triage-apply.js backlog/triage/YYYY-MM-DD-report.md --apply       # with confirmation
-node scripts/triage-apply.js backlog/triage/YYYY-MM-DD-report.md --apply --yes # CI-safe
+# Run from the target project root; scripts live under ${CLAUDE_SKILL_DIR}/scripts/.
+node "${CLAUDE_SKILL_DIR}/scripts/triage-apply.js" backlog/triage/YYYY-MM-DD-report.md               # dry-run
+node "${CLAUDE_SKILL_DIR}/scripts/triage-apply.js" backlog/triage/YYYY-MM-DD-report.md --apply       # with confirmation
+node "${CLAUDE_SKILL_DIR}/scripts/triage-apply.js" backlog/triage/YYYY-MM-DD-report.md --apply --yes # CI-safe
 ```
 
 Default is **dry-run**. `--apply` requires confirmation unless `--yes`. Idempotent: re-running after a partial apply emits `already-applied` log entries for actions already executed.

--- a/skills/backlog-triage/references/apply.md
+++ b/skills/backlog-triage/references/apply.md
@@ -1,0 +1,5 @@
+# Apply Semantics
+
+**Purpose.** Authoritative reference for the anchor-comment apply contract: anchor grammar, parse rules, the anchor+checkbox acceptance pair, idempotency guarantees, and the JSONL audit-log schema at `backlog/triage/<date>-apply.log`.
+
+> Scaffold stub. Full grammar, parser spec, idempotency contract, and log schema land with #64 (report renderer emits anchors) and #65 (apply step parses them). Until then, SKILL.md's "Anchor-Comment Apply Contract" section is the short form; this file will expand into the authoritative reference once renderer + apply exist.

--- a/skills/backlog-triage/references/classification.md
+++ b/skills/backlog-triage/references/classification.md
@@ -1,0 +1,5 @@
+# Classification
+
+**Purpose.** Document the bucketing rules `triage-collect.js` applies when it snapshots open issues — and the YAML schema (`backlog/triage-config.yml`) that parameterizes them.
+
+> Scaffold stub. Full rules + YAML schema land with #61 (collect + classify). Current SKILL.md captures the dimensions (label / theme / age / activity / milestone) and the minimal config shape; this file will expand into the authoritative reference once the script exists.

--- a/skills/backlog-triage/references/relationships.md
+++ b/skills/backlog-triage/references/relationships.md
@@ -1,0 +1,5 @@
+# Relationships
+
+**Purpose.** Document the relationship heuristics `triage-relate.js` applies to the snapshot — mentions, blocks / depends-on, duplicate candidates, merged-PR linkage — and the evidence format carried on every edge.
+
+> Scaffold stub. Full heuristics, confidence scoring, and edge schema land with #62 (relationship detection). Until then, SKILL.md summarises the signal list; this file will expand into the authoritative reference once the script exists.

--- a/skills/backlog-triage/references/stale.md
+++ b/skills/backlog-triage/references/stale.md
@@ -1,0 +1,5 @@
+# Stale / Obsolescence
+
+**Purpose.** Document the signals `triage-stale.js` uses to flag stale or obsolete open issues — inactive+old, PR already merged, referenced code removed, duplicate of closed, explicit `wontfix`/`invalid` — and the grammar of `suggested_action` (`close` / `revisit` / `merge-into:#N`).
+
+> Scaffold stub. Full signal list, thresholds, and suggested-action grammar land with #63 (stale signals). Until then, SKILL.md summarises the signal surface; this file will expand into the authoritative reference once the script exists.

--- a/skills/backlog-triage/scripts/.gitkeep
+++ b/skills/backlog-triage/scripts/.gitkeep
@@ -1,0 +1,8 @@
+Scripts land here — tracked under:
+  triage-collect.js  → #61
+  triage-relate.js   → #62
+  triage-stale.js    → #63
+  triage-report.js   → #64
+  triage-apply.js    → #65
+
+See ../SKILL.md for the full contract each script must honor.


### PR DESCRIPTION
## Summary

- Adds sibling skill `backlog-triage` under `skills/` — sits next to `dev-backlog`, does not replace it.
- `SKILL.md` is the execution contract: **183 lines**, two-phase model (**Report** → **Apply** with `--apply`), anchor-comment apply contract, ownership table vs `dev-backlog`.
- Scaffolds `references/{classification,relationships,stale,apply}.md` as purpose-tagged stubs — full contents follow in #61 / #62 / #63 / #65.
- `scripts/.gitkeep` maps each future script to its child issue.
- README gets a new "Backlog Triage (sibling skill)" section + a Docs link.

Closes #60. Part of epic #59.

## Self-check against #60 AC

- [x] Directory scaffold exists (`SKILL.md`, `references/`, `scripts/`)
- [x] SKILL.md under 250 lines (183). Passes self-check: Phase 1 collect→analyze→render, Phase 2 `--apply` (dry-run default, idempotent)
- [x] `metadata.related-skills: "dev-backlog, relay, relay-plan"`
- [x] README mentions `backlog-triage` alongside `dev-backlog`
- [x] No scripts yet — scaffold only

## Test plan

- [ ] Read `skills/backlog-triage/SKILL.md` top-to-bottom; confirm two-phase flow is self-contained
- [ ] Confirm all four `references/*.md` links resolve (no dangling pointers)
- [ ] Confirm README's new section renders on GitHub and the Docs link is live
- [ ] Line-count: `wc -l skills/backlog-triage/SKILL.md` returns `< 250`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * GitHub 이슈 백로그 정리를 위한 새로운 스킬 문서 추가
  * 두 단계 워크플로우 설명: 읽기 전용 검토 단계와 선택적 적용 단계
  * 백로그 분류, 관계 분석, 오래된 이슈 감지 등 참고 자료 제공
  * README에 새 스킬 링크 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->