### PR TITLE
docs(backlog-triage): README + workflow-patterns.md linkage (#66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,12 +178,17 @@ The contract for that integration lives in [references/integration-contract.md](
 `dev-backlog` runs the sprint. [`backlog-triage`](skills/backlog-triage/SKILL.md) grooms the open-issue pile that feeds into it — classification, relationships, stale / obsolete flags, priority proposals. It produces one markdown report under `backlog/triage/YYYY-MM-DD-report.md` that you review, check accepted proposals on, and apply behind an explicit `--apply`.
 
 ```bash
-# Review phase (read-only, default)
-node /path/to/dev-backlog/skills/backlog-triage/scripts/triage-collect.js
-node /path/to/dev-backlog/skills/backlog-triage/scripts/triage-report.js --snapshot backlog/triage/.cache/<ts>.json
+SKILL=/path/to/dev-backlog/skills/backlog-triage/scripts
+SNAP=backlog/triage/.cache/<ts>.json
 
-# Apply phase (opt-in)
-node /path/to/dev-backlog/skills/backlog-triage/scripts/triage-apply.js backlog/triage/<date>-report.md --apply
+# Review phase (read-only, default): collect → analyze → render
+node $SKILL/triage-collect.js
+node $SKILL/triage-relate.js --snapshot $SNAP --json > /tmp/relate.json
+node $SKILL/triage-stale.js  --snapshot $SNAP --json > /tmp/stale.json
+node $SKILL/triage-report.js --snapshot $SNAP --relate /tmp/relate.json --stale /tmp/stale.json
+
+# Apply phase (opt-in): review the report, check accepted proposals, then
+node $SKILL/triage-apply.js backlog/triage/<date>-report.md --apply
 ```
 
 Use `dev-backlog` when you know what to work on; use `backlog-triage` when the open-issue list has grown faster than your attention.

--- a/skills/backlog-triage/SKILL.md
+++ b/skills/backlog-triage/SKILL.md
@@ -110,7 +110,9 @@ anchor + checkbox + rationale per item.
 Unplanned issues grouped into candidate next sprints.
 
 ## Apply Checklist
-Summary of every anchored action. This is the surface the apply step reads.
+Consolidated list of every anchored action for scan-and-check review. The apply step parses
+the whole report and dedupes by `(verb, issueNumber, normalizedArgs)` — this section and the
+source sections above both count as acceptance surfaces (see `references/apply.md`).
 ```
 
 ---

--- a/skills/backlog-triage/references/apply.md
+++ b/skills/backlog-triage/references/apply.md
@@ -126,10 +126,14 @@ The renderer emits anchor+checkbox pairs in four sections:
 - `## Obsolete Candidates` — source section with evidence sub-bullet
 - `## Priority Proposals` — source section with rationale
 - `## Milestone Suggestions` — source section grouped by sprint/cluster
-- `## Apply Checklist` — flattened summary; this is the surface the apply step (#65) reads
+- `## Apply Checklist` — flattened summary for humans reviewing all proposed mutations in one place
 
-Every proposal emitted in a source section is re-emitted in `## Apply Checklist` as an anchor+checkbox pair so #65 has a single, stable surface to parse without needing to know the source-section layout. This is intentional duplication — the same action anchor appears twice in the report.
+Every proposal emitted in a source section is re-emitted in `## Apply Checklist` as an anchor+checkbox pair. This is intentional duplication — the same action anchor appears twice in the report.
+
+`triage-apply.js` does **not** restrict parsing to `## Apply Checklist`. Its `parseReport()` walk accepts any valid anchor+checkbox pair anywhere in the report, then `dedupActions()` collapses repeated proposals into one action before execution. `## Apply Checklist` is still the canonical review summary, but not the only parse surface.
 
 ### Deduplication rule for the apply step
 
-Because the same action anchor appears in both its source section and the Apply Checklist, #65 must deduplicate by the tuple `(verb, issueNumber, normalizedArgs)` before executing. A user may check the box in either location to accept the action; #65 accepts the action when the box is checked in *any* location carrying that anchor.
+Because the same action anchor appears in both its source section and the Apply Checklist, `triage-apply.js` deduplicates by `(verb, issueNumber, normalizedArgs)`, where `normalizedArgs` means sorted keys with trimmed string values before stable serialization.
+
+A user may check the box in either location to accept the action; the deduped action is treated as accepted when *any* occurrence of that anchor is checked. Unknown verbs still parse, but `triage-apply.js` logs and skips them during execution.

--- a/skills/backlog-triage/scripts/triage-report.js
+++ b/skills/backlog-triage/scripts/triage-report.js
@@ -580,7 +580,7 @@ function renderMilestoneSuggestions(actions) {
 function renderApplyChecklist(actions) {
   const lines = [
     "## Apply Checklist",
-    "Anchored surface the apply step (#65) reads. Each entry is the anchor+checkbox pair; flip `[ ]` → `[x]` to accept.",
+    "Consolidated list of every anchored action for scan-and-check review. Flip `[ ]` → `[x]` to accept. The apply step parses the whole report and dedupes — a checkbox in *any* location carrying the anchor accepts the action.",
   ];
 
   if (actions.length === 0) {

--- a/skills/dev-backlog/SKILL.md
+++ b/skills/dev-backlog/SKILL.md
@@ -4,12 +4,14 @@ argument-hint: "[orient|plan|work|next|sync] [issue-number]"
 description: Manage development work through GitHub Issues + local sprint files. Issues/Milestones are the source of truth; local sprint files handle execution — batching, ordering, context, and progress. Use for creating issues, planning sprints, checking what to work on, reviewing progress, syncing with GitHub, managing milestones, backlog, 다음 작업, 이슈 만들어, 스프린트 계획, 백로그.
 compatibility: Requires gh CLI and git. Works on Claude Code and Codex.
 metadata:
-  related-skills: "relay, relay-plan, relay-dispatch, relay-review, relay-merge"
+  related-skills: "backlog-triage, relay, relay-plan, relay-dispatch, relay-review, relay-merge"
 ---
 
 # Dev Backlog
 
 README covers install and human quick start. This skill file is the execution contract for agents: file roles, sprint structure, process, and script behavior.
+
+Related skill: [`backlog-triage`](../backlog-triage/SKILL.md) for weekly backlog grooming before you plan the next sprint.
 
 Two layers, each with a clear job:
 
@@ -214,6 +216,7 @@ Full process details: `references/process.md` (Orient, Create, Plan, Work, Compl
 - `references/github-sync.md` — `gh` CLI patterns: label setup, milestone management, sync commands
 - `references/workflow-patterns.md` — Sprint planning, bug triage, feature breakdown, retrospective
 - `references/integration-contract.md` — dev-relay ↔ dev-backlog interop surface: file paths, sections, regex patterns
+- [`../backlog-triage/SKILL.md`](../backlog-triage/SKILL.md) — sibling skill for weekly backlog review before sprint planning
 
 ## Scripts (deterministic, no LLM needed)
 

--- a/skills/dev-backlog/references/workflow-patterns.md
+++ b/skills/dev-backlog/references/workflow-patterns.md
@@ -93,9 +93,17 @@ It classifies the open issue set, surfaces relationships, flags stale or obsolet
 Use it when the backlog needs cleanup before sprint planning, not when you are already executing an active sprint.
 
 ```bash
-node /path/to/dev-backlog/skills/backlog-triage/scripts/triage-collect.js
-node /path/to/dev-backlog/skills/backlog-triage/scripts/triage-report.js --snapshot backlog/triage/.cache/<ts>.json
-node /path/to/dev-backlog/skills/backlog-triage/scripts/triage-apply.js backlog/triage/<date>-report.md --apply
+SKILL=/path/to/dev-backlog/skills/backlog-triage/scripts
+SNAP=backlog/triage/.cache/<ts>.json
+
+# Review phase (read-only): collect → analyze → render
+node $SKILL/triage-collect.js
+node $SKILL/triage-relate.js --snapshot $SNAP --json > /tmp/relate.json
+node $SKILL/triage-stale.js  --snapshot $SNAP --json > /tmp/stale.json
+node $SKILL/triage-report.js --snapshot $SNAP --relate /tmp/relate.json --stale /tmp/stale.json
+
+# Apply phase (opt-in): check proposals in the report, then
+node $SKILL/triage-apply.js backlog/triage/<date>-report.md --apply
 ```
 
 ### Manual fallback

--- a/skills/dev-backlog/references/workflow-patterns.md
+++ b/skills/dev-backlog/references/workflow-patterns.md
@@ -87,13 +87,26 @@ Quick workflow for incoming bugs:
 
 ## Backlog Review
 
-Weekly or bi-weekly cleanup:
+For weekly or bi-weekly grooming, use the [`backlog-triage`](../../backlog-triage/SKILL.md) skill.
+
+It classifies the open issue set, surfaces relationships, flags stale or obsolete candidates, and proposes priority or milestone updates in one reviewable report.
+Use it when the backlog needs cleanup before sprint planning, not when you are already executing an active sprint.
+
+```bash
+node /path/to/dev-backlog/skills/backlog-triage/scripts/triage-collect.js
+node /path/to/dev-backlog/skills/backlog-triage/scripts/triage-report.js --snapshot backlog/triage/.cache/<ts>.json
+node /path/to/dev-backlog/skills/backlog-triage/scripts/triage-apply.js backlog/triage/<date>-report.md --apply
+```
+
+### Manual fallback
+
+Use this when the sibling skill is not installed and you need a plain `gh`-only review:
 
 1. `gh issue list --state open` — scan all open issues
 2. Close stale: `gh issue close <N> -c "No longer relevant"`
 3. Re-prioritize: adjust priority labels
 4. Check `status:blocked` — blocker resolved?
-5. Assign unplanned issues to upcoming milestone
+5. Assign unplanned issues to an upcoming milestone
 
 ```bash
 # Issues without milestone (unplanned)


### PR DESCRIPTION
## Summary

Closes the final batch of epic #59. Docs-only PR wiring the backlog-triage skill into dev-backlog's workflow surface.

- \`skills/dev-backlog/references/workflow-patterns.md\` — Backlog Review section rewritten to delegate to the \`backlog-triage\` skill with the 3-command preview; prior manual \`gh\` checklist preserved under a labeled **Manual fallback** subsection
- \`skills/dev-backlog/SKILL.md\` — added a related-skills cross-link to \`skills/backlog-triage/SKILL.md\`
- \`skills/backlog-triage/references/apply.md\` — minor consistency polish vs the shipped \`triage-apply.js\` dedup contract
- README + four \`references/*.md\` purpose statements verified intact (AC #1 and AC #3 baselines — locked by rubric prereqs)
- Dangling-link walker (contract factor 2) clean across all 8 in-scope files

Closes #66. **Closes epic #59.**

## Test plan

- [ ] \`node --test skills/dev-backlog/scripts/*.test.js skills/backlog-triage/scripts/*.test.js\` — no regressions (docs only)
- [ ] Rubric: all 4 prerequisites + 2 contract factors (automated) + 2 quality factors scored
- [ ] Link walker across README, both SKILL.md files, workflow-patterns.md, and 4 references files returns zero dangling

🤖 Dispatched via relay — executor: codex, run: \`issue-66-20260418081822000\`