### PR TITLE
docs(backlog-charter): create-mode interview + signals + seed-Decisions guidance (#93 #94 #96)

### DIFF
--- a/skills/backlog-charter/SKILL.md
+++ b/skills/backlog-charter/SKILL.md
@@ -38,9 +38,9 @@ A stable core makes the moving parts meaningful. This tiering prevents the axis 
 
 Use create mode when `CHARTER.md` is absent at the repo root, or when invoked as `backlog-charter create` and no charter exists.
 
-1. Draft from repo signals: `README.md`, `CLAUDE.md`, open epics/issues, and recent commits.
-2. Interview the user to fill and sharpen Problem, Approach, Non-Goals, and initial Objectives.
-3. Write repo-root `CHARTER.md` from `templates/charter.md` with `revision: 1` and today's `last_amended`.
+1. Draft from repo signals: `README.md` ≻ `CLAUDE.md` ≻ open epics/issues ≻ recent commits ≻ `CHANGELOG.md`. When signals conflict, surface the conflict in the interview rather than picking silently.
+2. Interview the user to fill and sharpen Problem, Approach, Non-Goals, and initial Objectives. Follow the checklist in `references/create.md` — Problem framing options, the wedge test for Approach, Non-Goals elicitation, and Objective framing that cites `references/objectives.md`.
+3. Write repo-root `CHARTER.md` from `templates/charter.md` with `revision: 1` and today's `last_amended`. The Decisions table may be left empty — seed 3–5 rows only when prior design docs, ADRs, or notable merged PRs already record direction; remember that whatever lands becomes immutable from revision 2.
 
 Objective conventions:
 
@@ -72,6 +72,7 @@ See `references/amendment.md` for deep challenge and proof-gate heuristics.
 
 ## References
 
+- `references/create.md` — create-mode signals priority, conflict handling, interview checklist, seed-Decisions guidance.
 - `references/amendment.md` — challenge checklist, proof-gate rules, no-rubber-stamp discipline, and bloat checks.
 - `references/alignment.md` — shared work↔objective mapping logic consumed by `backlog-triage` and `dev-backlog`.
 - `references/objectives.md` — verifiable-predicate examples (5 good, 5 bad), common rewrite patterns, 30-second test.

--- a/skills/backlog-charter/references/create.md
+++ b/skills/backlog-charter/references/create.md
@@ -1,0 +1,106 @@
+# Charter Create Mode: Signals, Interview, Seed Decisions
+
+Use this reference in `backlog-charter` create mode after confirming no repo-root `CHARTER.md` exists. The goal is a defensible first revision that survives its own proof gate — not a perfect axis on day one. Stability comes from amend mode; create mode just has to set a credible starting point.
+
+## 1. Signal Collection (Priority + Conflict)
+
+Create mode step 1 draws from repo signals. When signals are rich, weight them by intent fidelity; when they are missing, fall back rather than stalling.
+
+### Priority order
+
+1. **`README.md`** — outward-facing problem framing, audience, and approach. Highest fidelity for Problem and Approach.
+2. **`CLAUDE.md`** (or `AGENTS.md`, `GEMINI.md`) — internal working conventions; second-highest for Approach + Non-Goals.
+3. **Open epics and issues** — current execution surface; useful for Objectives and active scope.
+4. **Recent commits** (last ~30 merged PRs) — what is actually being built; corrects for stale README.
+5. **`CHANGELOG.md`** — shipped reality; useful when commits are noisy.
+
+Stop at the first three signals that produce a coherent draft. More signals beyond that mean diminishing returns and longer interview prep.
+
+### Fallback when README is absent or stale
+
+- Derive Problem from the **5 most-recurring issue titles** plus any pinned issue or epic.
+- Derive Approach from the **5 most recent merged PRs** — what choices keep recurring across them?
+- Surface the absence in the interview: "There is no README — I drafted Problem from issue titles; correct me where I'm wrong."
+
+### Conflict handling
+
+When signals disagree (e.g., README says "CLI tool," CLAUDE.md says "web app," commits show both), do not pick silently.
+
+- Name the conflict explicitly in the interview.
+- Ask which surface is the project's current center of gravity.
+- Prefer the most recent signal as a tiebreaker only if the user has no answer.
+
+Silent picks pollute Problem and Approach for the life of the charter.
+
+## 2. Interview Checklist
+
+Create mode step 2 is an interview to fill and sharpen Problem, Approach, Non-Goals, and initial Objectives. Run the prompts below in order. Each question has a default frame; offer it as a starting point, do not impose it.
+
+### Problem framing
+
+Pick the closest frame and pressure-test it:
+
+- **AI-context-loss** — "Agents and humans re-derive state every session; nothing persists between them."
+- **Shared-state-missing** — "Humans and tools each have their own view; no single read-it-once surface."
+- **Source-of-truth-without-abandonment** — "An existing tool (GitHub, Jira) is canonical; we add to it without replacing it."
+- **Other** — let the user name it; do not force a frame.
+
+Confirm the frame is **diagnosis-only** — no solution language leaks into Problem.
+
+### Approach (the wedge test)
+
+> "What is the wedge that would shrink if scope shrunk?"
+
+The answer names the irreducible Approach. If the user names a tool ("we use GitHub Issues"), keep digging — the wedge is the *choice* behind the tool, not the tool itself.
+
+Pressure-test: "If we removed everything else, would this still be the project?" If no, the wedge is wrong.
+
+### Non-Goals elicitation
+
+> "What would you say no to even if a user asked for it?"
+
+Then:
+
+> "What has a contributor already proposed that you rejected, and why?"
+
+Both questions surface real Non-Goals (intentional rejections with rationale) rather than abstract anti-patterns. Three to six entries is healthy; ten is bloat.
+
+### Initial Objectives
+
+> "Name 2–3 outcomes a user could observe today, and mark status by current shipped reality."
+
+Use the shape `O<n> [status]    <verifiable predicate> · src: user`. Default new objectives to `active` unless the user has shipped evidence (then `validated`) or deliberately parked them (then `deferred`).
+
+For predicate quality, follow [`objectives.md`](objectives.md): five good and five bad worked examples, common rewrite patterns, and the 30-second test. Run any draft objective through the 30-second test before committing it.
+
+## 3. Seed Decisions
+
+Create mode step 3 writes the file from `templates/charter.md`. The Decisions table may be left empty.
+
+### Default: empty is fine
+
+Decisions accrue naturally through amend mode as cross-cutting choices get made. An empty Decisions table on revision 1 is not a defect.
+
+### When to seed 3–5 rows
+
+Seed only when the project has prior artifacts that already record direction:
+
+- Design documents or RFCs that locked an architectural choice.
+- ADRs (Architectural Decision Records).
+- Notable merged PRs whose descriptions explain a non-obvious direction.
+
+Pull three to five entries, no more. Each row needs `date`, `decision`, `rationale`, and (if reversing prior direction) `supersedes`.
+
+### Immutability from revision 2 onward
+
+Whatever lands in Decisions on revision 1 — including seeded entries — is immutable from revision 2 onward. A reversal is a new row with `supersedes`, never an edit or delete. Mention this to the user before seeding so they do not overpopulate optimistically.
+
+## Outcome
+
+A first-revision charter produced via this checklist should:
+
+- Read in under 5 minutes (run [`check-size.js`](../scripts/check-size.js) if available).
+- Carry Problem / Approach / Non-Goals that survived a challenge round, not first-draft acceptance.
+- List 2–3 Objectives, each one the 30-second test would pass.
+- Have an empty or lightly-seeded Decisions table.
+- Match in shape (not content) the charter dev-backlog created for itself on 2026-05-23.


### PR DESCRIPTION
Closes #93, #94, #96 — Batch 1 of the v0.6 polish sprint ([sprint file](backlog/sprints/2026-05-backlog-charter-v06.md), milestone #5).

Three dogfooding findings from the 2026-05-23 self-application of \`backlog-charter\` ship together as one create-mode reference. They are tightly coupled (same file, same Create Mode polish) and read better as a single consolidated doc than three separate inserts.

## What

\`skills/backlog-charter/references/create.md\` (new, ~106 lines):

1. **Signal collection** (#94) — priority order (README ≻ CLAUDE.md ≻ epics ≻ commits ≻ CHANGELOG), fallback when README is absent or stale, explicit conflict-handling rule (no silent picks).
2. **Interview checklist** (#93) — Problem framing options, the wedge test for Approach, Non-Goals elicitation prompts, Objective framing that cites \`references/objectives.md\` and the 30-second predicate test.
3. **Seed Decisions** (#96) — empty-is-fine default, criteria for seeding 3–5 rows, immutability warning from revision 2 onward.

\`SKILL.md\` Create Mode block updated:
- Step 1 names the priority order inline and the conflict-surfacing rule.
- Step 2 cites \`references/create.md\` for the interview checklist.
- Step 3 names the empty-is-fine default plus the immutability warning.
- References list adds \`create.md\`.

## Why

Dogfooding finding from the 2026-05-23 self-application of \`backlog-charter\` to \`dev-backlog\`. Each issue surfaced a different gap in Create mode: signals listed without priority (#94), no interview script (#93), Decisions seeding ambiguity (#96). Consolidating them into one reference gives a future Create-mode author a single read-it-once doc, and keeps \`SKILL.md\` under the 250-line agent-contract budget (currently 78 lines).

## Verification

- [x] \`SKILL.md\` stays well under 250 lines (78)
- [x] Create mode steps 1–3 each cite the new reference for deeper guidance
- [x] Interview checklist cites \`references/objectives.md\` (the predicate worked examples from #95 / PR #99)
- [x] Signal priority + conflict rule match the gap described in #94
- [x] Seed-Decisions guidance names the immutability gotcha from #96

## Test plan

- [x] No code paths affected — pure docs
- [ ] Smoke test: re-run \`backlog-charter\` create mode on a fresh repo and confirm the interview produces a CHARTER comparable in shape to dev-backlog's own (next CHARTER-create dogfood opportunity)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 백로그 헌장 작성 프로세스에 대한 상세 가이드를 추가했습니다.
  * 문제 정의, 접근 방식, 목표 설정 단계별 체크리스트를 구체화했습니다.
  * 헌장 생성 시 필수 항목과 초기화 규칙을 명시했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-backlog/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->