### PR TITLE
feat(backlog-triage): apply step with explicit confirmation (#65)

### DIFF
--- a/skills/backlog-triage/scripts/triage-apply.js
+++ b/skills/backlog-triage/scripts/triage-apply.js
@@ -1,0 +1,899 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+const { execFileSync } = require("node:child_process");
+const { ANCHOR_PATTERN, parseAnchor } = require("./triage-report.js");
+
+const DEFAULT_TRIAGE_DIR = path.join("backlog", "triage");
+const CHECKBOX_PATTERN = /^\s*-\s+\[([ xX])\]\s+/;
+const SUPPORTED_VERBS = new Set([
+  "close",
+  "revisit",
+  "close-duplicate",
+  "set-priority",
+  "assign-milestone",
+]);
+const UNKNOWN_PRIORITY_PLACEHOLDER = "priority:<existing-if-any>";
+
+function usage() {
+  return "Usage: triage-apply.js <report.md> [--apply] [--yes] [--json]";
+}
+
+function parseArgs(args) {
+  const options = {
+    reportPath: undefined,
+    apply: false,
+    yes: false,
+    json: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === "--apply") {
+      options.apply = true;
+      continue;
+    }
+
+    if (arg === "--yes") {
+      options.yes = true;
+      continue;
+    }
+
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+
+    if (arg.startsWith("--")) {
+      return { ...options, error: `Unknown argument: ${arg}. ${usage()}` };
+    }
+
+    if (options.reportPath) {
+      return { ...options, error: `Expected exactly one report path. ${usage()}` };
+    }
+
+    options.reportPath = arg;
+  }
+
+  if (!options.reportPath) {
+    return { ...options, error: `Missing required report.md path. ${usage()}` };
+  }
+
+  return options;
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeArgs(args) {
+  const source = isPlainObject(args) ? args : {};
+  const normalized = {};
+
+  for (const key of Object.keys(source).sort()) {
+    const value = source[key];
+    if (typeof value === "string") {
+      normalized[key] = value.trim();
+      continue;
+    }
+    if (typeof value === "number" || typeof value === "boolean" || value === null) {
+      normalized[key] = value;
+      continue;
+    }
+    normalized[key] = String(value).trim();
+  }
+
+  return normalized;
+}
+
+function stableSerialize(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableSerialize(entry)).join(",")}]`;
+  }
+
+  if (isPlainObject(value)) {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableSerialize(value[key])}`).join(",")}}`;
+  }
+
+  return JSON.stringify(value);
+}
+
+function buildActionKey(action) {
+  return `${action.verb}|${action.issueNumber}|${stableSerialize(action.normalizedArgs || normalizeArgs(action.args))}`;
+}
+
+function parseFrontmatter(text) {
+  const lines = String(text || "").split(/\r?\n/);
+  if (lines[0] !== "---") return {};
+
+  const endIndex = lines.indexOf("---", 1);
+  if (endIndex === -1) {
+    throw new Error("Malformed report: frontmatter block is missing its closing --- marker.");
+  }
+
+  const frontmatter = {};
+  for (let index = 1; index < endIndex; index += 1) {
+    const line = lines[index];
+    const separatorIndex = line.indexOf(":");
+    if (separatorIndex === -1) continue;
+
+    const key = line.slice(0, separatorIndex).trim();
+    const value = line.slice(separatorIndex + 1).trim();
+    if (key) {
+      frontmatter[key] = value;
+    }
+  }
+
+  return frontmatter;
+}
+
+function parseReport(text) {
+  const source = String(text || "");
+  if (source.includes("<!-- AC:BEGIN -->")) {
+    throw new Error("Malformed report: triage reports must not contain dev-backlog AC markers.");
+  }
+
+  const lines = source.split(/\r?\n/);
+  const frontmatter = parseFrontmatter(source);
+  const anchors = [];
+  const parsed = {
+    anchors: 0,
+    checked: 0,
+    unchecked: 0,
+    unknown_verb: 0,
+  };
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const anchor = parseAnchor(lines[index]);
+    if (!anchor) continue;
+
+    let checkboxIndex = index + 1;
+    while (checkboxIndex < lines.length && lines[checkboxIndex].trim() === "") {
+      checkboxIndex += 1;
+    }
+
+    const checkboxLine = lines[checkboxIndex];
+    const checkboxMatch = checkboxLine ? checkboxLine.match(CHECKBOX_PATTERN) : null;
+    if (!checkboxMatch) {
+      throw new Error(
+        `Malformed report: triage anchor on line ${index + 1} must be followed by a checkbox line.`
+      );
+    }
+
+    const checked = checkboxMatch[1].toLowerCase() === "x";
+    const knownVerb = SUPPORTED_VERBS.has(anchor.verb);
+    const normalizedArgs = normalizeArgs(anchor.args);
+    const entry = {
+      verb: anchor.verb,
+      issueNumber: anchor.issueNumber,
+      args: anchor.args,
+      normalizedArgs,
+      checked,
+      knownVerb,
+      key: `${anchor.verb}|${anchor.issueNumber}|${stableSerialize(normalizedArgs)}`,
+      anchorLine: index + 1,
+      checkboxLine: checkboxIndex + 1,
+    };
+
+    anchors.push(entry);
+    parsed.anchors += 1;
+    if (checked) {
+      parsed.checked += 1;
+    } else {
+      parsed.unchecked += 1;
+    }
+    if (!knownVerb) {
+      parsed.unknown_verb += 1;
+    }
+  }
+
+  return { frontmatter, anchors, parsed };
+}
+
+function dedupActions(anchors) {
+  const deduped = new Map();
+
+  for (const anchor of anchors) {
+    const existing = deduped.get(anchor.key);
+    if (!existing) {
+      deduped.set(anchor.key, {
+        verb: anchor.verb,
+        issueNumber: anchor.issueNumber,
+        args: anchor.args,
+        normalizedArgs: anchor.normalizedArgs,
+        checked: anchor.checked,
+        knownVerb: anchor.knownVerb,
+        key: anchor.key,
+        occurrences: [
+          {
+            anchorLine: anchor.anchorLine,
+            checkboxLine: anchor.checkboxLine,
+            checked: anchor.checked,
+          },
+        ],
+      });
+      continue;
+    }
+
+    if (anchor.checked) {
+      existing.checked = true;
+    }
+    existing.occurrences.push({
+      anchorLine: anchor.anchorLine,
+      checkboxLine: anchor.checkboxLine,
+      checked: anchor.checked,
+    });
+  }
+
+  return [...deduped.values()];
+}
+
+function formatRevisitComment(reason) {
+  return `triage: revisit — ${String(reason || "").trim()}`;
+}
+
+function formatDuplicateComment(target, reason) {
+  const targetRef = String(target || "").trim();
+  const reasonText = String(reason || "").trim();
+  return reasonText ? `Duplicate of ${targetRef}. ${reasonText}` : `Duplicate of ${targetRef}.`;
+}
+
+function buildPriorityEditCommand(issueNumber, targetValue, currentPriorityLabels) {
+  const issue = String(issueNumber);
+  const targetLabel = `priority:${String(targetValue || "").trim()}`;
+  const labels = Array.isArray(currentPriorityLabels)
+    ? currentPriorityLabels.map((label) => String(label).trim()).filter(Boolean)
+    : [];
+  const uniqueLabels = [...new Set(labels)];
+  const toRemove = uniqueLabels.filter((label) => label.startsWith("priority:") && label !== targetLabel);
+  const hasTarget = uniqueLabels.includes(targetLabel);
+
+  if (hasTarget && toRemove.length === 0) {
+    return [];
+  }
+
+  const argv = ["issue", "edit", issue, "--add-label", targetLabel];
+  for (const label of toRemove) {
+    argv.push("--remove-label", label);
+  }
+  return [argv];
+}
+
+function toGhCommands(action, context = {}) {
+  const issue = String(action.issueNumber);
+  const args = action.args || {};
+
+  switch (action.verb) {
+    case "close":
+      return [
+        ["issue", "comment", issue, "-b", String(args.reason || "").trim()],
+        ["issue", "close", issue],
+      ];
+    case "revisit":
+      return [
+        ["issue", "comment", issue, "-b", formatRevisitComment(args.reason)],
+      ];
+    case "close-duplicate":
+      return [
+        ["issue", "comment", issue, "-b", formatDuplicateComment(args.target, args.reason)],
+        ["issue", "close", issue, "-r", "not_planned"],
+      ];
+    case "set-priority":
+      if (Array.isArray(context.currentPriorityLabels)) {
+        return buildPriorityEditCommand(issue, args.value, context.currentPriorityLabels);
+      }
+      return [
+        ["issue", "view", issue, "--json", "labels"],
+        ["issue", "edit", issue, "--add-label", `priority:${String(args.value || "").trim()}`, "--remove-label", UNKNOWN_PRIORITY_PLACEHOLDER],
+      ];
+    case "assign-milestone":
+      return [
+        ["issue", "edit", issue, "--milestone", String(args.name || "").trim()],
+      ];
+    default:
+      return [];
+  }
+}
+
+function quoteShellArg(value) {
+  const source = String(value);
+  if (/^[A-Za-z0-9_./:#=-]+$/.test(source)) return source;
+  return `'${source.replace(/'/g, `'\"'\"'`)}'`;
+}
+
+function formatGhCommand(argv) {
+  return `gh ${argv.map((arg) => quoteShellArg(arg)).join(" ")}`;
+}
+
+function trimStderr(stderr) {
+  return String(stderr || "").trim().slice(-500);
+}
+
+function runGh(argv, { execFile = execFileSync } = {}) {
+  try {
+    const stdout = execFile("gh", argv, {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return {
+      status: 0,
+      stdout: stdout || "",
+      stderr: "",
+    };
+  } catch (error) {
+    return {
+      status: error.status || 1,
+      stdout: typeof error.stdout === "string" ? error.stdout : error.stdout?.toString?.("utf-8") || "",
+      stderr: typeof error.stderr === "string" ? error.stderr : error.stderr?.toString?.("utf-8") || error.message,
+    };
+  }
+}
+
+function parseGhLabels(stdout) {
+  let parsed;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch (error) {
+    throw new Error(`Failed to parse gh issue view JSON: ${error.message}`);
+  }
+
+  if (!parsed || typeof parsed !== "object" || !Array.isArray(parsed.labels)) {
+    throw new Error("Malformed gh issue view response: expected { labels: [] }.");
+  }
+
+  return parsed.labels
+    .map((label) => (typeof label === "string" ? label : label?.name))
+    .filter(Boolean);
+}
+
+function extractCommandArrays(value) {
+  if (!Array.isArray(value)) return [];
+  if (value.every((entry) => typeof entry === "string")) {
+    return [value];
+  }
+  return value.filter(
+    (entry) => Array.isArray(entry) && entry.every((part) => typeof part === "string")
+  );
+}
+
+function readApplyLog(logPath, readFile = fs.readFileSync) {
+  let raw;
+  try {
+    raw = readFile(logPath, "utf-8");
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return {
+        entries: [],
+        appliedCommandsByAction: new Map(),
+      };
+    }
+    throw new Error(`Failed to read apply log at ${logPath}: ${error.message}`);
+  }
+
+  const entries = [];
+  const appliedCommandsByAction = new Map();
+  const lines = raw.split(/\r?\n/).filter(Boolean);
+
+  for (let index = 0; index < lines.length; index += 1) {
+    let entry;
+    try {
+      entry = JSON.parse(lines[index]);
+    } catch (error) {
+      throw new Error(`Malformed apply log at ${logPath}: line ${index + 1} is not valid JSON.`);
+    }
+
+    entries.push(entry);
+    if (entry.result !== "applied") continue;
+    if (typeof entry.verb !== "string" || !Number.isInteger(entry.issue)) continue;
+
+    const key = buildActionKey({
+      verb: entry.verb,
+      issueNumber: entry.issue,
+      args: entry.args || {},
+      normalizedArgs: normalizeArgs(entry.args || {}),
+    });
+    const commands = extractCommandArrays(entry.gh_argv);
+    if (commands.length === 0) continue;
+
+    if (!appliedCommandsByAction.has(key)) {
+      appliedCommandsByAction.set(key, new Set());
+    }
+    const commandSet = appliedCommandsByAction.get(key);
+    for (const command of commands) {
+      commandSet.add(stableSerialize(command));
+    }
+  }
+
+  return {
+    entries,
+    appliedCommandsByAction,
+  };
+}
+
+function appendLogLine(logPath, entry, appendFile = fs.appendFileSync, mkdir = fs.mkdirSync) {
+  mkdir(path.dirname(logPath), { recursive: true });
+  appendFile(logPath, `${JSON.stringify(entry)}\n`);
+}
+
+function buildLogEntry(action, result, ghArgv, timestamp, extra = {}) {
+  const entry = {
+    timestamp,
+    issue: action.issueNumber,
+    verb: action.verb,
+    args: action.args,
+    result,
+    gh_argv: ghArgv,
+  };
+
+  if (extra.stderr_tail) {
+    entry.stderr_tail = trimStderr(extra.stderr_tail);
+  }
+
+  return entry;
+}
+
+function resolveReportDate(frontmatter, nowIso) {
+  const generated = String(frontmatter.generated || "").trim();
+  if (/^\d{4}-\d{2}-\d{2}$/.test(generated)) {
+    return generated;
+  }
+  if (/^\d{4}-\d{2}-\d{2}T/.test(generated)) {
+    return generated.slice(0, 10);
+  }
+  return String(nowIso).slice(0, 10);
+}
+
+function resolveLogPath(reportDate, cwd) {
+  return path.resolve(cwd, DEFAULT_TRIAGE_DIR, `${reportDate}-apply.log`);
+}
+
+function readLineSync(inputFd = 0) {
+  const buffer = Buffer.alloc(1);
+  let line = "";
+
+  while (true) {
+    const bytesRead = fs.readSync(inputFd, buffer, 0, 1, null);
+    if (bytesRead === 0) break;
+    const char = buffer.toString("utf-8", 0, bytesRead);
+    if (char === "\n") break;
+    if (char !== "\r") line += char;
+  }
+
+  return line;
+}
+
+function confirmApply({ output = process.stderr, inputFd = 0 } = {}) {
+  output.write("Type `yes` to proceed: ");
+  return readLineSync(inputFd).trim() === "yes";
+}
+
+function ensureApplyAllowed(options, deps) {
+  if (!options.apply) return;
+  if (options.yes) return;
+
+  const stdinIsTTY = deps.stdinIsTTY ?? Boolean(process.stdin.isTTY);
+  const stdoutIsTTY = deps.stdoutIsTTY ?? Boolean(process.stdout.isTTY);
+
+  if (!stdinIsTTY || !stdoutIsTTY) {
+    throw new Error("Refusing to mutate GitHub in non-interactive mode without --yes. Re-run with --apply --yes.");
+  }
+
+  const confirmed = (deps.confirmApply || confirmApply)({
+    output: deps.stderr || process.stderr,
+    inputFd: deps.inputFd ?? 0,
+  });
+
+  if (!confirmed) {
+    throw new Error("Apply aborted. Re-run with --apply --yes to skip confirmation.");
+  }
+}
+
+function recordLog(logPath, action, result, ghArgv, deps, extra = {}) {
+  const timestamp = deps.now();
+  const entry = buildLogEntry(action, result, ghArgv, timestamp, extra);
+  appendLogLine(logPath, entry, deps.appendFile, deps.mkdir);
+  return entry;
+}
+
+function applyAcceptedAction(action, context) {
+  const actionKey = action.key || buildActionKey(action);
+  const appliedCommands = context.appliedCommandsByAction.get(actionKey) || new Set();
+  let plannedCommands;
+
+  if (action.verb === "set-priority") {
+    if (appliedCommands.size > 0) {
+      const alreadyEntry = recordLog(context.logPath, action, "already-applied", [], context.deps);
+      return {
+        ok: true,
+        action: {
+          verb: action.verb,
+          issueNumber: action.issueNumber,
+          args: action.args,
+          gh_argv: [],
+          result: "already-applied",
+          log: alreadyEntry,
+        },
+      };
+    }
+
+    const viewArgv = ["issue", "view", String(action.issueNumber), "--json", "labels"];
+    const viewResult = context.deps.runGh(viewArgv);
+    if (viewResult.status !== 0) {
+      const errorEntry = recordLog(context.logPath, action, "error", [viewArgv], context.deps, {
+        stderr_tail: viewResult.stderr,
+      });
+      return {
+        ok: false,
+        error: errorEntry,
+      };
+    }
+
+    let labels;
+    try {
+      labels = parseGhLabels(viewResult.stdout);
+    } catch (error) {
+      const errorEntry = recordLog(context.logPath, action, "error", [viewArgv], context.deps, {
+        stderr_tail: error.message,
+      });
+      return {
+        ok: false,
+        error: errorEntry,
+      };
+    }
+
+    plannedCommands = toGhCommands(action, { currentPriorityLabels: labels });
+    if (plannedCommands.length === 0) {
+      const alreadyEntry = recordLog(context.logPath, action, "already-applied", [], context.deps);
+      return {
+        ok: true,
+        action: {
+          verb: action.verb,
+          issueNumber: action.issueNumber,
+          args: action.args,
+          gh_argv: [],
+          result: "already-applied",
+          log: alreadyEntry,
+        },
+      };
+    }
+  } else {
+    plannedCommands = toGhCommands(action);
+  }
+
+  const missingCommands = plannedCommands.filter(
+    (argv) => !appliedCommands.has(stableSerialize(argv))
+  );
+
+  if (missingCommands.length === 0) {
+    const alreadyEntry = recordLog(context.logPath, action, "already-applied", plannedCommands, context.deps);
+    return {
+      ok: true,
+      action: {
+        verb: action.verb,
+        issueNumber: action.issueNumber,
+        args: action.args,
+        gh_argv: plannedCommands,
+        result: "already-applied",
+        log: alreadyEntry,
+      },
+    };
+  }
+
+  const executedCommands = [];
+  for (const argv of missingCommands) {
+    const result = context.deps.runGh(argv);
+    if (result.status !== 0) {
+      const errorEntry = recordLog(context.logPath, action, "error", [argv], context.deps, {
+        stderr_tail: result.stderr,
+      });
+      return {
+        ok: false,
+        error: errorEntry,
+        action: {
+          verb: action.verb,
+          issueNumber: action.issueNumber,
+          args: action.args,
+          gh_argv: plannedCommands,
+          executed_gh_argv: executedCommands,
+          result: "error",
+        },
+      };
+    }
+
+    recordLog(context.logPath, action, "applied", [argv], context.deps);
+    executedCommands.push(argv);
+    if (!context.appliedCommandsByAction.has(actionKey)) {
+      context.appliedCommandsByAction.set(actionKey, new Set());
+    }
+    context.appliedCommandsByAction.get(actionKey).add(stableSerialize(argv));
+  }
+
+  return {
+    ok: true,
+    action: {
+      verb: action.verb,
+      issueNumber: action.issueNumber,
+      args: action.args,
+      gh_argv: plannedCommands,
+      executed_gh_argv: executedCommands,
+      result: "applied",
+    },
+  };
+}
+
+function summarizeResults(actions, skipped) {
+  const counts = new Map();
+
+  for (const action of actions) {
+    counts.set(action.result, (counts.get(action.result) || 0) + 1);
+  }
+  for (const entry of skipped) {
+    counts.set(entry.result, (counts.get(entry.result) || 0) + 1);
+  }
+
+  return counts;
+}
+
+function renderText(result) {
+  const lines = [];
+
+  for (const action of result.actions) {
+    if (action.result === "dry-run") {
+      for (const argv of action.gh_argv) {
+        lines.push(`DRY-RUN: ${formatGhCommand(argv)}`);
+      }
+      continue;
+    }
+
+    if (action.result === "applied") {
+      for (const argv of action.executed_gh_argv || []) {
+        lines.push(`APPLY: ${formatGhCommand(argv)}`);
+      }
+      continue;
+    }
+
+    if (action.result === "already-applied") {
+      lines.push(`ALREADY-APPLIED: triage:${action.verb} #${action.issueNumber}`);
+    }
+  }
+
+  for (const skipped of result.skipped) {
+    const reason =
+      skipped.result === "skipped-pending"
+        ? "unchecked"
+        : "unknown verb";
+    lines.push(`SKIP: triage:${skipped.verb} #${skipped.issueNumber} (${reason})`);
+  }
+
+  const counts = summarizeResults(result.actions, result.skipped);
+  lines.push(
+    `Summary: ${[
+      `dry-run=${counts.get("dry-run") || 0}`,
+      `applied=${counts.get("applied") || 0}`,
+      `already-applied=${counts.get("already-applied") || 0}`,
+      `skipped-pending=${counts.get("skipped-pending") || 0}`,
+      `skipped-unknown-verb=${counts.get("skipped-unknown-verb") || 0}`,
+    ].join(", ")}`
+  );
+
+  return `${lines.join("\n")}\n`;
+}
+
+function execute(argv = process.argv.slice(2), deps = {}) {
+  const options = parseArgs(argv);
+  if (options.error) {
+    return {
+      exitCode: 1,
+      error: options.error,
+    };
+  }
+
+  const cwd = deps.cwd || process.cwd();
+  const reportPath = path.resolve(cwd, options.reportPath);
+  const now = deps.now || (() => new Date().toISOString());
+
+  let reportText;
+  try {
+    reportText = (deps.readFile || fs.readFileSync)(reportPath, "utf-8");
+  } catch (error) {
+    return {
+      exitCode: 1,
+      error: `Failed to read report at ${reportPath}: ${error.message}`,
+    };
+  }
+
+  let report;
+  try {
+    report = parseReport(reportText);
+  } catch (error) {
+    return {
+      exitCode: 1,
+      error: error.message,
+    };
+  }
+
+  try {
+    ensureApplyAllowed(options, {
+      confirmApply: deps.confirmApply,
+      stderr: deps.stderr,
+      stdinIsTTY: deps.stdinIsTTY,
+      stdoutIsTTY: deps.stdoutIsTTY,
+      inputFd: deps.inputFd,
+    });
+  } catch (error) {
+    return {
+      exitCode: 1,
+      error: error.message,
+    };
+  }
+
+  const deduped = dedupActions(report.anchors);
+  const applyMode = options.apply ? "apply" : "dry-run";
+  const result = {
+    report: reportPath,
+    parsed: report.parsed,
+    deduped: deduped.length,
+    actions: [],
+    skipped: [],
+    apply_mode: applyMode,
+  };
+
+  let logPath;
+  let appliedCommandsByAction = new Map();
+  if (options.apply) {
+    const reportDate = resolveReportDate(report.frontmatter, now());
+    logPath = resolveLogPath(reportDate, cwd);
+
+    try {
+      const logState = readApplyLog(logPath, deps.readFile || fs.readFileSync);
+      appliedCommandsByAction = logState.appliedCommandsByAction;
+    } catch (error) {
+      return {
+        exitCode: 1,
+        error: error.message,
+      };
+    }
+  }
+
+  const effectDeps = {
+    now,
+    runGh: deps.runGh || ((argvToRun) => runGh(argvToRun, { execFile: deps.execFile || execFileSync })),
+    appendFile: deps.appendFile || fs.appendFileSync,
+    mkdir: deps.mkdir || fs.mkdirSync,
+  };
+
+  for (const action of deduped) {
+    if (!action.checked) {
+      result.skipped.push({
+        verb: action.verb,
+        issueNumber: action.issueNumber,
+        reason: "unchecked",
+        result: "skipped-pending",
+      });
+      if (options.apply) {
+        recordLog(logPath, action, "skipped-pending", toGhCommands(action), effectDeps);
+      }
+      continue;
+    }
+
+    if (!action.knownVerb) {
+      result.skipped.push({
+        verb: action.verb,
+        issueNumber: action.issueNumber,
+        reason: "unknown verb",
+        result: "skipped-unknown-verb",
+      });
+      if (options.apply) {
+        recordLog(logPath, action, "skipped-unknown-verb", [], effectDeps);
+      }
+      continue;
+    }
+
+    if (!options.apply) {
+      result.actions.push({
+        verb: action.verb,
+        issueNumber: action.issueNumber,
+        args: action.args,
+        gh_argv: toGhCommands(action),
+        result: "dry-run",
+      });
+      continue;
+    }
+
+    const applied = applyAcceptedAction(action, {
+      logPath,
+      appliedCommandsByAction,
+      deps: effectDeps,
+    });
+
+    if (!applied.ok) {
+      if (applied.action) {
+        result.actions.push(applied.action);
+      }
+      result.error = [
+        `Failed to apply triage:${action.verb} #${action.issueNumber}.`,
+        applied.error?.stderr_tail || null,
+      ].filter(Boolean).join(" ");
+      return {
+        ...result,
+        exitCode: 1,
+      };
+    }
+
+    result.actions.push(applied.action);
+  }
+
+  return {
+    ...result,
+    exitCode: 0,
+  };
+}
+
+function main() {
+  const wantsJson = process.argv.slice(2).includes("--json");
+  const result = execute();
+  if (result.error) {
+    console.error(result.error);
+  } else if (wantsJson) {
+    console.log(JSON.stringify({
+      report: result.report,
+      parsed: result.parsed,
+      deduped: result.deduped,
+      actions: result.actions.map((action) => ({
+        verb: action.verb,
+        issueNumber: action.issueNumber,
+        args: action.args,
+        gh_argv: action.gh_argv,
+        result: action.result,
+      })),
+      skipped: result.skipped,
+      apply_mode: result.apply_mode,
+    }, null, 2));
+  } else {
+    process.stdout.write(renderText(result));
+  }
+
+  if (result.exitCode !== 0) {
+    process.exit(result.exitCode);
+  }
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  ANCHOR_PATTERN,
+  CHECKBOX_PATTERN,
+  SUPPORTED_VERBS,
+  UNKNOWN_PRIORITY_PLACEHOLDER,
+  usage,
+  parseArgs,
+  normalizeArgs,
+  stableSerialize,
+  buildActionKey,
+  parseFrontmatter,
+  parseReport,
+  dedupActions,
+  formatRevisitComment,
+  formatDuplicateComment,
+  buildPriorityEditCommand,
+  toGhCommands,
+  formatGhCommand,
+  trimStderr,
+  runGh,
+  parseGhLabels,
+  extractCommandArrays,
+  readApplyLog,
+  appendLogLine,
+  buildLogEntry,
+  resolveReportDate,
+  resolveLogPath,
+  readLineSync,
+  confirmApply,
+  ensureApplyAllowed,
+  applyAcceptedAction,
+  summarizeResults,
+  renderText,
+  execute,
+};

--- a/skills/backlog-triage/scripts/triage-apply.test.js
+++ b/skills/backlog-triage/scripts/triage-apply.test.js
@@ -1,0 +1,397 @@
+const { describe, it, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { execFileSync } = require("node:child_process");
+const {
+  parseArgs,
+  parseReport,
+  dedupActions,
+  normalizeArgs,
+  buildActionKey,
+  buildPriorityEditCommand,
+  toGhCommands,
+  resolveLogPath,
+  readApplyLog,
+  execute,
+} = require("./triage-apply.js");
+
+function makeReport() {
+  return [
+    "---",
+    "generated: 2026-04-18",
+    "repo: sungjunlee/dev-backlog",
+    "snapshot: backlog/triage/.cache/2026-04-18T01-30-00Z.json",
+    "open_issues: 5",
+    "---",
+    "",
+    "# Backlog Triage - 2026-04-18",
+    "",
+    "## Obsolete Candidates",
+    "<!-- triage:close #104 reason=\"stale cleanup\" -->",
+    "- [x] Close #104 - stale cleanup",
+    "",
+    "<!-- triage:future-action #999 reason=\"wait for roadmap\" -->",
+    "- [x] Future action #999 - wait for roadmap",
+    "",
+    "## Priority Proposals",
+    "<!-- triage:set-priority #101 reason=\" theme auth hot \" value=high -->",
+    "- [ ] Set priority:high on #101 - theme auth hot",
+    "",
+    "## Milestone Suggestions",
+    "<!-- triage:assign-milestone #102 name=\"Sprint W17\" cluster=auth -->",
+    "",
+    "- [x] Assign Sprint W17 to #102",
+    "",
+    "## Apply Checklist",
+    "<!-- triage:close #104 reason=\"stale cleanup\" -->",
+    "- [ ] Close #104 - stale cleanup _(from Obsolete Candidates)_",
+    "",
+    "<!-- triage:set-priority #101 value=high reason=\"theme auth hot\" -->",
+    "- [x] Set priority:high on #101 - theme auth hot _(from Priority Proposals)_",
+    "",
+    "<!-- triage:assign-milestone #102 cluster=auth name=\"Sprint W17\" -->",
+    "- [ ] Assign Sprint W17 to #102 _(from Milestone Suggestions)_",
+    "",
+    "<!-- triage:close-duplicate #103 target=#101 reason=\"duplicate candidate converged\" -->",
+    "- [x] Close duplicate #103 into #101 _(from Obsolete Candidates)_",
+    "",
+  ].join("\n");
+}
+
+describe("parseArgs", () => {
+  it("parses the positional report path and flags", () => {
+    assert.deepEqual(parseArgs(["report.md", "--apply", "--yes", "--json"]), {
+      reportPath: "report.md",
+      apply: true,
+      yes: true,
+      json: true,
+    });
+  });
+
+  it("fails on missing report paths", () => {
+    assert.match(parseArgs([]).error, /report/i);
+  });
+});
+
+describe("parseReport", () => {
+  it("parses anchors, enforces paired checkboxes, and counts unknown verbs", () => {
+    const parsed = parseReport(makeReport());
+
+    assert.equal(parsed.parsed.anchors, 8);
+    assert.equal(parsed.parsed.checked, 5);
+    assert.equal(parsed.parsed.unchecked, 3);
+    assert.equal(parsed.parsed.unknown_verb, 1);
+    assert.equal(parsed.frontmatter.generated, "2026-04-18");
+
+    assert.equal(parsed.anchors[0].verb, "close");
+    assert.equal(parsed.anchors[0].checked, true);
+  });
+
+  it("fails clearly on malformed anchor pairing", () => {
+    assert.throws(
+      () =>
+        parseReport([
+          "---",
+          "generated: 2026-04-18",
+          "---",
+          "<!-- triage:close #42 reason=\"broken\" -->",
+          "not a checkbox",
+        ].join("\n")),
+      /must be followed by a checkbox/i
+    );
+  });
+});
+
+describe("dedupActions", () => {
+  it("dedups by normalized args and accepts a checked box in any location", () => {
+    const parsed = parseReport(makeReport());
+    const deduped = dedupActions(parsed.anchors);
+
+    assert.equal(deduped.length, 5);
+
+    const closeAction = deduped.find((action) => action.verb === "close");
+    assert.equal(closeAction.checked, true);
+    assert.equal(closeAction.occurrences.length, 2);
+
+    const milestoneAction = deduped.find((action) => action.verb === "assign-milestone");
+    assert.equal(milestoneAction.checked, true);
+
+    const priorityAction = deduped.find((action) => action.verb === "set-priority");
+    assert.deepEqual(priorityAction.normalizedArgs, {
+      reason: "theme auth hot",
+      value: "high",
+    });
+  });
+
+  it("builds stable action keys from sorted, trimmed args", () => {
+    const left = buildActionKey({
+      verb: "assign-milestone",
+      issueNumber: 42,
+      args: { name: "Sprint W17", cluster: " auth " },
+      normalizedArgs: normalizeArgs({ name: "Sprint W17", cluster: " auth " }),
+    });
+    const right = buildActionKey({
+      verb: "assign-milestone",
+      issueNumber: 42,
+      args: { cluster: "auth", name: "Sprint W17" },
+      normalizedArgs: normalizeArgs({ cluster: "auth", name: "Sprint W17" }),
+    });
+
+    assert.equal(left, right);
+  });
+});
+
+describe("toGhCommands", () => {
+  it("renders the MVP gh argv for every supported verb", () => {
+    assert.deepEqual(
+      toGhCommands({ verb: "close", issueNumber: 104, args: { reason: "stale cleanup" } }),
+      [
+        ["issue", "comment", "104", "-b", "stale cleanup"],
+        ["issue", "close", "104"],
+      ]
+    );
+
+    assert.deepEqual(
+      toGhCommands({ verb: "revisit", issueNumber: 200, args: { reason: "needs product input" } }),
+      [["issue", "comment", "200", "-b", "triage: revisit — needs product input"]]
+    );
+
+    assert.deepEqual(
+      toGhCommands({
+        verb: "close-duplicate",
+        issueNumber: 103,
+        args: { target: "#101", reason: "duplicate candidate converged" },
+      }),
+      [
+        ["issue", "comment", "103", "-b", "Duplicate of #101. duplicate candidate converged"],
+        ["issue", "close", "103", "-r", "not_planned"],
+      ]
+    );
+
+    assert.deepEqual(buildPriorityEditCommand(101, "high", ["priority:medium", "type:feature"]), [
+      ["issue", "edit", "101", "--add-label", "priority:high", "--remove-label", "priority:medium"],
+    ]);
+
+    assert.deepEqual(
+      toGhCommands(
+        { verb: "set-priority", issueNumber: 101, args: { value: "high", reason: "theme auth hot" } },
+        { currentPriorityLabels: ["priority:medium", "type:feature"] }
+      ),
+      [["issue", "edit", "101", "--add-label", "priority:high", "--remove-label", "priority:medium"]]
+    );
+
+    assert.deepEqual(
+      toGhCommands({ verb: "assign-milestone", issueNumber: 102, args: { name: "Sprint W17" } }),
+      [["issue", "edit", "102", "--milestone", "Sprint W17"]]
+    );
+  });
+});
+
+describe("execute", () => {
+  let tempDir;
+  let repoRoot;
+  let reportPath;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "triage-apply-"));
+    repoRoot = path.join(tempDir, "repo");
+    fs.mkdirSync(path.join(repoRoot, "backlog", "triage"), { recursive: true });
+    reportPath = path.join(repoRoot, "backlog", "triage", "2026-04-18-report.md");
+    fs.writeFileSync(reportPath, `${makeReport()}\n`);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("runs dry-run without invoking gh and emits pseudo commands", () => {
+    const binDir = path.join(tempDir, "bin");
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(binDir, "gh"),
+      "#!/bin/sh\necho 'gh should not run in dry-run' >&2\nexit 99\n",
+      { mode: 0o755 }
+    );
+
+    const stdout = execFileSync(
+      process.execPath,
+      [path.join(__dirname, "triage-apply.js"), reportPath],
+      {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH}`,
+        },
+      }
+    );
+
+    assert.match(stdout, /DRY-RUN: gh issue comment 104/);
+    assert.match(stdout, /DRY-RUN: gh issue view 101 --json labels/);
+    assert.match(stdout, /DRY-RUN: gh issue close 103 -r not_planned/);
+    assert.match(stdout, /SKIP: triage:future-action #999 \(unknown verb\)/);
+    assert.match(stdout, /Summary: dry-run=4, applied=0, already-applied=0, skipped-pending=0, skipped-unknown-verb=1/);
+  });
+
+  it("emits machine-readable json in dry-run mode", () => {
+    const stdout = execFileSync(
+      process.execPath,
+      [path.join(__dirname, "triage-apply.js"), reportPath, "--json"],
+      {
+        cwd: repoRoot,
+        encoding: "utf-8",
+      }
+    );
+
+    const parsed = JSON.parse(stdout);
+    assert.equal(parsed.apply_mode, "dry-run");
+    assert.equal(parsed.deduped, 5);
+    assert.equal(parsed.actions.length, 4);
+    assert.equal(parsed.skipped.length, 1);
+    assert.deepEqual(parsed.actions[0].gh_argv, [
+      ["issue", "comment", "104", "-b", "stale cleanup"],
+      ["issue", "close", "104"],
+    ]);
+  });
+
+  it("refuses non-interactive apply without --yes", () => {
+    const result = execute([reportPath, "--apply"], {
+      cwd: repoRoot,
+      stdinIsTTY: false,
+      stdoutIsTTY: false,
+    });
+
+    assert.equal(result.exitCode, 1);
+    assert.match(result.error, /--yes/);
+  });
+
+  it("uses the log to skip already-applied actions and resumes partial close-duplicate runs", () => {
+    const logPath = resolveLogPath("2026-04-18", repoRoot);
+    fs.writeFileSync(
+      logPath,
+      [
+        JSON.stringify({
+          timestamp: "2026-04-18T07:00:00.000Z",
+          issue: 104,
+          verb: "close",
+          args: { reason: "stale cleanup" },
+          result: "applied",
+          gh_argv: [["issue", "comment", "104", "-b", "stale cleanup"]],
+        }),
+        JSON.stringify({
+          timestamp: "2026-04-18T07:00:01.000Z",
+          issue: 104,
+          verb: "close",
+          args: { reason: "stale cleanup" },
+          result: "applied",
+          gh_argv: [["issue", "close", "104"]],
+        }),
+        JSON.stringify({
+          timestamp: "2026-04-18T07:00:02.000Z",
+          issue: 103,
+          verb: "close-duplicate",
+          args: { target: "#101", reason: "duplicate candidate converged" },
+          result: "applied",
+          gh_argv: [["issue", "comment", "103", "-b", "Duplicate of #101. duplicate candidate converged"]],
+        }),
+      ].join("\n") + "\n"
+    );
+
+    const calls = [];
+    const result = execute([reportPath, "--apply", "--yes"], {
+      cwd: repoRoot,
+      now: () => "2026-04-18T08:00:00.000Z",
+      runGh: (argv) => {
+        calls.push(argv);
+        if (argv[0] === "issue" && argv[1] === "view") {
+          return {
+            status: 0,
+            stdout: JSON.stringify({ labels: [{ name: "priority:medium" }, { name: "type:feature" }] }),
+            stderr: "",
+          };
+        }
+        return {
+          status: 0,
+          stdout: "",
+          stderr: "",
+        };
+      },
+    });
+
+    assert.equal(result.exitCode, 0);
+    assert.deepEqual(calls, [
+      ["issue", "view", "101", "--json", "labels"],
+      ["issue", "edit", "101", "--add-label", "priority:high", "--remove-label", "priority:medium"],
+      ["issue", "edit", "102", "--milestone", "Sprint W17"],
+      ["issue", "close", "103", "-r", "not_planned"],
+    ]);
+
+    const entries = fs
+      .readFileSync(logPath, "utf-8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+
+    assert.ok(entries.some((entry) => entry.result === "already-applied" && entry.issue === 104));
+    assert.ok(entries.some((entry) => entry.result === "applied" && entry.issue === 101));
+    assert.ok(entries.some((entry) => entry.result === "applied" && entry.issue === 103 && entry.gh_argv[0][1] === "close"));
+
+    const replay = readApplyLog(logPath);
+    const closeKey = buildActionKey({
+      verb: "close",
+      issueNumber: 104,
+      args: { reason: "stale cleanup" },
+      normalizedArgs: normalizeArgs({ reason: "stale cleanup" }),
+    });
+    assert.equal(replay.appliedCommandsByAction.get(closeKey).size, 2);
+  });
+
+  it("stops close-duplicate when the comment step fails and records stderr_tail", () => {
+    const duplicateOnlyReport = path.join(repoRoot, "backlog", "triage", "duplicate-only.md");
+    fs.writeFileSync(
+      duplicateOnlyReport,
+      [
+        "---",
+        "generated: 2026-04-18",
+        "---",
+        "<!-- triage:close-duplicate #103 target=#101 reason=\"duplicate candidate converged\" -->",
+        "- [x] Close duplicate #103 into #101",
+        "",
+      ].join("\n")
+    );
+
+    const calls = [];
+    const result = execute([duplicateOnlyReport, "--apply", "--yes"], {
+      cwd: repoRoot,
+      now: () => "2026-04-18T09:00:00.000Z",
+      runGh: (argv) => {
+        calls.push(argv);
+        return {
+          status: 1,
+          stdout: "",
+          stderr: "comment permission denied",
+        };
+      },
+    });
+
+    assert.equal(result.exitCode, 1);
+    assert.match(result.error, /comment permission denied/);
+    assert.deepEqual(calls, [["issue", "comment", "103", "-b", "Duplicate of #101. duplicate candidate converged"]]);
+
+    const logLines = fs
+      .readFileSync(resolveLogPath("2026-04-18", repoRoot), "utf-8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    assert.equal(logLines.at(-1).result, "error");
+    assert.equal(logLines.at(-1).stderr_tail, "comment permission denied");
+  });
+
+  it("fails clearly when the report is missing", () => {
+    const result = execute(["missing.md"], { cwd: repoRoot });
+    assert.equal(result.exitCode, 1);
+    assert.match(result.error, /failed to read report/i);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `scripts/triage-apply.js` — the apply step that parses a triage report (from #64) and executes accepted actions via `gh`. Mutations gated behind explicit `--apply` + confirmation.

- Anchor+checkbox pair required per apply.md contract; imports shared `parseAnchor` from `triage-report.js`
- Dedup by `(verb, issueNumber, normalizedArgs)` — same action in Apply Checklist + source section collapses to one
- Default dry-run; `--apply` prompts (or refuses non-TTY without `--yes`)
- Idempotent via JSONL log at `backlog/triage/<date>-apply.log` — already-applied actions skipped
- Pure decision layer (`parseReport` / `dedupActions` / `toGhCommands`) separated from effect layer (`runGh`) for testability
- 5 MVP verbs: close, revisit, close-duplicate, set-priority (with label diff), assign-milestone
- Unknown verbs logged as `skipped-unknown-verb`, never fatal (forward-compat per apply.md)

**Deferred**: automated integration test against a disposable scratch repo — follow-up issue will be filed at merge time per AC.

Closes #65. Part of epic #59.

## Test plan

- [ ] `node --test skills/dev-backlog/scripts/*.test.js skills/backlog-triage/scripts/*.test.js` — full suite green
- [ ] Rubric Phase 1 + Phase 2 scored (see \`~/.relay/runs/dev-backlog-ceca3b0f/issue-65-20260418075900082/\`)
- [ ] Dry-run against a fixture report does not invoke gh (enforced by failing-gh shim in prereq 4)
- [ ] Seeded log blocks re-execution; JSONL schema validated

🤖 Dispatched via relay — executor: codex, run: \`issue-65-20260418075900082\`