### PR TITLE
feat(backlog-triage): add snapshot v2 collector

### DIFF
--- a/skills/backlog-triage/references/classification.md
+++ b/skills/backlog-triage/references/classification.md
@@ -11,6 +11,9 @@ theme_keywords:
 activity_days:
   warm: 14
   cold: 60
+comment_fetch_concurrency: 5
+closed_issue_days: 180
+closed_issue_limit: 200
 stale_days: 60
 duplicate_threshold: 0.75
 ```
@@ -18,6 +21,9 @@ duplicate_threshold: 0.75
 - `theme_keywords` maps a theme name to title-keyword substrings. The first matching theme wins.
 - `activity_days.warm` is the exclusive upper bound for the `recent` bucket.
 - `activity_days.cold` is the exclusive upper bound for the `warm` bucket.
+- `comment_fetch_concurrency` bounds `--with-comments` fan-out when comment hydration is enabled.
+- `closed_issue_days` bounds the lookback window for `--with-closed-issues`.
+- `closed_issue_limit` caps how many recent closed issues are collected for snapshot v2 enrichment.
 - `stale_days` and `duplicate_threshold` are collected as config-as-data for downstream scripts (`triage-stale`, `triage-relate`); `triage-collect` does not apply them yet.
 
 ## Per-issue snapshot shape
@@ -33,11 +39,29 @@ Each entry in `snapshot.issues` has:
   "createdAt": "...",
   "updatedAt": "...",
   "milestone": "Backlog Triage MVP" | null,
+  "closing_prs": [{ "number": 87, "state": "MERGED", "mergedAt": "...", "url": "..." }],
+  "comments": [{ "author": "octocat", "body": "...", "createdAt": "..." }],
   "buckets": { "label": {...}, "theme": "...", "age": "...", "activity": "...", "milestone": "assigned" | "unassigned" }
 }
 ```
 
 `body` is always a string — empty (`""`) when `gh` returns null or the field is missing, never `undefined`. Downstream scripts (`triage-relate` today, and future `triage-stale` follow-ups if code-reference signals are added later) rely on body being present so they never need to re-fetch from `gh`.
+
+`closing_prs` is always present and defaults to `[]`. It comes from GraphQL `closedByPullRequestsReferences`, so downstream analysis can distinguish issues already covered by merged PRs without a second fetch.
+
+`comments` is optional and appears only when `triage-collect.js` runs with `--with-comments`. The default path stays at one GraphQL collection pass; comment hydration is an explicit cost/performance tradeoff.
+
+Snapshot v2 may also add a top-level `closed_issues` array when `--with-closed-issues` is enabled:
+
+```json
+{
+  "closed_issues": [
+    { "number": 55, "title": "...", "body": "...", "closedAt": "..." }
+  ]
+}
+```
+
+This enrichment is opt-in and bounded by `closed_issue_days` and `closed_issue_limit` so the default advisory loop remains cheap.
 
 ## Bucketing rules
 

--- a/skills/backlog-triage/scripts/triage-collect.js
+++ b/skills/backlog-triage/scripts/triage-collect.js
@@ -4,7 +4,7 @@ const { execFileSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const {
-  fetchOpenIssues,
+  GH_EXEC_DEFAULTS,
   readTriageConfig,
 } = require("../../dev-backlog/scripts/lib");
 const { parseMarkerMonth } = require("../../dev-backlog/scripts/progress-sync-render");
@@ -12,6 +12,63 @@ const { parseMarkerMonth } = require("../../dev-backlog/scripts/progress-sync-re
 const CONFIG_PATH = path.join("backlog", "triage-config.yml");
 const SNAPSHOT_DIR = path.join("backlog", "triage", ".cache");
 const TRIAGE_DEFAULT_FETCH_LIMIT = 2147483647;
+const GRAPHQL_PAGE_SIZE = 100;
+const DEFAULT_CLOSED_ISSUE_DAYS = 180;
+const DEFAULT_CLOSED_ISSUE_LIMIT = 200;
+const DEFAULT_COMMENT_FETCH_CONCURRENCY = 5;
+const OPEN_ISSUES_QUERY = `
+  query($owner: String!, $name: String!, $pageSize: Int!, $endCursor: String) {
+    repository(owner: $owner, name: $name) {
+      issues(states: OPEN, first: $pageSize, after: $endCursor, orderBy: { field: CREATED_AT, direction: ASC }) {
+        nodes {
+          number
+          title
+          body
+          createdAt
+          updatedAt
+          milestone {
+            title
+          }
+          labels(first: 100) {
+            nodes {
+              name
+            }
+          }
+          closedByPullRequestsReferences(first: 5, includeClosedPrs: true) {
+            nodes {
+              number
+              state
+              mergedAt
+              url
+            }
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+`;
+const CLOSED_ISSUES_QUERY = `
+  query($searchQuery: String!, $pageSize: Int!, $endCursor: String) {
+    search(type: ISSUE, query: $searchQuery, first: $pageSize, after: $endCursor) {
+      nodes {
+        ... on Issue {
+          number
+          title
+          body
+          closedAt
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`;
 
 function parseLimitValue(value) {
   if (!/^\d+$/.test(value)) {
@@ -30,6 +87,8 @@ function parseArgs(args) {
   const options = {
     repo: undefined,
     limit: undefined,
+    withComments: false,
+    withClosedIssues: false,
     json: false,
     dryRun: false,
   };
@@ -44,6 +103,16 @@ function parseArgs(args) {
 
     if (arg === "--dry-run") {
       options.dryRun = true;
+      continue;
+    }
+
+    if (arg === "--with-comments") {
+      options.withComments = true;
+      continue;
+    }
+
+    if (arg === "--with-closed-issues") {
+      options.withClosedIssues = true;
       continue;
     }
 
@@ -120,6 +189,255 @@ function detectRepo(execFile = execFileSync) {
   return repo;
 }
 
+function parseRepoParts(repo) {
+  const [owner, name] = String(repo || "").split("/");
+  if (!owner || !name) {
+    throw new Error(`Invalid repo value: ${repo}. Expected OWNER/REPO.`);
+  }
+  return { owner, name };
+}
+
+function splitJsonDocuments(raw) {
+  const text = String(raw || "").trim();
+  if (!text) return [];
+
+  try {
+    return [JSON.parse(text)];
+  } catch {
+    const documents = [];
+    let start = null;
+    let depth = 0;
+    let inString = false;
+    let isEscaped = false;
+
+    for (let index = 0; index < text.length; index += 1) {
+      const char = text[index];
+
+      if (inString) {
+        if (isEscaped) {
+          isEscaped = false;
+          continue;
+        }
+        if (char === "\\") {
+          isEscaped = true;
+          continue;
+        }
+        if (char === "\"") {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (char === "\"") {
+        inString = true;
+        continue;
+      }
+
+      if (char === "{") {
+        if (depth === 0) start = index;
+        depth += 1;
+        continue;
+      }
+
+      if (char === "}") {
+        depth -= 1;
+        if (depth < 0) {
+          throw new Error("Failed to parse paginated gh output: unmatched closing brace.");
+        }
+        if (depth === 0 && start !== null) {
+          documents.push(JSON.parse(text.slice(start, index + 1)));
+          start = null;
+        }
+      }
+    }
+
+    if (inString || depth !== 0 || documents.length === 0) {
+      throw new Error("Failed to parse paginated gh output: incomplete JSON document stream.");
+    }
+
+    return documents;
+  }
+}
+
+function normalizeClosingPrs(closingPrs) {
+  const nodes = closingPrs?.nodes || [];
+  return nodes.map((pr) => ({
+    number: pr.number,
+    state: pr.state,
+    mergedAt: pr.mergedAt || null,
+    url: pr.url || null,
+  }));
+}
+
+function normalizeOpenIssueNode(issue) {
+  return {
+    number: issue.number,
+    title: issue.title,
+    body: typeof issue.body === "string" ? issue.body : "",
+    labels: (issue.labels?.nodes || []).map((label) => label.name),
+    createdAt: issue.createdAt,
+    updatedAt: issue.updatedAt,
+    milestone: issue.milestone ? { title: issue.milestone.title } : null,
+    closing_prs: normalizeClosingPrs(issue.closedByPullRequestsReferences),
+  };
+}
+
+function graphqlArgs(query, variables, { paginate = false } = {}) {
+  const args = ["api", "graphql"];
+  for (const [key, value] of Object.entries(variables)) {
+    args.push("-F", `${key}=${value}`);
+  }
+  args.push("-f", `query=${query}`);
+  if (paginate) args.push("--paginate");
+  return args;
+}
+
+function fetchOpenIssuesGraphql({ repo, limit, execFile = execFileSync }) {
+  const resolvedLimit = limit ?? TRIAGE_DEFAULT_FETCH_LIMIT;
+  if (resolvedLimit === 0) return [];
+
+  const { owner, name } = parseRepoParts(repo);
+  const pageSize = Math.min(resolvedLimit, GRAPHQL_PAGE_SIZE);
+  const paginate = resolvedLimit > GRAPHQL_PAGE_SIZE || resolvedLimit === TRIAGE_DEFAULT_FETCH_LIMIT;
+  const output = execFile(
+    "gh",
+    graphqlArgs(
+      OPEN_ISSUES_QUERY,
+      { owner, name, pageSize },
+      { paginate }
+    ),
+    GH_EXEC_DEFAULTS
+  );
+
+  return splitJsonDocuments(output)
+    .flatMap((page) => page?.data?.repository?.issues?.nodes || [])
+    .map(normalizeOpenIssueNode)
+    .slice(0, resolvedLimit);
+}
+
+function parsePaginatedApiArray(output) {
+  const text = String(output || "").trim();
+  if (!text) return [];
+
+  try {
+    const parsed = JSON.parse(text);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {}
+
+  try {
+    const parsed = JSON.parse(`[${text.replace(/\]\s*\[/g, "],[")}]`);
+    return parsed.flatMap((page) => (Array.isArray(page) ? page : [page]));
+  } catch (error) {
+    throw new Error(`Failed to parse paginated gh array output: ${error.message}`);
+  }
+}
+
+function normalizeIssueComments(comments) {
+  return comments.map((comment) => ({
+    author: comment.user?.login || comment.author?.login || null,
+    body: typeof comment.body === "string" ? comment.body : "",
+    createdAt: comment.created_at || comment.createdAt || null,
+  }));
+}
+
+function fetchIssueComments({ repo, issueNumber, execFile = execFileSync }) {
+  const { owner, name } = parseRepoParts(repo);
+  const output = execFile(
+    "gh",
+    [
+      "api",
+      `repos/${owner}/${name}/issues/${issueNumber}/comments`,
+      "--paginate",
+    ],
+    GH_EXEC_DEFAULTS
+  );
+  return normalizeIssueComments(parsePaginatedApiArray(output));
+}
+
+async function mapWithConcurrency(items, limit, mapper) {
+  const results = new Array(items.length);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < items.length) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      results[currentIndex] = await mapper(items[currentIndex], currentIndex);
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(limit, items.length) }, () => worker());
+  await Promise.all(workers);
+  return results;
+}
+
+async function enrichIssuesWithComments({ repo, issues, execFile, concurrency }) {
+  if (issues.length === 0) return issues;
+  const commentsByIssue = await mapWithConcurrency(
+    issues,
+    Math.max(1, concurrency),
+    async (issue) => fetchIssueComments({ repo, issueNumber: issue.number, execFile })
+  );
+
+  return issues.map((issue, index) => ({
+    ...issue,
+    comments: commentsByIssue[index],
+  }));
+}
+
+function resolveClosedIssueDays(config) {
+  const configured = Number(config?.closed_issue_days);
+  if (Number.isSafeInteger(configured) && configured > 0) return configured;
+  return DEFAULT_CLOSED_ISSUE_DAYS;
+}
+
+function resolveClosedIssueLimit(config) {
+  const configured = Number(config?.closed_issue_limit);
+  if (Number.isSafeInteger(configured) && configured > 0) return configured;
+  return DEFAULT_CLOSED_ISSUE_LIMIT;
+}
+
+function resolveCommentFetchConcurrency(config) {
+  const configured = Number(config?.comment_fetch_concurrency);
+  if (Number.isSafeInteger(configured) && configured > 0) return configured;
+  return DEFAULT_COMMENT_FETCH_CONCURRENCY;
+}
+
+function isoDateDaysAgo(generated, days) {
+  const date = new Date(generated);
+  date.setUTCDate(date.getUTCDate() - days);
+  return date.toISOString().slice(0, 10);
+}
+
+function fetchClosedIssues({ repo, generated, config, execFile = execFileSync }) {
+  const closedIssueLimit = resolveClosedIssueLimit(config);
+  const searchQuery = [
+    `repo:${repo}`,
+    "is:issue",
+    "is:closed",
+    `closed:>=${isoDateDaysAgo(generated, resolveClosedIssueDays(config))}`,
+  ].join(" ");
+  const output = execFile(
+    "gh",
+    graphqlArgs(
+      CLOSED_ISSUES_QUERY,
+      { searchQuery, pageSize: Math.min(closedIssueLimit, GRAPHQL_PAGE_SIZE) },
+      { paginate: closedIssueLimit > GRAPHQL_PAGE_SIZE }
+    ),
+    GH_EXEC_DEFAULTS
+  );
+
+  return splitJsonDocuments(output)
+    .flatMap((page) => page?.data?.search?.nodes || [])
+    .map((issue) => ({
+      number: issue.number,
+      title: issue.title,
+      body: typeof issue.body === "string" ? issue.body : "",
+      closedAt: issue.closedAt || null,
+    }))
+    .slice(0, closedIssueLimit);
+}
+
 function normalizeLabels(labels) {
   return (labels || [])
     .map((label) => (typeof label === "string" ? label : label?.name))
@@ -192,6 +510,7 @@ function classifyIssue(issue, { generated, config }) {
     createdAt: issue.createdAt,
     updatedAt: issue.updatedAt,
     milestone,
+    closing_prs: Array.isArray(issue.closing_prs) ? issue.closing_prs : [],
     buckets: {
       label: classifyLabelBuckets(labels),
       theme: classifyTheme(issue.title, config),
@@ -199,6 +518,7 @@ function classifyIssue(issue, { generated, config }) {
       activity: classifyActivity(issue.updatedAt, generated, config.activity_days),
       milestone: milestone ? "assigned" : "unassigned",
     },
+    ...(Array.isArray(issue.comments) ? { comments: issue.comments } : {}),
   };
 }
 
@@ -206,8 +526,8 @@ function isProgressIssue(issue) {
   return parseMarkerMonth(issue?.body) !== null;
 }
 
-function buildSnapshot({ issues, repo, generated, configPath = CONFIG_PATH, config }) {
-  return {
+function buildSnapshot({ issues, repo, generated, configPath = CONFIG_PATH, config, closedIssues }) {
+  const snapshot = {
     generated,
     repo,
     config_path: configPath,
@@ -215,6 +535,12 @@ function buildSnapshot({ issues, repo, generated, configPath = CONFIG_PATH, conf
       .filter((issue) => !isProgressIssue(issue))
       .map((issue) => classifyIssue(issue, { generated, config })),
   };
+
+  if (Array.isArray(closedIssues)) {
+    snapshot.closed_issues = closedIssues;
+  }
+
+  return snapshot;
 }
 
 function formatSnapshotFilename(generated) {
@@ -229,9 +555,19 @@ function writeSnapshot(snapshot, snapshotDir = SNAPSHOT_DIR) {
   return filePath;
 }
 
-function collectSnapshot({
+function buildWarnings({ withComments, issueCount, config }) {
+  if (!withComments) return [];
+  const concurrency = resolveCommentFetchConcurrency(config);
+  return [
+    `--with-comments enabled: fetching issue comments adds ${issueCount} gh API calls (concurrency ${concurrency}).`,
+  ];
+}
+
+async function collectSnapshot({
   repo,
   limit,
+  withComments = false,
+  withClosedIssues = false,
   dryRun = false,
   execFile = execFileSync,
   generated = new Date().toISOString(),
@@ -241,27 +577,45 @@ function collectSnapshot({
 } = {}) {
   const resolvedRepo = repo || detectRepo(execFile);
   const triageConfig = config || readTriageConfig("backlog");
-  const issues = fetchOpenIssues({
+  const issues = fetchOpenIssuesGraphql({
     repo: resolvedRepo,
     limit,
-    defaultLimit: TRIAGE_DEFAULT_FETCH_LIMIT,
     execFile,
   });
+  const candidateIssues = issues.filter((issue) => !isProgressIssue(issue));
+  const issuesWithComments = withComments
+    ? await enrichIssuesWithComments({
+      repo: resolvedRepo,
+      issues: candidateIssues,
+      execFile,
+      concurrency: resolveCommentFetchConcurrency(triageConfig),
+    })
+    : candidateIssues;
+  const closedIssues = withClosedIssues
+    ? fetchClosedIssues({
+      repo: resolvedRepo,
+      generated,
+      config: triageConfig,
+      execFile,
+    })
+    : undefined;
   const snapshot = buildSnapshot({
-    issues,
+    issues: issuesWithComments,
     repo: resolvedRepo,
     generated,
     configPath,
     config: triageConfig,
+    closedIssues,
   });
 
   return {
     snapshot,
     snapshotPath: dryRun ? null : writeSnapshot(snapshot, snapshotDir),
+    warnings: buildWarnings({ withComments, issueCount: candidateIssues.length, config: triageConfig }),
   };
 }
 
-function main() {
+async function main() {
   const options = parseArgs(process.argv.slice(2));
   if (options.error) {
     console.error(options.error);
@@ -270,7 +624,7 @@ function main() {
 
   let result;
   try {
-    result = collectSnapshot(options);
+    result = await collectSnapshot(options);
   } catch (error) {
     console.error(error.message);
     process.exit(1);
@@ -282,23 +636,47 @@ function main() {
   }
 
   if (options.dryRun) {
+    for (const warning of result.warnings || []) {
+      console.error(`[warn] ${warning}`);
+    }
     console.log(
       `[dry-run] Collected ${result.snapshot.issues.length} open issues for ${result.snapshot.repo}.`
     );
     return;
   }
 
+  for (const warning of result.warnings || []) {
+    console.error(`[warn] ${warning}`);
+  }
   console.log(
     `Wrote ${result.snapshot.issues.length} open issues to ${result.snapshotPath}.`
   );
 }
 
-if (require.main === module) main();
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}
 
 module.exports = {
+  GRAPHQL_PAGE_SIZE,
+  DEFAULT_CLOSED_ISSUE_DAYS,
+  DEFAULT_CLOSED_ISSUE_LIMIT,
+  DEFAULT_COMMENT_FETCH_CONCURRENCY,
+  OPEN_ISSUES_QUERY,
+  CLOSED_ISSUES_QUERY,
   parseArgs,
   parseRepoFromRemoteUrl,
+  parseRepoParts,
   detectRepo,
+  splitJsonDocuments,
+  normalizeOpenIssueNode,
+  normalizeIssueComments,
+  fetchOpenIssuesGraphql,
+  fetchIssueComments,
+  fetchClosedIssues,
   classifyLabelBuckets,
   classifyTheme,
   classifyAge,

--- a/skills/backlog-triage/scripts/triage-collect.test.js
+++ b/skills/backlog-triage/scripts/triage-collect.test.js
@@ -36,22 +36,86 @@ function makeIssue(overrides = {}) {
   return {
     number: 61,
     title: "feat(backlog-triage): collect + classify open issues",
+    body: "Issue body",
     labels: [],
     createdAt: "2026-04-17T01:30:00.000Z",
     updatedAt: "2026-04-17T01:30:00.000Z",
     milestone: null,
+    closing_prs: [],
     ...overrides,
   };
 }
 
+function toGraphqlOpenIssue(issue) {
+  return {
+    number: issue.number,
+    title: issue.title,
+    body: issue.body,
+    createdAt: issue.createdAt,
+    updatedAt: issue.updatedAt,
+    milestone: issue.milestone,
+    labels: {
+      nodes: (issue.labels || []).map((label) => (
+        typeof label === "string" ? { name: label } : { name: label.name }
+      )),
+    },
+    closedByPullRequestsReferences: {
+      nodes: (issue.closing_prs || []).map((pr) => ({
+        number: pr.number,
+        state: pr.state,
+        mergedAt: pr.mergedAt || null,
+        url: pr.url || null,
+      })),
+    },
+  };
+}
+
+function openIssuesPage(issues, pageInfo = { hasNextPage: false, endCursor: null }) {
+  return JSON.stringify({
+    data: {
+      repository: {
+        issues: {
+          nodes: issues.map(toGraphqlOpenIssue),
+          pageInfo,
+        },
+      },
+    },
+  });
+}
+
+function closedIssuesPage(issues, pageInfo = { hasNextPage: false, endCursor: null }) {
+  return JSON.stringify({
+    data: {
+      search: {
+        nodes: issues,
+        pageInfo,
+      },
+    },
+  });
+}
+
 describe("parseArgs", () => {
-  it("parses repo, limit, json, and dry-run flags", () => {
-    assert.deepEqual(parseArgs(["--repo", "owner/repo", "--limit", "3", "--json", "--dry-run"]), {
-      repo: "owner/repo",
-      limit: 3,
-      json: true,
-      dryRun: true,
-    });
+  it("parses repo, limit, comment/closed flags, json, and dry-run flags", () => {
+    assert.deepEqual(
+      parseArgs([
+        "--repo",
+        "owner/repo",
+        "--limit",
+        "3",
+        "--with-comments",
+        "--with-closed-issues",
+        "--json",
+        "--dry-run",
+      ]),
+      {
+        repo: "owner/repo",
+        limit: 3,
+        withComments: true,
+        withClosedIssues: true,
+        json: true,
+        dryRun: true,
+      }
+    );
   });
 
   it("rejects invalid repo and limit values", () => {
@@ -207,6 +271,18 @@ describe("classifyIssue", () => {
     assert.equal(withoutBody.body, "");
     assert.equal(nullBody.body, "");
   });
+
+  it("preserves closing_prs and comments for downstream snapshot v2 consumers", () => {
+    const comments = [{ author: "octocat", body: "Tracked in #73", createdAt: GENERATED }];
+    const closingPrs = [{ number: 120, state: "MERGED", mergedAt: GENERATED, url: "https://example.com/pr/120" }];
+    const issue = classifyIssue(makeIssue({ closing_prs: closingPrs, comments }), {
+      generated: GENERATED,
+      config: CONFIG,
+    });
+
+    assert.deepEqual(issue.closing_prs, closingPrs);
+    assert.deepEqual(issue.comments, comments);
+  });
 });
 
 describe("collectSnapshot", () => {
@@ -220,17 +296,20 @@ describe("collectSnapshot", () => {
     fs.rmSync(snapshotDir, { recursive: true, force: true });
   });
 
-  it("writes a canonical snapshot with an FS-safe filename", () => {
-    const execFile = () =>
-      JSON.stringify([
+  it("writes a canonical snapshot with an FS-safe filename", async () => {
+    const calls = [];
+    const execFile = (command, args) => {
+      calls.push({ command, args });
+      return openIssuesPage([
         makeIssue({
           number: 61,
           title: "OAuth token refresh flow",
           labels: [{ name: "type:feature" }],
         }),
       ]);
+    };
 
-    const result = collectSnapshot({
+    const result = await collectSnapshot({
       repo: "sungjunlee/dev-backlog",
       limit: 1,
       execFile,
@@ -248,12 +327,28 @@ describe("collectSnapshot", () => {
     assert.equal(written.repo, "sungjunlee/dev-backlog");
     assert.equal(written.config_path, "backlog/triage-config.yml");
     assert.equal(written.issues.length, 1);
+    assert.deepEqual(written.issues[0].closing_prs, []);
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].command, "gh");
+    assert.deepEqual(calls[0].args.slice(0, 8), [
+      "api",
+      "graphql",
+      "-F",
+      "owner=sungjunlee",
+      "-F",
+      "name=dev-backlog",
+      "-F",
+      "pageSize=1",
+    ]);
+    assert.equal(calls[0].args[8], "-f");
+    assert.match(calls[0].args[9], /^query=\s*query\(/);
   });
 
-  it("honors dry-run by skipping all snapshot writes", () => {
-    const execFile = () => JSON.stringify([makeIssue()]);
+  it("honors dry-run by skipping all snapshot writes", async () => {
+    const execFile = () => openIssuesPage([makeIssue()]);
 
-    const result = collectSnapshot({
+    const result = await collectSnapshot({
       repo: "sungjunlee/dev-backlog",
       limit: 1,
       dryRun: true,
@@ -267,10 +362,10 @@ describe("collectSnapshot", () => {
     assert.deepEqual(fs.readdirSync(snapshotDir), []);
   });
 
-  it("excludes dev-backlog progress issues from the snapshot", () => {
-    const execFile = () => JSON.stringify(loadFixtureIssues());
+  it("excludes dev-backlog progress issues from the snapshot", async () => {
+    const execFile = () => openIssuesPage(loadFixtureIssues());
 
-    const result = collectSnapshot({
+    const result = await collectSnapshot({
       repo: "sungjunlee/dev-backlog",
       dryRun: true,
       execFile,
@@ -286,16 +381,16 @@ describe("collectSnapshot", () => {
     assert.equal(result.snapshot.issues[0].title, "fix(backlog-triage): preserve conventional commit prefixes in report titles");
   });
 
-  it("detects the default repo from git remote get-url origin when --repo is omitted", () => {
+  it("detects the default repo from git remote get-url origin when --repo is omitted", async () => {
     const calls = [];
     const execFile = (command, args) => {
       calls.push({ command, args });
       if (command === "git") return "git@github.com:sungjunlee/dev-backlog.git\n";
-      if (command === "gh") return JSON.stringify([makeIssue()]);
+      if (command === "gh") return openIssuesPage([makeIssue()]);
       throw new Error(`Unexpected command: ${command}`);
     };
 
-    const result = collectSnapshot({
+    const result = await collectSnapshot({
       limit: 1,
       dryRun: true,
       execFile,
@@ -306,32 +401,25 @@ describe("collectSnapshot", () => {
 
     assert.equal(result.snapshot.repo, "sungjunlee/dev-backlog");
     assert.equal(calls[0].command, "git");
-    assert.deepEqual(calls[1], {
-      command: "gh",
-      args: [
-        "issue",
-        "list",
-        "--state",
-        "open",
-        "--limit",
-        "1",
-        "--repo",
-        "sungjunlee/dev-backlog",
-        "--json",
-        "number,title,body,labels,milestone,assignees,createdAt,updatedAt",
-      ],
-    });
+    assert.deepEqual(calls[0].args, ["remote", "get-url", "origin"]);
+    assert.equal(calls[1].command, "gh");
+    assert.equal(calls[1].args[0], "api");
+    assert.equal(calls[1].args[1], "graphql");
+    assert.ok(calls[1].args.includes("owner=sungjunlee"));
+    assert.ok(calls[1].args.includes("name=dev-backlog"));
+    assert.ok(calls[1].args.includes("pageSize=1"));
+    assert.equal(calls[1].args.includes("--paginate"), false);
   });
 
-  it("uses a single gh issue list fetch when --limit is omitted", () => {
+  it("uses a single paginated gh graphql fetch when --limit is omitted", async () => {
     const calls = [];
     const execFile = (command, args) => {
       calls.push({ command, args });
-      if (command === "gh") return JSON.stringify([makeIssue()]);
+      if (command === "gh") return openIssuesPage([makeIssue()]);
       throw new Error(`Unexpected command: ${command}`);
     };
 
-    const result = collectSnapshot({
+    const result = await collectSnapshot({
       repo: "sungjunlee/dev-backlog",
       dryRun: true,
       execFile,
@@ -341,20 +429,150 @@ describe("collectSnapshot", () => {
     });
 
     assert.equal(result.snapshot.issues.length, 1);
-    assert.deepEqual(calls, [{
-      command: "gh",
-      args: [
-        "issue",
-        "list",
-        "--state",
-        "open",
-        "--limit",
-        String(TRIAGE_DEFAULT_FETCH_LIMIT),
-        "--repo",
-        "sungjunlee/dev-backlog",
-        "--json",
-        "number,title,body,labels,milestone,assignees,createdAt,updatedAt",
-      ],
-    }]);
+    assert.equal(TRIAGE_DEFAULT_FETCH_LIMIT, 2147483647);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].command, "gh");
+    assert.deepEqual(calls[0].args.slice(0, 8), [
+      "api",
+      "graphql",
+      "-F",
+      "owner=sungjunlee",
+      "-F",
+      "name=dev-backlog",
+      "-F",
+      "pageSize=100",
+    ]);
+    assert.equal(calls[0].args[8], "-f");
+    assert.match(calls[0].args[9], /^query=\s*query\(/);
+    assert.equal(calls[0].args[10], "--paginate");
+  });
+
+  it("adds normalized comments only when --with-comments is enabled", async () => {
+    const calls = [];
+    const execFile = (command, args) => {
+      calls.push({ command, args });
+      if (command !== "gh") throw new Error(`Unexpected command: ${command}`);
+
+      if (args[0] === "api" && args[1] === "graphql") {
+        return openIssuesPage([
+          makeIssue({ number: 61 }),
+          makeIssue({
+            number: 78,
+            title: "Progress: April 2026",
+            body: "<!-- dev-backlog:progress-issue month=2026-04 -->",
+          }),
+        ]);
+      }
+
+      if (args[0] === "api" && args[1] === "repos/sungjunlee/dev-backlog/issues/61/comments") {
+        return JSON.stringify([
+          {
+            user: { login: "octocat" },
+            body: "Looks good",
+            created_at: GENERATED,
+          },
+        ]);
+      }
+
+      throw new Error(`Unexpected gh args: ${args.join(" ")}`);
+    };
+
+    const result = await collectSnapshot({
+      repo: "sungjunlee/dev-backlog",
+      dryRun: true,
+      withComments: true,
+      execFile,
+      config: { ...CONFIG, comment_fetch_concurrency: 3 },
+      generated: GENERATED,
+      snapshotDir,
+    });
+
+    assert.deepEqual(result.snapshot.issues, [
+      {
+        number: 61,
+        title: "feat(backlog-triage): collect + classify open issues",
+        body: "Issue body",
+        labels: [],
+        createdAt: "2026-04-17T01:30:00.000Z",
+        updatedAt: "2026-04-17T01:30:00.000Z",
+        milestone: null,
+        closing_prs: [],
+        comments: [{ author: "octocat", body: "Looks good", createdAt: GENERATED }],
+        buckets: {
+          label: { type: "uncategorized", priority: "medium", status: "todo" },
+          theme: "uncategorized",
+          age: "<7d",
+          activity: "recent",
+          milestone: "unassigned",
+        },
+      },
+    ]);
+    assert.deepEqual(result.warnings, [
+      "--with-comments enabled: fetching issue comments adds 1 gh API calls (concurrency 3).",
+    ]);
+    assert.equal(
+      calls.filter((call) => call.args[1] === "repos/sungjunlee/dev-backlog/issues/61/comments").length,
+      1
+    );
+    assert.equal(
+      calls.some((call) => call.args[1] === "repos/sungjunlee/dev-backlog/issues/78/comments"),
+      false
+    );
+  });
+
+  it("adds top-level closed_issues only when --with-closed-issues is enabled", async () => {
+    const calls = [];
+    const execFile = (command, args) => {
+      calls.push({ command, args });
+      if (command !== "gh") throw new Error(`Unexpected command: ${command}`);
+
+      if (args[0] === "api" && args[1] === "graphql" && args.includes("owner=sungjunlee")) {
+        return openIssuesPage([makeIssue()]);
+      }
+
+      if (args[0] === "api" && args[1] === "graphql" && args.some((arg) => arg.startsWith("searchQuery="))) {
+        return closedIssuesPage([
+          {
+            number: 55,
+            title: "Old triage follow-up",
+            body: "Closed via follow-up PR",
+            closedAt: "2026-04-10T00:00:00Z",
+          },
+        ]);
+      }
+
+      throw new Error(`Unexpected gh args: ${args.join(" ")}`);
+    };
+
+    const result = await collectSnapshot({
+      repo: "sungjunlee/dev-backlog",
+      dryRun: true,
+      withClosedIssues: true,
+      execFile,
+      config: {
+        ...CONFIG,
+        closed_issue_days: 30,
+        closed_issue_limit: 2,
+      },
+      generated: GENERATED,
+      snapshotDir,
+    });
+
+    assert.deepEqual(result.snapshot.closed_issues, [
+      {
+        number: 55,
+        title: "Old triage follow-up",
+        body: "Closed via follow-up PR",
+        closedAt: "2026-04-10T00:00:00Z",
+      },
+    ]);
+
+    const searchCall = calls.find((call) => call.args.some((arg) => arg.startsWith("searchQuery=")));
+    assert.ok(searchCall);
+    assert.ok(
+      searchCall.args.includes("searchQuery=repo:sungjunlee/dev-backlog is:issue is:closed closed:>=2026-03-19")
+    );
+    assert.ok(searchCall.args.includes("pageSize=2"));
+    assert.equal(searchCall.args.includes("--paginate"), false);
   });
 });


### PR DESCRIPTION
## Summary\n- switch triage collection to a GraphQL snapshot-v2 path with closing PR metadata\n- add opt-in comment and recent closed-issue enrichment while keeping the default path cheap\n- document the snapshot-v2 schema and extend triage-collect coverage\n\n## Testing\n- node --test skills/dev-backlog/scripts/*.test.js skills/backlog-triage/scripts/*.test.js\n\nCloses #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 스냅샷에 문제 주석 수집 기능 추가
  * 스냅샷에 종료된 이슈 포함 옵션 추가
  * 주석 병렬 처리 및 종료된 이슈 제한을 위한 설정 매개변수 추가

* **향상된 기능**
  * 스냅샷 데이터 구조에 닫는 PR 정보 추가

* **문서**
  * 설정 및 스냅샷 스키마 문서 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->