### PR TITLE
feat(backlog-triage): relationship detection (mentions, blocks, duplicates) (#62)

### DIFF
--- a/skills/backlog-triage/references/relationships.md
+++ b/skills/backlog-triage/references/relationships.md
@@ -1,5 +1,129 @@
 # Relationships
 
-**Purpose.** Document the relationship heuristics `triage-relate.js` applies to the snapshot — mentions, blocks / depends-on, duplicate candidates, merged-PR linkage — and the evidence format carried on every edge.
+**Purpose.** `triage-relate.js` reads a previously collected issue snapshot and emits read-only relationship edges for four snapshot-resident signals:
 
-> Scaffold stub. Full heuristics, confidence scoring, and edge schema land with #62 (relationship detection). Until then, SKILL.md summarises the signal list; this file will expand into the authoritative reference once the script exists.
+- `mentions` from plain `#123` references in issue bodies
+- `blocks` from explicit blocking / closing phrases in issue bodies
+- `depends-on` from explicit dependency phrases in issue bodies
+- `duplicate-candidate` from title-token Jaccard overlap
+
+Every emitted edge carries evidence taken directly from the snapshot so downstream report rendering can show why the relationship was inferred without re-fetching from GitHub.
+
+## Implemented Heuristics
+
+### `mentions`
+
+- Source: `issue.body`
+- Match rule: plain `#123` references outside fenced code blocks
+- Filters:
+  - ignore self-references (`#100` inside issue `100`)
+  - ignore references inside URL tokens such as GitHub links or `/path#fragment`
+- Confidence: `0.75`
+- Evidence:
+  - `match`: matched issue reference, for example `#123`
+  - `snippet`: normalized sentence/line fragment containing the match
+
+### `blocks`
+
+- Source: `issue.body`
+- Keywords used by `scanBlocks`:
+  - `blocks #123`
+  - `closes #123`
+- Confidence: `1`
+- Evidence:
+  - `phrase`: normalized matched phrase, for example `Blocks #123`
+  - `snippet`: normalized sentence/line fragment containing the phrase
+
+### `depends-on`
+
+- Source: `issue.body`
+- Keywords used by `scanDependsOn`:
+  - `blocked by #123`
+  - `depends on #123`
+  - `depends-on #123`
+- Confidence: `1`
+- Evidence:
+  - `phrase`: normalized matched phrase, for example `depends on #123`
+  - `snippet`: normalized sentence/line fragment containing the phrase
+
+### `duplicate-candidate`
+
+- Source: `issue.title`
+- Threshold: `backlog/triage-config.yml -> duplicate_threshold`
+- Confidence: Jaccard similarity score
+- Canonicalization:
+  - compare each issue pair once
+  - emit a single edge with the smaller issue number as `from`
+- Evidence:
+  - `score`: rounded Jaccard score (`4` decimal places)
+  - `overlap`: sorted shared title tokens
+  - `titles.from`: lower-numbered issue title
+  - `titles.to`: higher-numbered issue title
+
+## Jaccard Tokenization Rules
+
+Title similarity uses the following normalization before scoring:
+
+- lowercase the title
+- extract tokens with regex `[a-z0-9]+`
+- drop one-character tokens
+- deduplicate tokens per title by converting to a set
+- compute `overlap / union`
+
+If the union is empty, the score is `0` and no edge is emitted.
+
+## Evidence Schema
+
+All edges share the outer shape:
+
+```json
+{
+  "from": 100,
+  "to": 101,
+  "kind": "mentions|blocks|depends-on|duplicate-candidate",
+  "confidence": 0.75,
+  "evidence": {}
+}
+```
+
+Evidence payloads vary by kind:
+
+- `mentions`
+
+```json
+{
+  "match": "#101",
+  "snippet": "See also #101 before filing a follow-up."
+}
+```
+
+- `blocks` / `depends-on`
+
+```json
+{
+  "phrase": "depends on #101",
+  "snippet": "This depends on #101 before rollout."
+}
+```
+
+- `duplicate-candidate`
+
+```json
+{
+  "score": 0.8,
+  "overlap": ["flow", "oauth", "refresh", "token"],
+  "titles": {
+    "from": "OAuth token refresh flow",
+    "to": "OAuth token refresh flow redesign"
+  }
+}
+```
+
+## Deferred to #73
+
+These signals are intentionally out of scope for `#62` because the current snapshot schema does not include the required fields:
+
+- `comments`-based mention scan
+  - Reason: the snapshot currently carries `issue.body` only, so comment text is unavailable without extending the snapshot in `#73`.
+- `merged-pr-link` edge kind
+  - Reason: PR linkage depends on `closing_prs` metadata that is also deferred to the `#73` snapshot extension.

--- a/skills/backlog-triage/scripts/triage-relate.js
+++ b/skills/backlog-triage/scripts/triage-relate.js
@@ -1,0 +1,430 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+const { readTriageConfig } = require("../../dev-backlog/scripts/lib");
+
+const DEFAULT_CONFIG_PATH = path.join("backlog", "triage-config.yml");
+
+function parseArgs(args) {
+  const options = {
+    snapshotPath: undefined,
+    json: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+
+    if (arg === "--snapshot") {
+      const nextValue = args[index + 1];
+      if (!nextValue) {
+        return { ...options, error: "Missing value for --snapshot. Expected a snapshot JSON path." };
+      }
+      options.snapshotPath = nextValue;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--snapshot=")) {
+      options.snapshotPath = arg.slice("--snapshot=".length);
+      continue;
+    }
+
+    return { ...options, error: `Unknown argument: ${arg}` };
+  }
+
+  if (!options.snapshotPath) {
+    return {
+      ...options,
+      error: "Missing required --snapshot PATH. Usage: triage-relate.js --snapshot PATH [--json]",
+    };
+  }
+
+  return options;
+}
+
+function maskFencedCodeBlocks(text) {
+  const source = typeof text === "string" ? text : "";
+  const parts = source.split(/(\r?\n)/);
+  let inFence = false;
+  let fenceChar = "";
+  let output = "";
+
+  for (const part of parts) {
+    if (part === "\n" || part === "\r\n") {
+      output += part;
+      continue;
+    }
+
+    const fenceMatch = part.match(/^\s*(`{3,}|~{3,})/);
+    if (fenceMatch) {
+      const nextFenceChar = fenceMatch[1][0];
+      if (!inFence) {
+        inFence = true;
+        fenceChar = nextFenceChar;
+      } else if (nextFenceChar === fenceChar) {
+        inFence = false;
+        fenceChar = "";
+      }
+      output += part.replace(/[^\r\n]/g, " ");
+      continue;
+    }
+
+    output += inFence ? part.replace(/[^\r\n]/g, " ") : part;
+  }
+
+  return output;
+}
+
+function getTokenBounds(text, index) {
+  let start = index;
+  let end = index;
+
+  while (start > 0 && !/\s/.test(text[start - 1])) start -= 1;
+  while (end < text.length && !/\s/.test(text[end])) end += 1;
+
+  return { start, end };
+}
+
+function isIssueRefInUrlToken(text, hashIndex) {
+  const { start, end } = getTokenBounds(text, hashIndex);
+  const token = text.slice(start, end);
+  const relativeIndex = hashIndex - start;
+  const beforeHash = token.slice(0, relativeIndex);
+
+  return (
+    /(?:https?:\/\/|www\.|[A-Za-z0-9.-]+\.[A-Za-z]{2,})/i.test(beforeHash) ||
+    beforeHash.includes("/")
+  );
+}
+
+function normalizeSnippet(snippet) {
+  return snippet.replace(/\s+/g, " ").trim();
+}
+
+function extractSnippet(text, start, end) {
+  const lineStart = text.lastIndexOf("\n", start - 1) + 1;
+  const nextNewline = text.indexOf("\n", end);
+  const lineEnd = nextNewline === -1 ? text.length : nextNewline;
+  const line = text.slice(lineStart, lineEnd);
+  const startInLine = Math.max(0, start - lineStart);
+  const endInLine = Math.min(line.length, end - lineStart);
+
+  const sentenceStartOffset = Math.max(
+    line.lastIndexOf(". ", startInLine - 1),
+    line.lastIndexOf("! ", startInLine - 1),
+    line.lastIndexOf("? ", startInLine - 1)
+  );
+  const sentenceStart = sentenceStartOffset === -1 ? 0 : sentenceStartOffset + 2;
+
+  const sentenceEndCandidates = [line.indexOf(". ", endInLine), line.indexOf("! ", endInLine), line.indexOf("? ", endInLine)]
+    .filter((value) => value !== -1)
+    .sort((left, right) => left - right);
+  const sentenceEnd = sentenceEndCandidates.length === 0 ? line.length : sentenceEndCandidates[0] + 1;
+
+  return normalizeSnippet(line.slice(sentenceStart, sentenceEnd));
+}
+
+function extractIssueRefs(text) {
+  const source = typeof text === "string" ? text : "";
+  const masked = maskFencedCodeBlocks(source);
+  const refs = [];
+  const pattern = /(^|[^A-Za-z0-9_])#(\d+)\b/g;
+
+  let match;
+  while ((match = pattern.exec(masked)) !== null) {
+    const hashIndex = match.index + match[1].length;
+    if (isIssueRefInUrlToken(masked, hashIndex)) continue;
+
+    refs.push({
+      number: Number(match[2]),
+      match: `#${match[2]}`,
+      index: hashIndex,
+      end: hashIndex + match[2].length + 1,
+      snippet: extractSnippet(source, hashIndex, hashIndex + match[2].length + 1),
+    });
+  }
+
+  return refs;
+}
+
+function makeEdge({ from, to, kind, confidence, evidence }) {
+  return { from, to, kind, confidence, evidence };
+}
+
+function dedupeEdges(edges) {
+  const seen = new Set();
+  return edges.filter((edge) => {
+    const key = `${edge.from}:${edge.to}:${edge.kind}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function scanMentions(snapshot) {
+  const edges = [];
+
+  for (const issue of snapshot.issues) {
+    for (const ref of extractIssueRefs(issue.body)) {
+      if (issue.number === ref.number) continue;
+      edges.push(
+        makeEdge({
+          from: issue.number,
+          to: ref.number,
+          kind: "mentions",
+          confidence: 0.75,
+          evidence: {
+            match: ref.match,
+            snippet: ref.snippet,
+          },
+        })
+      );
+    }
+  }
+
+  return dedupeEdges(edges);
+}
+
+function scanPhraseEdges(snapshot, patterns, kind, confidence) {
+  const edges = [];
+
+  for (const issue of snapshot.issues) {
+    const source = typeof issue.body === "string" ? issue.body : "";
+    const masked = maskFencedCodeBlocks(source);
+
+    for (const pattern of patterns) {
+      let match;
+      while ((match = pattern.exec(masked)) !== null) {
+        const phraseIndex = match.index;
+        const hashIndex = masked.indexOf("#", phraseIndex);
+        if (hashIndex === -1 || isIssueRefInUrlToken(masked, hashIndex)) continue;
+
+        const target = Number(match[1]);
+        if (issue.number === target) continue;
+
+        edges.push(
+          makeEdge({
+            from: issue.number,
+            to: target,
+            kind,
+            confidence,
+            evidence: {
+              phrase: normalizeSnippet(match[0]),
+              snippet: extractSnippet(source, phraseIndex, phraseIndex + match[0].length),
+            },
+          })
+        );
+      }
+      pattern.lastIndex = 0;
+    }
+  }
+
+  return dedupeEdges(edges);
+}
+
+function scanBlocks(snapshot) {
+  return scanPhraseEdges(snapshot, [/\bblocks\s+#(\d+)\b/gi, /\bcloses\s+#(\d+)\b/gi], "blocks", 1);
+}
+
+function scanDependsOn(snapshot) {
+  return scanPhraseEdges(
+    snapshot,
+    [/\bblocked by\s+#(\d+)\b/gi, /\bdepends(?:\s+on|-on)\s+#(\d+)\b/gi],
+    "depends-on",
+    1
+  );
+}
+
+function tokenizeTitle(title) {
+  return new Set(
+    String(title || "")
+      .toLowerCase()
+      .match(/[a-z0-9]+/g)?.filter((token) => token.length > 1) || []
+  );
+}
+
+function jaccardSimilarity(left, right) {
+  const leftTokens = [...left];
+  const rightTokens = [...right];
+  const union = new Set([...leftTokens, ...rightTokens]);
+  if (union.size === 0) return 0;
+
+  const overlap = leftTokens.filter((token) => right.has(token));
+  return {
+    score: overlap.length / union.size,
+    overlap,
+  };
+}
+
+function findDuplicateCandidates(snapshot, config = readTriageConfig("backlog")) {
+  const threshold = Number(config.duplicate_threshold) || 0;
+  const edges = [];
+
+  for (let index = 0; index < snapshot.issues.length; index += 1) {
+    for (let otherIndex = index + 1; otherIndex < snapshot.issues.length; otherIndex += 1) {
+      const left = snapshot.issues[index];
+      const right = snapshot.issues[otherIndex];
+      const similarity = jaccardSimilarity(tokenizeTitle(left.title), tokenizeTitle(right.title));
+
+      if (similarity.score < threshold || similarity.overlap.length === 0) continue;
+
+      const from = Math.min(left.number, right.number);
+      const to = Math.max(left.number, right.number);
+      const fromIssue = from === left.number ? left : right;
+      const toIssue = to === right.number ? right : left;
+
+      edges.push(
+        makeEdge({
+          from,
+          to,
+          kind: "duplicate-candidate",
+          confidence: similarity.score,
+          evidence: {
+            score: Number(similarity.score.toFixed(4)),
+            overlap: similarity.overlap.sort(),
+            titles: {
+              from: fromIssue.title,
+              to: toIssue.title,
+            },
+          },
+        })
+      );
+    }
+  }
+
+  return dedupeEdges(edges);
+}
+
+function findMergedPullRequestLinks() {
+  // TODO(#62): wire PR linkage once closing-PR metadata exists in the snapshot.
+  return [];
+}
+
+function compareEdges(left, right) {
+  return left.from - right.from || left.to - right.to || left.kind.localeCompare(right.kind);
+}
+
+function sortEdges(edges) {
+  return [...edges].sort(compareEdges);
+}
+
+function validateSnapshot(snapshot) {
+  if (!snapshot || typeof snapshot !== "object" || Array.isArray(snapshot)) {
+    throw new Error("Invalid snapshot JSON: expected a top-level object.");
+  }
+
+  if (!Array.isArray(snapshot.issues)) {
+    throw new Error("Invalid snapshot JSON: expected an issues array.");
+  }
+
+  for (const issue of snapshot.issues) {
+    if (!Number.isInteger(issue?.number)) {
+      throw new Error("Invalid snapshot JSON: each issue must include an integer number.");
+    }
+    if (typeof issue?.title !== "string") {
+      throw new Error(`Invalid snapshot JSON: issue #${issue.number} is missing a string title.`);
+    }
+    if (typeof issue?.body !== "string") {
+      throw new Error(`Invalid snapshot JSON: issue #${issue.number} is missing a string body.`);
+    }
+  }
+
+  return snapshot;
+}
+
+function readSnapshotFile(snapshotPath) {
+  if (!fs.existsSync(snapshotPath)) {
+    throw new Error(`Snapshot file is missing or unreadable: ${snapshotPath}`);
+  }
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(snapshotPath, "utf-8"));
+    return validateSnapshot(parsed);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error(`Malformed snapshot JSON at ${snapshotPath}: ${error.message}`);
+    }
+    throw error;
+  }
+}
+
+function resolveBacklogDir(snapshot) {
+  const configPath =
+    typeof snapshot.config_path === "string" && snapshot.config_path.trim()
+      ? snapshot.config_path
+      : DEFAULT_CONFIG_PATH;
+  const backlogDir = path.dirname(configPath);
+  return backlogDir === "." ? "backlog" : backlogDir;
+}
+
+function analyzeSnapshot(snapshot, { config = readTriageConfig(resolveBacklogDir(snapshot)) } = {}) {
+  return sortEdges([
+    ...scanMentions(snapshot),
+    ...scanBlocks(snapshot),
+    ...scanDependsOn(snapshot),
+    ...findDuplicateCandidates(snapshot, config),
+    ...findMergedPullRequestLinks(snapshot, config),
+  ]);
+}
+
+function formatEdge(edge) {
+  if (edge.kind === "duplicate-candidate") {
+    return `#${edge.from} ${edge.kind} #${edge.to} (${edge.confidence.toFixed(2)}) ${edge.evidence.titles.from} <> ${edge.evidence.titles.to}`;
+  }
+
+  const snippet = typeof edge.evidence === "object" ? edge.evidence.snippet || edge.evidence.phrase : edge.evidence;
+  return `#${edge.from} ${edge.kind} #${edge.to} ${snippet}`;
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.error) {
+    console.error(options.error);
+    process.exit(1);
+  }
+
+  let edges;
+  try {
+    const snapshot = readSnapshotFile(options.snapshotPath);
+    edges = analyzeSnapshot(snapshot);
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+
+  if (options.json) {
+    console.log(JSON.stringify({ edges }, null, 2));
+    return;
+  }
+
+  if (edges.length === 0) {
+    console.log("No relationships found.");
+    return;
+  }
+
+  for (const edge of edges) {
+    console.log(formatEdge(edge));
+  }
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  parseArgs,
+  maskFencedCodeBlocks,
+  extractIssueRefs,
+  scanMentions,
+  scanBlocks,
+  scanDependsOn,
+  findDuplicateCandidates,
+  readSnapshotFile,
+  analyzeSnapshot,
+  sortEdges,
+  resolveBacklogDir,
+};

--- a/skills/backlog-triage/scripts/triage-relate.js
+++ b/skills/backlog-triage/scripts/triage-relate.js
@@ -301,11 +301,6 @@ function findDuplicateCandidates(snapshot, config = readTriageConfig("backlog"))
   return dedupeEdges(edges);
 }
 
-function findMergedPullRequestLinks() {
-  // TODO(#62): wire PR linkage once closing-PR metadata exists in the snapshot.
-  return [];
-}
-
 function compareEdges(left, right) {
   return left.from - right.from || left.to - right.to || left.kind.localeCompare(right.kind);
 }
@@ -369,7 +364,6 @@ function analyzeSnapshot(snapshot, { config = readTriageConfig(resolveBacklogDir
     ...scanBlocks(snapshot),
     ...scanDependsOn(snapshot),
     ...findDuplicateCandidates(snapshot, config),
-    ...findMergedPullRequestLinks(snapshot, config),
   ]);
 }
 

--- a/skills/backlog-triage/scripts/triage-relate.js
+++ b/skills/backlog-triage/scripts/triage-relate.js
@@ -253,7 +253,7 @@ function jaccardSimilarity(left, right) {
   const leftTokens = [...left];
   const rightTokens = [...right];
   const union = new Set([...leftTokens, ...rightTokens]);
-  if (union.size === 0) return 0;
+  if (union.size === 0) return { score: 0, overlap: [] };
 
   const overlap = leftTokens.filter((token) => right.has(token));
   return {

--- a/skills/backlog-triage/scripts/triage-relate.js
+++ b/skills/backlog-triage/scripts/triage-relate.js
@@ -167,12 +167,18 @@ function dedupeEdges(edges) {
   });
 }
 
+function snapshotIssueNumbers(snapshot) {
+  return new Set(snapshot.issues.map((issue) => issue.number));
+}
+
 function scanMentions(snapshot) {
   const edges = [];
+  const openNumbers = snapshotIssueNumbers(snapshot);
 
   for (const issue of snapshot.issues) {
     for (const ref of extractIssueRefs(issue.body)) {
       if (issue.number === ref.number) continue;
+      if (!openNumbers.has(ref.number)) continue;
       edges.push(
         makeEdge({
           from: issue.number,
@@ -193,6 +199,7 @@ function scanMentions(snapshot) {
 
 function scanPhraseEdges(snapshot, patterns, kind, confidence) {
   const edges = [];
+  const openNumbers = snapshotIssueNumbers(snapshot);
 
   for (const issue of snapshot.issues) {
     const source = typeof issue.body === "string" ? issue.body : "";
@@ -207,6 +214,7 @@ function scanPhraseEdges(snapshot, patterns, kind, confidence) {
 
         const target = Number(match[1]);
         if (issue.number === target) continue;
+        if (!openNumbers.has(target)) continue;
 
         edges.push(
           makeEdge({

--- a/skills/backlog-triage/scripts/triage-relate.test.js
+++ b/skills/backlog-triage/scripts/triage-relate.test.js
@@ -1,0 +1,287 @@
+const { describe, it, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const {
+  parseArgs,
+  extractIssueRefs,
+  scanMentions,
+  scanBlocks,
+  scanDependsOn,
+  findDuplicateCandidates,
+  analyzeSnapshot,
+  readSnapshotFile,
+} = require("./triage-relate.js");
+
+function makeSnapshot(overrides = {}) {
+  return {
+    generated: "2026-04-18T05:00:00.000Z",
+    repo: "sungjunlee/dev-backlog",
+    config_path: "backlog/triage-config.yml",
+    issues: [],
+    ...overrides,
+  };
+}
+
+function makeIssue(overrides = {}) {
+  return {
+    number: 100,
+    title: "OAuth token refresh flow",
+    body: "",
+    labels: [],
+    createdAt: "2026-04-10T00:00:00.000Z",
+    updatedAt: "2026-04-17T00:00:00.000Z",
+    milestone: null,
+    buckets: {
+      label: { type: "feature", priority: "medium", status: "todo" },
+      theme: "auth",
+      age: "7-30d",
+      activity: "recent",
+      milestone: "unassigned",
+    },
+    ...overrides,
+  };
+}
+
+describe("parseArgs", () => {
+  it("parses snapshot and json flags", () => {
+    assert.deepEqual(parseArgs(["--snapshot", "tmp.json", "--json"]), {
+      snapshotPath: "tmp.json",
+      json: true,
+    });
+  });
+
+  it("rejects missing snapshot paths", () => {
+    assert.match(parseArgs([]).error, /--snapshot/);
+    assert.match(parseArgs(["--snapshot"]).error, /--snapshot/);
+  });
+});
+
+describe("extractIssueRefs", () => {
+  it("ignores fenced code blocks and URL fragments", () => {
+    const refs = extractIssueRefs([
+      "See #101 for the follow-up.",
+      "```md",
+      "Blocked by #102",
+      "```",
+      "Reference: https://github.com/owner/name/pull/123#issuecomment-456",
+      "Self note #100",
+    ].join("\n"));
+
+    assert.deepEqual(
+      refs.map((ref) => ref.number),
+      [101, 100]
+    );
+    assert.equal(refs[0].snippet, "See #101 for the follow-up.");
+  });
+});
+
+describe("scanMentions", () => {
+  it("mentions: emits body references and suppresses self/code/url noise", () => {
+    const snapshot = makeSnapshot({
+      issues: [
+        makeIssue({
+          number: 100,
+          body: [
+            "See also #101 before filing a follow-up.",
+            "```js",
+            "const hidden = '#102';",
+            "```",
+            "https://github.com/owner/name/pull/123#issuecomment-456",
+            "Reminder #100 should stay local.",
+          ].join("\n"),
+        }),
+      ],
+    });
+
+    assert.deepEqual(scanMentions(snapshot), [
+      {
+        from: 100,
+        to: 101,
+        kind: "mentions",
+        confidence: 0.75,
+        evidence: {
+          match: "#101",
+          snippet: "See also #101 before filing a follow-up.",
+        },
+      },
+    ]);
+  });
+});
+
+describe("scanBlocks", () => {
+  it("blocks: emits blocks and closes phrases with concrete evidence", () => {
+    const snapshot = makeSnapshot({
+      issues: [
+        makeIssue({
+          number: 100,
+          body: "Blocks #101 until the token flow lands. Later it closes #102 cleanly.",
+        }),
+      ],
+    });
+
+    const edges = scanBlocks(snapshot);
+    assert.deepEqual(
+      edges.map((edge) => [edge.from, edge.to, edge.kind, edge.evidence.phrase]),
+      [
+        [100, 101, "blocks", "Blocks #101"],
+        [100, 102, "blocks", "closes #102"],
+      ]
+    );
+    assert.match(edges[0].evidence.snippet, /Blocks #101/);
+    assert.match(edges[1].evidence.snippet, /closes #102/);
+  });
+});
+
+describe("scanDependsOn", () => {
+  it("depends-on: emits blocked by / depends on / depends-on phrases", () => {
+    const snapshot = makeSnapshot({
+      issues: [
+        makeIssue({
+          number: 101,
+          body: "Blocked by #100 today. Then depends on #102 and depends-on #103 later.",
+        }),
+      ],
+    });
+
+    const edges = scanDependsOn(snapshot);
+    assert.deepEqual(
+      edges.map((edge) => [edge.from, edge.to, edge.kind, edge.evidence.phrase]),
+      [
+        [101, 100, "depends-on", "Blocked by #100"],
+        [101, 102, "depends-on", "depends on #102"],
+        [101, 103, "depends-on", "depends-on #103"],
+      ]
+    );
+    assert.match(edges[0].evidence.snippet, /Blocked by #100/);
+    assert.match(edges[1].evidence.snippet, /depends on #102/);
+    assert.match(edges[2].evidence.snippet, /depends-on #103/);
+  });
+});
+
+describe("findDuplicateCandidates", () => {
+  it("duplicate-candidate: emits one canonical edge with overlap and score", () => {
+    const snapshot = makeSnapshot({
+      issues: [
+        makeIssue({ number: 100, title: "OAuth token refresh flow" }),
+        makeIssue({ number: 200, title: "OAuth token refresh flow redesign" }),
+        makeIssue({ number: 300, title: "Add rate limiting to API endpoints" }),
+      ],
+    });
+
+    assert.deepEqual(findDuplicateCandidates(snapshot, { duplicate_threshold: 0.75 }), [
+      {
+        from: 100,
+        to: 200,
+        kind: "duplicate-candidate",
+        confidence: 0.8,
+        evidence: {
+          score: 0.8,
+          overlap: ["flow", "oauth", "refresh", "token"],
+          titles: {
+            from: "OAuth token refresh flow",
+            to: "OAuth token refresh flow redesign",
+          },
+        },
+      },
+    ]);
+  });
+});
+
+describe("analyzeSnapshot", () => {
+  let originalCwd;
+  let tempDir;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "triage-relate-test-"));
+    fs.mkdirSync(path.join(tempDir, "backlog"), { recursive: true });
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("honors backlog/triage-config.yml duplicate_threshold and sorts output", () => {
+    process.chdir(tempDir);
+    fs.writeFileSync(
+      path.join(tempDir, "backlog", "triage-config.yml"),
+      [
+        "theme_keywords:",
+        "  auth: [auth, oauth]",
+        "activity_days:",
+        "  warm: 14",
+        "  cold: 60",
+        "stale_days: 60",
+        "duplicate_threshold: 0.99",
+        "",
+      ].join("\n")
+    );
+
+    const snapshot = makeSnapshot({
+      issues: [
+        makeIssue({
+          number: 100,
+          title: "OAuth token refresh flow",
+          body: "Blocks #101. See also #200.",
+        }),
+        makeIssue({
+          number: 101,
+          title: "OAuth session persistence",
+          body: "Depends on #100.",
+        }),
+        makeIssue({
+          number: 200,
+          title: "OAuth token refresh flow redesign",
+          body: "Rewrite of the refresh flow.",
+        }),
+      ],
+    });
+
+    const strictEdges = analyzeSnapshot(snapshot);
+    assert.equal(strictEdges.some((edge) => edge.kind === "duplicate-candidate"), false);
+
+    fs.writeFileSync(
+      path.join(tempDir, "backlog", "triage-config.yml"),
+      [
+        "theme_keywords:",
+        "  auth: [auth, oauth]",
+        "activity_days:",
+        "  warm: 14",
+        "  cold: 60",
+        "stale_days: 60",
+        "duplicate_threshold: 0.75",
+        "",
+      ].join("\n")
+    );
+
+    const looseEdges = analyzeSnapshot(snapshot);
+    assert.deepEqual(
+      looseEdges.map((edge) => [edge.from, edge.to, edge.kind]),
+      [
+        [100, 101, "blocks"],
+        [100, 101, "mentions"],
+        [100, 200, "duplicate-candidate"],
+        [100, 200, "mentions"],
+        [101, 100, "depends-on"],
+        [101, 100, "mentions"],
+      ]
+    );
+  });
+
+  it("reads fixture snapshots from disk and errors on malformed JSON", () => {
+    process.chdir(tempDir);
+
+    const snapshotPath = path.join(tempDir, "snapshot.json");
+    fs.writeFileSync(snapshotPath, `${JSON.stringify(makeSnapshot({ issues: [makeIssue()] }), null, 2)}\n`);
+
+    const snapshot = readSnapshotFile(snapshotPath);
+    assert.equal(snapshot.issues[0].number, 100);
+
+    const badPath = path.join(tempDir, "bad.json");
+    fs.writeFileSync(badPath, "not json\n");
+    assert.throws(() => readSnapshotFile(badPath), /Malformed snapshot JSON/);
+  });
+});

--- a/skills/backlog-triage/scripts/triage-relate.test.js
+++ b/skills/backlog-triage/scripts/triage-relate.test.js
@@ -92,6 +92,7 @@ describe("scanMentions", () => {
             "Reminder #100 should stay local.",
           ].join("\n"),
         }),
+        makeIssue({ number: 101, body: "" }),
       ],
     });
 
@@ -108,6 +109,20 @@ describe("scanMentions", () => {
       },
     ]);
   });
+
+  it("mentions: drops refs to issues not present in the snapshot (closed / unrelated)", () => {
+    // Regression: edges must never point at issue numbers outside snapshot.issues.
+    const snapshot = makeSnapshot({
+      issues: [
+        makeIssue({ number: 100, body: "See #999 for history and #101 for follow-up." }),
+        makeIssue({ number: 101, body: "" }),
+      ],
+    });
+
+    const edges = scanMentions(snapshot);
+    assert.equal(edges.length, 1);
+    assert.equal(edges[0].to, 101);
+  });
 });
 
 describe("scanBlocks", () => {
@@ -118,6 +133,8 @@ describe("scanBlocks", () => {
           number: 100,
           body: "Blocks #101 until the token flow lands. Later it closes #102 cleanly.",
         }),
+        makeIssue({ number: 101, body: "" }),
+        makeIssue({ number: 102, body: "" }),
       ],
     });
 
@@ -132,6 +149,19 @@ describe("scanBlocks", () => {
     assert.match(edges[0].evidence.snippet, /Blocks #101/);
     assert.match(edges[1].evidence.snippet, /closes #102/);
   });
+
+  it("blocks: drops phrases targeting issues absent from the snapshot", () => {
+    // Regression: `Blocks #999` must not emit an edge if #999 is not in snapshot.issues.
+    const snapshot = makeSnapshot({
+      issues: [
+        makeIssue({ number: 100, body: "Blocks #999. Also blocks #101." }),
+        makeIssue({ number: 101, body: "" }),
+      ],
+    });
+    const edges = scanBlocks(snapshot);
+    assert.equal(edges.length, 1);
+    assert.equal(edges[0].to, 101);
+  });
 });
 
 describe("scanDependsOn", () => {
@@ -142,6 +172,9 @@ describe("scanDependsOn", () => {
           number: 101,
           body: "Blocked by #100 today. Then depends on #102 and depends-on #103 later.",
         }),
+        makeIssue({ number: 100, body: "" }),
+        makeIssue({ number: 102, body: "" }),
+        makeIssue({ number: 103, body: "" }),
       ],
     });
 

--- a/skills/backlog-triage/scripts/triage-relate.test.js
+++ b/skills/backlog-triage/scripts/triage-relate.test.js
@@ -65,7 +65,7 @@ describe("extractIssueRefs", () => {
       "```md",
       "Blocked by #102",
       "```",
-      "Reference: https://github.com/owner/name/pull/123#issuecomment-456",
+      "Reference: https://github.com/owner/name/pull/123/files#diff-1",
       "Self note #100",
     ].join("\n"));
 
@@ -88,7 +88,7 @@ describe("scanMentions", () => {
             "```js",
             "const hidden = '#102';",
             "```",
-            "https://github.com/owner/name/pull/123#issuecomment-456",
+            "https://github.com/owner/name/pull/123/files#diff-1",
             "Reminder #100 should stay local.",
           ].join("\n"),
         }),
@@ -271,7 +271,7 @@ describe("analyzeSnapshot", () => {
     );
   });
 
-  it("reads fixture snapshots from disk and errors on malformed JSON", () => {
+  it("reads fixture snapshots from disk and errors on missing or malformed JSON", () => {
     process.chdir(tempDir);
 
     const snapshotPath = path.join(tempDir, "snapshot.json");
@@ -279,6 +279,11 @@ describe("analyzeSnapshot", () => {
 
     const snapshot = readSnapshotFile(snapshotPath);
     assert.equal(snapshot.issues[0].number, 100);
+
+    assert.throws(
+      () => readSnapshotFile(path.join(tempDir, "missing.json")),
+      /Snapshot file is missing or unreadable/
+    );
 
     const badPath = path.join(tempDir, "bad.json");
     fs.writeFileSync(badPath, "not json\n");

--- a/skills/backlog-triage/scripts/triage-relate.test.js
+++ b/skills/backlog-triage/scripts/triage-relate.test.js
@@ -187,6 +187,23 @@ describe("findDuplicateCandidates", () => {
       },
     ]);
   });
+
+  it("duplicate-candidate: does not crash on titles that tokenize to the empty set", () => {
+    // Single-character / stopword-only titles produce zero tokens via tokenizeTitle's length>1 filter.
+    // Regression test — previously jaccardSimilarity returned scalar 0 on empty union and the caller crashed on similarity.overlap.length.
+    const snapshot = makeSnapshot({
+      issues: [
+        makeIssue({ number: 100, title: "A" }),
+        makeIssue({ number: 200, title: "B" }),
+      ],
+    });
+
+    assert.doesNotThrow(() =>
+      findDuplicateCandidates(snapshot, { duplicate_threshold: 0.0 })
+    );
+    // Zero tokens → zero overlap → no duplicate-candidate edge emitted.
+    assert.deepEqual(findDuplicateCandidates(snapshot, { duplicate_threshold: 0.0 }), []);
+  });
 });
 
 describe("analyzeSnapshot", () => {


### PR DESCRIPTION
## Summary

Implements #62 — `scripts/triage-relate.js`, the relationship detector that consumes the snapshot (no re-fetching) and emits mention / blocks / depends-on / duplicate-candidate edges.

- **`skills/backlog-triage/scripts/triage-relate.js`** — CLI `triage-relate.js --snapshot PATH [--json]`. Pure snapshot consumer. Uses `readTriageConfig` for `duplicate_threshold`. Exports modular scanners: `scanMentions`, `scanBlocks`, `scanDependsOn`, `findDuplicateCandidates`. Suppresses self-references, URL-path mentions, fenced-code-block matches. Dedupes duplicate-candidate pairs. Stable sort for deterministic output.
- **`skills/backlog-triage/scripts/triage-relate.test.js`** — fixture-based node --test coverage; each edge kind has named tests referencing it.

Closes #62. Part of epic #59.

## Dispatch context

- Run ID: `issue-62-20260418045041403`. Elapsed 566s.
- Rubric: `/tmp/rubric-62.yaml` (persisted alongside manifest).
- Pure snapshot consumer — no `gh` invocation. Prerequisite gate confirms this via static scan.
- Score Log deferred to `/relay-review`.

## Test plan

- [ ] Reviewer runs 3 rubric prerequisites (test suite, no-gh static scan, missing/malformed snapshot error)
- [ ] Reviewer runs C1-C5 contract checks (edge shape, mention/blocks/depends-on detection, duplicate-candidate threshold, config-honored, test coverage per kind)
- [ ] Reviewer scores Q1-Q3 (evidence quality, noise suppression, scanner modularity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 이슈 간 관계를 자동으로 분석하고 추적할 수 있는 기능 추가
  * 이슈에서 언급, 차단, 의존성, 중복 가능성 있는 관계를 감지합니다

* **문서**
  * 지원되는 관계 유형과 분석 규칙에 대한 상세 참고 자료 추가

* **테스트**
  * 이슈 관계 분석 기능에 대한 포괄적인 자동 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->