### PR TITLE
docs(backlog-charter): add good/bad verifiable-predicate examples (#95)

### DIFF
--- a/skills/backlog-charter/SKILL.md
+++ b/skills/backlog-charter/SKILL.md
@@ -50,6 +50,8 @@ Objective conventions:
 - Never reuse a removed objective ID; new objectives take the next free number.
 - Record provenance with `src:` (`user`, `inferred`, or `execution`).
 
+See `references/objectives.md` for 5 good and 5 bad worked examples, common rewrite patterns, and a 30-second predicate test.
+
 ## Amend Mode
 
 Use amend mode when `CHARTER.md` exists at the repo root, or when invoked as `backlog-charter amend`.
@@ -72,3 +74,4 @@ See `references/amendment.md` for deep challenge and proof-gate heuristics.
 
 - `references/amendment.md` — challenge checklist, proof-gate rules, no-rubber-stamp discipline, and bloat checks.
 - `references/alignment.md` — shared work↔objective mapping logic consumed by `backlog-triage` and `dev-backlog`.
+- `references/objectives.md` — verifiable-predicate examples (5 good, 5 bad), common rewrite patterns, 30-second test.

--- a/skills/backlog-charter/references/objectives.md
+++ b/skills/backlog-charter/references/objectives.md
@@ -1,0 +1,70 @@
+# Objective Predicates: Good vs. Bad
+
+Use this reference in `backlog-charter` create mode (or amend, when adding objectives) to write Tier 2 entries that survive their own proof gate. An Objective is a **verifiable predicate** — a statement that can be checked true or false against the world, not a task to do or an aspiration to feel good about.
+
+The shape:
+
+> `O<n> [status]    <verifiable predicate> · src: <user|inferred|execution>`
+
+The predicate should map to a verification path you could write down today: a command to run, a scenario to walk through, a count to take. If you cannot name the verification, the predicate is not yet verifiable — sharpen it before committing it to CHARTER.
+
+## ✅ Good Predicates
+
+Each example pairs a predicate with the concrete check that would advance its status to `validated`.
+
+1. **"A user can pull open GitHub issues into `backlog/tasks/` without API tokens beyond `gh auth`"**
+   *Verification:* run `node scripts/sync-pull.js` against a fresh repo; assert `backlog/tasks/*.md` exists and no token was prompted. A scenario predicate with a runnable check.
+
+2. **"An agent resuming a sprint mid-session sees in-flight `[~]` items it did not author and can act on them without re-asking the user"**
+   *Verification:* open the active sprint file in a fresh session; confirm `[~]` markers + PR refs are readable. A continuity predicate verified by a single observation.
+
+3. **"A user can answer 'is this project still on track?' in under 5 minutes against `CHARTER.md`"**
+   *Verification:* timed read + answer against the live CHARTER. Mixed-rigor: not a script, but a timed scenario with a binary outcome. (This is dev-backlog's own O3.)
+
+4. **"Every open Issue maps to an active or deferred Objective without manual triage"**
+   *Verification:* `backlog-triage` Alignment Check report shows 0 orphans on the current backlog. A drift predicate with an existing tool as the check.
+
+5. **"A new contributor reads `CHARTER.md` in under 5 minutes and can name one explicitly rejected scope"**
+   *Verification:* word count + Non-Goals section non-empty + onboarding scenario. Cheap to observe; sharper than "CHARTER is short."
+
+Notice the shape: each one names **who** does **what** with a **measurable outcome**. None of them say "improve" or "implement."
+
+## ❌ Bad Predicates (and How to Rewrite Them)
+
+Each failure mode appears regularly. The rewrite shows the move that fixes it.
+
+1. **"Improve sync performance"**
+   *Failure:* vague aspiration — no threshold, no observation point.
+   *Rewrite:* "`sync-pull` of 100 open issues completes in under 5s on a warm cache." Add a threshold + a fixture.
+
+2. **"Implement OAuth"**
+   *Failure:* a task, not an outcome. Closes when shipped, not when verified.
+   *Rewrite:* "A user signs in with Google and reaches their dashboard within one click of the login button." Move from build-it to user-observes-it.
+
+3. **"Better DX"**
+   *Failure:* unfalsifiable opinion. Whose DX, doing what, judged how?
+   *Rewrite:* "An agent dispatches a relay run with one command and no manual edits to manifest files." Name the actor, the action, the observable.
+
+4. **"Adopt CHARTER everywhere"**
+   *Failure:* process declaration, not a user-facing outcome. Confuses the project's internal habit with what the project produces.
+   *Rewrite:* "Every active project in this workspace has a committed `CHARTER.md` at repo root." Make it a count, not a vibe.
+
+5. **"Reduce context loss across sessions"**
+   *Failure:* direction without verification — true when? observed by whom?
+   *Rewrite:* "An agent reading only `_context.md` + the active sprint file resumes the previous session's in-flight work without asking the user." Bind the claim to a single scenario with a binary outcome.
+
+## Common Rewrite Patterns
+
+When a draft objective feels off, ask which pattern applies:
+
+| If the draft is... | The fix is... |
+|--------------------|---------------|
+| Vague aspiration ("improve", "better") | Add a threshold or a binary observation. |
+| A task ("implement X") | Restate as what the user observes when X exists. |
+| An opinion ("better DX") | Name actor + action + observable. |
+| A process declaration ("adopt Y") | Convert to a count or coverage statement. |
+| A direction ("reduce Z") | Bind to a single scenario with a yes/no outcome. |
+
+## The 30-Second Test
+
+Before committing a new Objective, read it aloud and answer: *what would I look at, right now, to decide if this is true?* If the answer is "I don't know" or "it depends on who you ask," the predicate is not yet ready. Sharpen, then commit.


### PR DESCRIPTION
Closes #95 — first task of the v0.6 polish sprint ([sprint file](backlog/sprints/2026-05-backlog-charter-v06.md), milestone #5).

## What

Adds `skills/backlog-charter/references/objectives.md`:
- **5 good predicates**, each paired with the concrete verification path that would advance it to `validated`
- **5 bad predicates** with their failure mode and a rewrite
- A common-rewrite-pattern table (vague → threshold, task → outcome, etc.)
- A 30-second predicate test

Links from `SKILL.md` Objective conventions and the References list.

## Why

Dogfooding finding from the 2026-05-23 self-application of `backlog-charter` to `dev-backlog`. `templates/charter.md` ships only one Objective example (`a user can log in with Google`); new authors easily slip into writing tasks or vague aspirations rather than verifiable predicates. The interview-checklist work in #93 will cite these examples directly.

## Verification

- [x] No code paths affected — pure docs
- [x] Renders the worked-example acceptance scenario from #95 ("After reading the doc, a user differentiates predicate from task in <30s")
- [x] SKILL.md still under the 250-line agent-contract budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **Documentation**
  * Objectives 작성을 위한 상세한 가이드라인이 추가되었습니다.
  * 검증 가능한 술어 작성 규칙과 5가지 좋은/나쁜 예시가 포함되어 있습니다.
  * 실행 가능한 검증 경로 구성 방법과 30초 테스트 기준이 제공됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-backlog/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->