### PR TITLE
fix(backlog-triage): exclude progress issues from triage snapshots

### DIFF
--- a/skills/backlog-triage/scripts/__fixtures__/triage-collect/open-issues.json
+++ b/skills/backlog-triage/scripts/__fixtures__/triage-collect/open-issues.json
@@ -1,0 +1,25 @@
+[
+  {
+    "number": 78,
+    "title": "fix(backlog-triage): exclude progress issues from open-issue snapshot",
+    "body": "<!-- dev-backlog:progress-issue month=2026-04 -->\n\n# Progress: April 2026",
+    "labels": [
+      { "name": "type:chore" }
+    ],
+    "createdAt": "2026-04-01T00:00:00.000Z",
+    "updatedAt": "2026-04-18T00:00:00.000Z",
+    "milestone": null
+  },
+  {
+    "number": 79,
+    "title": "fix(backlog-triage): preserve conventional commit prefixes in report titles",
+    "body": "Normal issue body",
+    "labels": [
+      { "name": "type:bug" },
+      { "name": "priority:high" }
+    ],
+    "createdAt": "2026-04-10T00:00:00.000Z",
+    "updatedAt": "2026-04-18T00:00:00.000Z",
+    "milestone": null
+  }
+]

--- a/skills/backlog-triage/scripts/triage-collect.js
+++ b/skills/backlog-triage/scripts/triage-collect.js
@@ -7,6 +7,7 @@ const {
   fetchOpenIssues,
   readTriageConfig,
 } = require("../../dev-backlog/scripts/lib");
+const { parseMarkerMonth } = require("../../dev-backlog/scripts/progress-sync-render");
 
 const CONFIG_PATH = path.join("backlog", "triage-config.yml");
 const SNAPSHOT_DIR = path.join("backlog", "triage", ".cache");
@@ -201,12 +202,18 @@ function classifyIssue(issue, { generated, config }) {
   };
 }
 
+function isProgressIssue(issue) {
+  return parseMarkerMonth(issue?.body) !== null;
+}
+
 function buildSnapshot({ issues, repo, generated, configPath = CONFIG_PATH, config }) {
   return {
     generated,
     repo,
     config_path: configPath,
-    issues: issues.map((issue) => classifyIssue(issue, { generated, config })),
+    issues: issues
+      .filter((issue) => !isProgressIssue(issue))
+      .map((issue) => classifyIssue(issue, { generated, config })),
   };
 }
 
@@ -297,6 +304,7 @@ module.exports = {
   classifyAge,
   classifyActivity,
   classifyIssue,
+  isProgressIssue,
   buildSnapshot,
   formatSnapshotFilename,
   writeSnapshot,

--- a/skills/backlog-triage/scripts/triage-collect.test.js
+++ b/skills/backlog-triage/scripts/triage-collect.test.js
@@ -3,6 +3,7 @@ const assert = require("node:assert/strict");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
+
 const {
   parseArgs,
   parseRepoFromRemoteUrl,
@@ -13,6 +14,7 @@ const {
 } = require("./triage-collect.js");
 
 const GENERATED = "2026-04-18T01:30:00.000Z";
+const FIXTURE_PATH = path.join(__dirname, "__fixtures__", "triage-collect", "open-issues.json");
 const CONFIG = {
   theme_keywords: {
     auth: ["auth", "oauth", "token"],
@@ -25,6 +27,10 @@ const CONFIG = {
   stale_days: 60,
   duplicate_threshold: 0.75,
 };
+
+function loadFixtureIssues() {
+  return JSON.parse(fs.readFileSync(FIXTURE_PATH, "utf-8"));
+}
 
 function makeIssue(overrides = {}) {
   return {
@@ -259,6 +265,25 @@ describe("collectSnapshot", () => {
 
     assert.equal(result.snapshotPath, null);
     assert.deepEqual(fs.readdirSync(snapshotDir), []);
+  });
+
+  it("excludes dev-backlog progress issues from the snapshot", () => {
+    const execFile = () => JSON.stringify(loadFixtureIssues());
+
+    const result = collectSnapshot({
+      repo: "sungjunlee/dev-backlog",
+      dryRun: true,
+      execFile,
+      config: CONFIG,
+      generated: GENERATED,
+      snapshotDir,
+    });
+
+    assert.deepEqual(
+      result.snapshot.issues.map((issue) => issue.number),
+      [79]
+    );
+    assert.equal(result.snapshot.issues[0].title, "fix(backlog-triage): preserve conventional commit prefixes in report titles");
   });
 
   it("detects the default repo from git remote get-url origin when --repo is omitted", () => {


### PR DESCRIPTION
## Summary
- exclude `<!-- dev-backlog:progress-issue ... -->` issues from `triage-collect` snapshots
- reuse the existing `dev-backlog` marker parser to keep the interop contract single-sourced
- add a fixture-backed regression test for mixed open-issue results

## Testing
- node --test skills/dev-backlog/scripts/*.test.js skills/backlog-triage/scripts/*.test.js

Closes #78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Tests**
  * 스냅샷 수집 기능에 대한 테스트 케이스 추가

* **Chores**
  * 내부 이슈 필터링 로직 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->