### PR TITLE
enhance(backlog-triage): add body field to snapshot (#69)

### DIFF
--- a/skills/backlog-triage/references/classification.md
+++ b/skills/backlog-triage/references/classification.md
@@ -20,6 +20,25 @@ duplicate_threshold: 0.75
 - `activity_days.cold` is the exclusive upper bound for the `warm` bucket.
 - `stale_days` and `duplicate_threshold` are collected as config-as-data for downstream scripts (`triage-stale`, `triage-relate`); `triage-collect` does not apply them yet.
 
+## Per-issue snapshot shape
+
+Each entry in `snapshot.issues` has:
+
+```json
+{
+  "number": 61,
+  "title": "...",
+  "body": "...",
+  "labels": ["..."],
+  "createdAt": "...",
+  "updatedAt": "...",
+  "milestone": "Backlog Triage MVP" | null,
+  "buckets": { "label": {...}, "theme": "...", "age": "...", "activity": "...", "milestone": "assigned" | "unassigned" }
+}
+```
+
+`body` is always a string — empty (`""`) when `gh` returns null or the field is missing, never `undefined`. Downstream scripts (`triage-relate` for mention / blocks / depends-on scans, `triage-stale` for referenced-code-removed signal) rely on body being present so they never need to re-fetch from `gh`.
+
 ## Bucketing rules
 
 ### Label bucket

--- a/skills/backlog-triage/scripts/triage-collect.js
+++ b/skills/backlog-triage/scripts/triage-collect.js
@@ -186,6 +186,7 @@ function classifyIssue(issue, { generated, config }) {
   return {
     number: issue.number,
     title: issue.title,
+    body: typeof issue.body === "string" ? issue.body : "",
     labels,
     createdAt: issue.createdAt,
     updatedAt: issue.updatedAt,

--- a/skills/backlog-triage/scripts/triage-collect.test.js
+++ b/skills/backlog-triage/scripts/triage-collect.test.js
@@ -179,6 +179,28 @@ describe("classifyIssue", () => {
       status: "in-progress",
     });
   });
+
+  it("passes through a populated body for downstream consumers (#62/#63 body-scan signals)", () => {
+    const body = "Blocks #42\n\nSee https://example.com for context.";
+    const issue = classifyIssue(makeIssue({ body }), {
+      generated: GENERATED,
+      config: CONFIG,
+    });
+    assert.equal(issue.body, body);
+  });
+
+  it("emits empty-string body when gh returns undefined or null (never undefined in snapshot)", () => {
+    const withoutBody = classifyIssue(makeIssue({ body: undefined }), {
+      generated: GENERATED,
+      config: CONFIG,
+    });
+    const nullBody = classifyIssue(makeIssue({ body: null }), {
+      generated: GENERATED,
+      config: CONFIG,
+    });
+    assert.equal(withoutBody.body, "");
+    assert.equal(nullBody.body, "");
+  });
 });
 
 describe("collectSnapshot", () => {


### PR DESCRIPTION
## Summary

Unblocks #62 and #63 by including issue `body` in the snapshot per-issue output. Previously, gh was already fetching `body` (it's in `OPEN_ISSUE_JSON_FIELDS`) but `classifyIssue` dropped it — meaning #62/#63 would have had to re-fetch to scan bodies, violating their "no re-fetch" AC.

- One-line pass-through in `classifyIssue` with explicit empty-string fallback (`body` is always a string in the snapshot, never undefined)
- Two unit tests: populated body preserved; null/undefined body → `""`
- Schema doc updated with the full per-issue shape and rationale

Closes #69. Still a single `gh` fetch on default path (no change to fetch behavior).

## Test plan

- [x] `node --test skills/backlog-triage/scripts/triage-collect.test.js` — 21/21 pass (2 new)
- [x] `node --test skills/dev-backlog/scripts/sync-pull.test.js` — still green
- [x] Live: `node skills/backlog-triage/scripts/triage-collect.js --limit 2 --dry-run --json` shows `body` populated on every issue
- [ ] Reviewer confirms `body` is a string for every issue in a live snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 이슈 JSON 스냅샷 스키마에 대한 상세 문서 추가 (필수 필드 및 중첩 구조 명시)

* **Bug Fixes**
  * 이슈 본문 필드 처리 개선으로 데이터 일관성 강화 (누락 또는 null 값에 대한 안정적인 처리)

* **Tests**
  * 이슈 본문 필드 검증 테스트 케이스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->