### PR TITLE
fix(backlog-triage): preserve meaningful title text in triage tables

### DIFF
--- a/skills/backlog-triage/scripts/triage-report.js
+++ b/skills/backlog-triage/scripts/triage-report.js
@@ -163,8 +163,10 @@ function issueRef(issue) {
 
 function shortText(text, maxLength = 140) {
   const normalized = String(text || "").replace(/\s+/g, " ").trim();
-  if (normalized.length <= maxLength) return normalized;
-  return `${normalized.slice(0, maxLength - 1)}…`;
+  const stripped = normalized.replace(/^[a-z]+(\([^)]*\))?!?:\s*/i, "");
+  const displayText = stripped || normalized;
+  if (displayText.length <= maxLength) return displayText;
+  return `${displayText.slice(0, maxLength - 1)}…`;
 }
 
 function buildIssueIndex(snapshot) {

--- a/skills/backlog-triage/scripts/triage-report.test.js
+++ b/skills/backlog-triage/scripts/triage-report.test.js
@@ -233,6 +233,37 @@ describe("renderer helpers", () => {
     assert.match(markdown, /## Relationships[\s\S]*_\(no input provided\)_/);
     assert.match(markdown, /## Obsolete Candidates[\s\S]*_\(no input provided\)_/);
   });
+
+  it("strips conventional-commit prefixes before truncating issue titles in classification tables", () => {
+    const snapshot = makeSnapshot();
+    snapshot.issues.push({
+      number: 107,
+      title: "feat(foo): the important part is here because the keyword should stay visible in the table",
+      body: "Long title regression case.",
+      labels: ["type:feature"],
+      createdAt: "2026-04-12T01:30:00.000Z",
+      updatedAt: "2026-04-17T01:30:00.000Z",
+      milestone: null,
+      buckets: {
+        label: { type: "feature", priority: "medium", status: "todo" },
+        theme: "auth",
+        age: "7-30d",
+        activity: "recent",
+        milestone: "unassigned",
+      },
+    });
+
+    const model = buildReportModel({
+      snapshot,
+      snapshotPath: "fixtures/snapshot.json",
+      relate: null,
+      stale: null,
+    });
+
+    const markdown = renderReport(model);
+    assert.match(markdown, /#107 the important part is here because the keyword /);
+    assert.doesNotMatch(markdown, /#107 feat\(foo\):/);
+  });
 });
 
 describe("triage-report integration chain", () => {


### PR DESCRIPTION
## Summary
- strip conventional-commit prefixes before truncating titles in triage classification tables
- keep a fallback to the normalized title if stripping would produce an empty string
- add a regression test that asserts the rendered report keeps the meaningful title words visible

## Testing
- node --test skills/dev-backlog/scripts/*.test.js skills/backlog-triage/scripts/*.test.js

Closes #79