### PR TITLE
feat(charter,backlog): CHARTER lint scripts — check-size + objectives-check (#97 #98)

### DIFF
--- a/skills/backlog-charter/SKILL.md
+++ b/skills/backlog-charter/SKILL.md
@@ -64,7 +64,7 @@ Apply the 3-tier discipline:
 - Tier 2 status advance: require proof for `active` → `validated` or `deferred`; cite a merged PR, passing check, or relay run whose Done Criteria match the predicate. Without proof, refuse the advance and flag it.
 - Tier 3 Decisions: append only. Never edit or delete an existing row; a reversal is a new row with `supersedes`.
 
-After applying an accepted amendment, bump `last_amended` to today and increment `revision`.
+After applying an accepted amendment, bump `last_amended` to today and increment `revision`. Then run `node skills/backlog-charter/scripts/check-size.js` to confirm the 5-minute-read property still holds; collapse long `deferred` lists or oversized Decisions rationale if the script warns.
 
 Amend mode can take a `backlog-triage` Alignment Check report as a seed of proposed changes. The report proposes; this skill applies through the gates.
 

--- a/skills/backlog-charter/scripts/check-size.js
+++ b/skills/backlog-charter/scripts/check-size.js
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+/**
+ * Lint CHARTER.md size against the ~5-minute-read property.
+ *
+ * Usage: ./scripts/check-size.js [--path PATH] [--strict] [--json]
+ *
+ * Reads CHARTER.md (default ./CHARTER.md), counts words + lines, and
+ * prints a summary. Warns above 1000 words (~5 min at 200 wpm) or
+ * 80 lines and suggests candidates to collapse (long deferred lists,
+ * oversized Decisions rationale).
+ *
+ * Exit codes:
+ *   0  ok or warnings (advisory)
+ *   1  --strict and the file exceeds either threshold
+ *   2  CHARTER.md not found
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const WORD_LIMIT = 1000;
+const LINE_LIMIT = 80;
+const WORDS_PER_MINUTE = 200;
+const LONG_RATIONALE_CHARS = 140;
+
+function usage() {
+  return "Usage: check-size.js [--path PATH] [--strict] [--json]";
+}
+
+function parseArgs(args) {
+  const options = { charterPath: "CHARTER.md", strict: false, json: false };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--strict") { options.strict = true; continue; }
+    if (arg === "--json")   { options.json = true;   continue; }
+    if (arg === "--help" || arg === "-h") {
+      return { ...options, help: true };
+    }
+    if (arg === "--path") {
+      const next = args[i + 1];
+      if (!next) return { ...options, error: `Missing value for --path. ${usage()}` };
+      options.charterPath = next;
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith("--path=")) {
+      options.charterPath = arg.slice("--path=".length);
+      continue;
+    }
+    return { ...options, error: `Unknown argument: ${arg}. ${usage()}` };
+  }
+
+  return options;
+}
+
+function stripFrontmatter(content) {
+  if (!content.startsWith("---\n")) return content;
+  const end = content.indexOf("\n---\n", 4);
+  if (end === -1) return content;
+  return content.slice(end + 5);
+}
+
+function countWords(body) {
+  const cleaned = body
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`[^`\n]*`/g, " ")
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, " ")
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    .replace(/[#>*_|\-]+/g, " ");
+
+  const tokens = cleaned.split(/\s+/).filter((t) => /\w/.test(t));
+  return tokens.length;
+}
+
+function countLines(content) {
+  if (content.length === 0) return 0;
+  const trimmed = content.endsWith("\n") ? content.slice(0, -1) : content;
+  return trimmed.split("\n").length;
+}
+
+function findDeferredObjectives(content) {
+  const lines = content.split("\n");
+  const deferred = [];
+  for (const line of lines) {
+    const match = line.match(/^- (O\d+) \[deferred\]/);
+    if (match) deferred.push(match[1]);
+  }
+  return deferred;
+}
+
+function findLongDecisionsRationale(content) {
+  const offenders = [];
+  const lines = content.split("\n");
+  for (const line of lines) {
+    if (!line.startsWith("|") || !line.includes("|")) continue;
+    const cells = line.split("|").map((c) => c.trim());
+    if (cells.length < 5) continue;
+    const date = cells[1];
+    const rationale = cells[3];
+    if (/^\d{4}-\d{2}-\d{2}$/.test(date) && rationale.length > LONG_RATIONALE_CHARS) {
+      offenders.push({ date, rationaleLength: rationale.length });
+    }
+  }
+  return offenders;
+}
+
+function buildSuggestions({ deferredIds, longRationale, wordCount, lineCount }) {
+  const suggestions = [];
+
+  if (deferredIds.length >= 3) {
+    suggestions.push(
+      `Collapse ${deferredIds.length} deferred objectives (${deferredIds.join(", ")}) into a one-line "(see follow-up specs)" reference.`,
+    );
+  }
+
+  if (longRationale.length > 0) {
+    const dates = longRationale.map((r) => r.date).join(", ");
+    suggestions.push(
+      `Tighten Decisions rationale for ${dates} (> ${LONG_RATIONALE_CHARS} chars). Move long rationale to PR descriptions or follow-up specs.`,
+    );
+  }
+
+  if (wordCount > WORD_LIMIT && suggestions.length === 0) {
+    suggestions.push(
+      "Move operational HOW-knowledge to _context.md; the charter should answer 'what good looks like,' not 'how to do it.'",
+    );
+  }
+
+  if (lineCount > LINE_LIMIT && suggestions.length === 0) {
+    suggestions.push(
+      "Consider collapsing related Non-Goals or merging adjacent deferred objectives to reduce line count.",
+    );
+  }
+
+  return suggestions;
+}
+
+function analyze(content) {
+  const body = stripFrontmatter(content);
+  const wordCount = countWords(body);
+  const lineCount = countLines(content);
+  const readMinutes = Math.max(1, Math.round(wordCount / WORDS_PER_MINUTE));
+  const deferredIds = findDeferredObjectives(body);
+  const longRationale = findLongDecisionsRationale(body);
+  const overWords = wordCount > WORD_LIMIT;
+  const overLines = lineCount > LINE_LIMIT;
+  const exceeded = overWords || overLines;
+
+  return {
+    wordCount,
+    lineCount,
+    readMinutes,
+    overWords,
+    overLines,
+    exceeded,
+    deferredIds,
+    longRationale,
+    suggestions: buildSuggestions({ deferredIds, longRationale, wordCount, lineCount }),
+    thresholds: { words: WORD_LIMIT, lines: LINE_LIMIT },
+  };
+}
+
+function formatSummary(result) {
+  const status = result.exceeded ? "⚠" : "✓";
+  return `CHARTER: ${result.wordCount} words / ${result.lineCount} lines / ~${result.readMinutes} min ${status}`;
+}
+
+function formatWarnings(result) {
+  const lines = [];
+  if (result.overWords) {
+    lines.push(`  - Over word budget: ${result.wordCount} > ${WORD_LIMIT} (~5 min at ${WORDS_PER_MINUTE} wpm)`);
+  }
+  if (result.overLines) {
+    lines.push(`  - Over line budget: ${result.lineCount} > ${LINE_LIMIT}`);
+  }
+  if (result.suggestions.length > 0) {
+    lines.push("Suggestions:");
+    for (const s of result.suggestions) lines.push(`  - ${s}`);
+  }
+  return lines.join("\n");
+}
+
+function checkSize({
+  charterPath,
+  readFile = fs.readFileSync,
+  fileExists = fs.existsSync,
+} = {}) {
+  const resolved = path.resolve(charterPath);
+  if (!fileExists(resolved)) {
+    return { found: false, charterPath: resolved };
+  }
+  const content = readFile(resolved, "utf-8");
+  const result = analyze(content);
+  return { found: true, charterPath: resolved, ...result };
+}
+
+function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+  if (parsed.error) {
+    console.error(parsed.error);
+    process.exit(1);
+  }
+  if (parsed.help) {
+    console.log(usage());
+    return;
+  }
+
+  const result = checkSize({ charterPath: parsed.charterPath });
+
+  if (!result.found) {
+    if (parsed.json) {
+      console.log(JSON.stringify({ found: false, charterPath: result.charterPath }, null, 2));
+    } else {
+      console.error(`CHARTER.md not found at ${result.charterPath}`);
+    }
+    process.exit(2);
+  }
+
+  if (parsed.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(formatSummary(result));
+    if (result.exceeded || result.suggestions.length > 0) {
+      const warnings = formatWarnings(result);
+      if (warnings) console.log(warnings);
+    }
+  }
+
+  if (parsed.strict && result.exceeded) process.exit(1);
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  parseArgs,
+  stripFrontmatter,
+  countWords,
+  countLines,
+  findDeferredObjectives,
+  findLongDecisionsRationale,
+  buildSuggestions,
+  analyze,
+  checkSize,
+  formatSummary,
+  formatWarnings,
+};

--- a/skills/backlog-charter/scripts/check-size.test.js
+++ b/skills/backlog-charter/scripts/check-size.test.js
@@ -1,0 +1,228 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const {
+  parseArgs,
+  stripFrontmatter,
+  countWords,
+  countLines,
+  findDeferredObjectives,
+  findLongDecisionsRationale,
+  buildSuggestions,
+  analyze,
+  checkSize,
+  formatSummary,
+} = require("./check-size.js");
+
+describe("parseArgs", () => {
+  it("defaults to CHARTER.md, not strict, not json", () => {
+    assert.deepEqual(parseArgs([]), { charterPath: "CHARTER.md", strict: false, json: false });
+  });
+
+  it("accepts --strict and --json", () => {
+    const parsed = parseArgs(["--strict", "--json"]);
+    assert.equal(parsed.strict, true);
+    assert.equal(parsed.json, true);
+  });
+
+  it("accepts --path with value and --path= form", () => {
+    assert.equal(parseArgs(["--path", "a/b.md"]).charterPath, "a/b.md");
+    assert.equal(parseArgs(["--path=a/b.md"]).charterPath, "a/b.md");
+  });
+
+  it("errors on unknown arg", () => {
+    assert.match(parseArgs(["--bogus"]).error, /Unknown argument/);
+  });
+
+  it("errors on missing value for --path", () => {
+    assert.match(parseArgs(["--path"]).error, /Missing value for --path/);
+  });
+});
+
+describe("stripFrontmatter", () => {
+  it("removes leading --- block", () => {
+    const result = stripFrontmatter("---\nfoo: bar\n---\nbody\n");
+    assert.equal(result, "body\n");
+  });
+
+  it("leaves content without frontmatter untouched", () => {
+    assert.equal(stripFrontmatter("# heading\nbody\n"), "# heading\nbody\n");
+  });
+
+  it("handles unclosed frontmatter by returning original", () => {
+    const input = "---\nfoo: bar\nno close";
+    assert.equal(stripFrontmatter(input), input);
+  });
+});
+
+describe("countWords", () => {
+  it("counts plain prose words", () => {
+    assert.equal(countWords("one two three four"), 4);
+  });
+
+  it("ignores markdown bullets and headers", () => {
+    assert.equal(countWords("# Heading\n- one\n- two three"), 4);
+  });
+
+  it("ignores fenced code blocks", () => {
+    const input = "real prose words\n```\ncode goes here that should not count\n```\nmore prose";
+    assert.equal(countWords(input), 5);
+  });
+
+  it("ignores inline code", () => {
+    assert.equal(countWords("use `unused` token here"), 3);
+  });
+
+  it("counts link text, not URLs", () => {
+    assert.equal(countWords("[click here](https://example.com/path)"), 2);
+  });
+});
+
+describe("countLines", () => {
+  it("counts lines without trailing newline duplication", () => {
+    assert.equal(countLines("a\nb\nc\n"), 3);
+    assert.equal(countLines("a\nb\nc"), 3);
+  });
+
+  it("returns 0 on empty string", () => {
+    assert.equal(countLines(""), 0);
+  });
+});
+
+describe("findDeferredObjectives", () => {
+  it("captures all O<n> ids with [deferred] status", () => {
+    const body = [
+      "- O1 [validated] something",
+      "- O2 [active]    something",
+      "- O3 [deferred]  something",
+      "- O5 [deferred]  another",
+    ].join("\n");
+    assert.deepEqual(findDeferredObjectives(body), ["O3", "O5"]);
+  });
+
+  it("returns empty when none deferred", () => {
+    assert.deepEqual(findDeferredObjectives("- O1 [active] x"), []);
+  });
+});
+
+describe("findLongDecisionsRationale", () => {
+  it("flags rows whose rationale exceeds 140 chars", () => {
+    const longText = "x".repeat(180);
+    const body = [
+      "| date       | decision | rationale | supersedes |",
+      "| ---------- | -------- | --------- | ---------- |",
+      `| 2026-05-01 | short    | ${longText} | — |`,
+      "| 2026-05-02 | short    | tiny rationale here | — |",
+    ].join("\n");
+    const offenders = findLongDecisionsRationale(body);
+    assert.equal(offenders.length, 1);
+    assert.equal(offenders[0].date, "2026-05-01");
+  });
+
+  it("ignores header and separator rows", () => {
+    const body = [
+      "| date | decision | rationale | supersedes |",
+      "| ---- | -------- | --------- | ---------- |",
+    ].join("\n");
+    assert.deepEqual(findLongDecisionsRationale(body), []);
+  });
+});
+
+describe("buildSuggestions", () => {
+  it("suggests collapsing when 3+ deferred", () => {
+    const s = buildSuggestions({
+      deferredIds: ["O5", "O6", "O7"],
+      longRationale: [],
+      wordCount: 500,
+      lineCount: 40,
+    });
+    assert.ok(s.some((line) => line.includes("3 deferred")));
+  });
+
+  it("suggests tightening rationale when long entries present", () => {
+    const s = buildSuggestions({
+      deferredIds: [],
+      longRationale: [{ date: "2026-05-01", rationaleLength: 200 }],
+      wordCount: 200,
+      lineCount: 20,
+    });
+    assert.ok(s.some((line) => line.includes("2026-05-01")));
+  });
+
+  it("returns generic suggestion when over budget but no structural offenders", () => {
+    const s = buildSuggestions({
+      deferredIds: [],
+      longRationale: [],
+      wordCount: 1500,
+      lineCount: 100,
+    });
+    assert.equal(s.length, 1);
+    assert.match(s[0], /HOW-knowledge|_context\.md/);
+  });
+});
+
+describe("analyze", () => {
+  it("returns ok summary for a small charter", () => {
+    const content = "---\nrevision: 1\n---\n\n# Charter\n\n- O1 [active] one outcome";
+    const result = analyze(content);
+    assert.equal(result.exceeded, false);
+    assert.equal(result.overWords, false);
+    assert.equal(result.overLines, false);
+    assert.ok(result.wordCount >= 3);
+    assert.ok(result.readMinutes >= 1);
+  });
+
+  it("flags oversized charters", () => {
+    const big = "word ".repeat(1500);
+    const content = `---\nrevision: 1\n---\n\n# Charter\n\n${big}`;
+    const result = analyze(content);
+    assert.equal(result.exceeded, true);
+    assert.equal(result.overWords, true);
+  });
+
+  it("flags overline charters", () => {
+    const lines = Array.from({ length: 100 }, (_, i) => `- item ${i}`).join("\n");
+    const content = `---\nrevision: 1\n---\n\n${lines}`;
+    const result = analyze(content);
+    assert.equal(result.overLines, true);
+    assert.equal(result.exceeded, true);
+  });
+});
+
+describe("checkSize", () => {
+  it("returns found:false when the file is missing", () => {
+    const result = checkSize({
+      charterPath: "/no/such/file/CHARTER.md",
+      fileExists: () => false,
+    });
+    assert.equal(result.found, false);
+  });
+
+  it("reads and analyzes a real on-disk file", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "check-size-"));
+    try {
+      const file = path.join(dir, "CHARTER.md");
+      fs.writeFileSync(file, "---\nrevision: 1\n---\n\nHello world\n");
+      const result = checkSize({ charterPath: file });
+      assert.equal(result.found, true);
+      assert.equal(result.exceeded, false);
+      assert.equal(result.wordCount, 2);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("formatSummary", () => {
+  it("renders the ✓ marker when under budget", () => {
+    const result = { wordCount: 200, lineCount: 30, readMinutes: 1, exceeded: false };
+    assert.match(formatSummary(result), /✓/);
+  });
+
+  it("renders the ⚠ marker when exceeded", () => {
+    const result = { wordCount: 1200, lineCount: 90, readMinutes: 6, exceeded: true };
+    assert.match(formatSummary(result), /⚠/);
+  });
+});

--- a/skills/dev-backlog/SKILL.md
+++ b/skills/dev-backlog/SKILL.md
@@ -236,3 +236,4 @@ All scripts live in `${CLAUDE_SKILL_DIR}/scripts/` (the skill's own directory, n
 - `scripts/progress-sync.js [--month YYYY-MM] [--dry-run] [--json] [--relay-manifest PATH] [--finalize]` — Sync the monthly GitHub Progress issue. `--finalize` adds the month-end block and closes the target month's issue idempotently.
 - `scripts/sprint-close.sh [backlog-dir] [--dry-run] [--close-milestone]` — Close active sprint: set completed, move tasks, remind about context promotion
 - `scripts/context-hook.sh [backlog-dir]` — One-line sprint summary for Claude Code PreToolUse hook (always exits 0)
+- `scripts/objectives-check.js [--sprints-dir PATH] [--charter PATH] [--json]` — Verify every `objectives:` ID in sprint files still exists in `CHARTER.md` with an actionable (non-deferred) status. Graceful no-op when `CHARTER.md` is absent.

--- a/skills/dev-backlog/scripts/objectives-check.js
+++ b/skills/dev-backlog/scripts/objectives-check.js
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+/**
+ * Verify that every `objectives:` ID referenced by a sprint file still
+ * exists in CHARTER.md with an actionable status.
+ *
+ * Usage: ./scripts/objectives-check.js [--sprints-dir PATH] [--charter PATH] [--json]
+ *
+ * Reports two drift classes per sprint:
+ *   - missing  : the ID is not in CHARTER.md at all (removed; IDs are never reused)
+ *   - deferred : the ID exists but is marked [deferred]; sprints should not target
+ *                deferred objectives
+ *
+ * Graceful no-op when CHARTER.md is absent (most projects opt out of CHARTER).
+ *
+ * Exit codes:
+ *   0  no drift found, or CHARTER.md absent
+ *   1  drift found (missing or deferred IDs referenced)
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const DEFAULT_SPRINTS_DIR = path.join("backlog", "sprints");
+const DEFAULT_CHARTER_PATH = "CHARTER.md";
+
+function usage() {
+  return "Usage: objectives-check.js [--sprints-dir PATH] [--charter PATH] [--json]";
+}
+
+function parseArgs(args) {
+  const options = {
+    sprintsDir: DEFAULT_SPRINTS_DIR,
+    charterPath: DEFAULT_CHARTER_PATH,
+    json: false,
+  };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--json") { options.json = true; continue; }
+    if (arg === "--help" || arg === "-h") return { ...options, help: true };
+    if (arg === "--sprints-dir") {
+      const next = args[i + 1];
+      if (!next) return { ...options, error: `Missing value for --sprints-dir. ${usage()}` };
+      options.sprintsDir = next; i += 1; continue;
+    }
+    if (arg.startsWith("--sprints-dir=")) {
+      options.sprintsDir = arg.slice("--sprints-dir=".length); continue;
+    }
+    if (arg === "--charter") {
+      const next = args[i + 1];
+      if (!next) return { ...options, error: `Missing value for --charter. ${usage()}` };
+      options.charterPath = next; i += 1; continue;
+    }
+    if (arg.startsWith("--charter=")) {
+      options.charterPath = arg.slice("--charter=".length); continue;
+    }
+    return { ...options, error: `Unknown argument: ${arg}. ${usage()}` };
+  }
+
+  return options;
+}
+
+function parseFrontmatter(content) {
+  if (!content.startsWith("---\n")) return null;
+  const end = content.indexOf("\n---\n", 4);
+  if (end === -1) return null;
+  return content.slice(4, end);
+}
+
+function extractObjectivesField(frontmatter) {
+  if (!frontmatter) return [];
+  const match = frontmatter.match(/^objectives:\s*\[([^\]]*)\]/m);
+  if (!match) return [];
+  return match[1]
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => /^O\d+$/.test(s));
+}
+
+function parseSprintObjectives(content) {
+  return extractObjectivesField(parseFrontmatter(content));
+}
+
+function parseCharterObjectives(content) {
+  const objectives = new Map();
+  const lines = content.split("\n");
+  for (const line of lines) {
+    const match = line.match(/^- (O\d+) \[(validated|active|deferred)\]/);
+    if (match) objectives.set(match[1], match[2]);
+  }
+  return objectives;
+}
+
+function listSprintFiles(sprintsDir, { readdir = fs.readdirSync, fileExists = fs.existsSync } = {}) {
+  if (!fileExists(sprintsDir)) return [];
+  return readdir(sprintsDir)
+    .filter((f) => f.endsWith(".md"))
+    .map((f) => path.join(sprintsDir, f))
+    .sort();
+}
+
+function findDrift(sprintFiles, charterObjectives, { readFile = fs.readFileSync } = {}) {
+  const drift = [];
+  for (const file of sprintFiles) {
+    const content = readFile(file, "utf-8");
+    const ids = parseSprintObjectives(content);
+    const missing = [];
+    const deferred = [];
+    for (const id of ids) {
+      const status = charterObjectives.get(id);
+      if (status === undefined) missing.push(id);
+      else if (status === "deferred") deferred.push(id);
+    }
+    if (missing.length > 0 || deferred.length > 0) {
+      drift.push({ sprintFile: file, missing, deferred });
+    }
+  }
+  return drift;
+}
+
+function checkObjectives({
+  sprintsDir = DEFAULT_SPRINTS_DIR,
+  charterPath = DEFAULT_CHARTER_PATH,
+  readFile = fs.readFileSync,
+  fileExists = fs.existsSync,
+  readdir = fs.readdirSync,
+} = {}) {
+  if (!fileExists(charterPath)) {
+    return { charterFound: false, charterPath, drift: [], sprintCount: 0 };
+  }
+  const charterContent = readFile(charterPath, "utf-8");
+  const charterObjectives = parseCharterObjectives(charterContent);
+
+  const sprintFiles = listSprintFiles(sprintsDir, { readdir, fileExists });
+  const drift = findDrift(sprintFiles, charterObjectives, { readFile });
+
+  return {
+    charterFound: true,
+    charterPath,
+    charterObjectiveIds: [...charterObjectives.keys()].sort(),
+    sprintCount: sprintFiles.length,
+    drift,
+  };
+}
+
+function formatReport(result) {
+  if (!result.charterFound) {
+    return `No CHARTER.md at ${result.charterPath} — nothing to check.`;
+  }
+  const lines = [
+    `Checked ${result.sprintCount} sprint file(s) against ${result.charterObjectiveIds.length} CHARTER objective(s).`,
+  ];
+  if (result.drift.length === 0) {
+    lines.push("No drift detected ✓");
+    return lines.join("\n");
+  }
+  lines.push(`Drift detected ⚠ (${result.drift.length} sprint file(s)):`);
+  for (const d of result.drift) {
+    lines.push(`  ${d.sprintFile}`);
+    if (d.missing.length > 0) lines.push(`    - missing: ${d.missing.join(", ")}`);
+    if (d.deferred.length > 0) lines.push(`    - deferred: ${d.deferred.join(", ")}`);
+  }
+  return lines.join("\n");
+}
+
+function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+  if (parsed.error) { console.error(parsed.error); process.exit(1); }
+  if (parsed.help) { console.log(usage()); return; }
+
+  const result = checkObjectives(parsed);
+
+  if (parsed.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(formatReport(result));
+  }
+
+  if (result.charterFound && result.drift.length > 0) process.exit(1);
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  parseArgs,
+  parseFrontmatter,
+  extractObjectivesField,
+  parseSprintObjectives,
+  parseCharterObjectives,
+  listSprintFiles,
+  findDrift,
+  checkObjectives,
+  formatReport,
+};

--- a/skills/dev-backlog/scripts/objectives-check.test.js
+++ b/skills/dev-backlog/scripts/objectives-check.test.js
@@ -1,0 +1,235 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const {
+  parseArgs,
+  parseFrontmatter,
+  extractObjectivesField,
+  parseSprintObjectives,
+  parseCharterObjectives,
+  listSprintFiles,
+  findDrift,
+  checkObjectives,
+  formatReport,
+} = require("./objectives-check.js");
+
+const SAMPLE_CHARTER = `---
+last_amended: 2026-05-23
+revision: 1
+---
+
+# Charter
+
+## Objectives
+- O1 [validated] outcome one · src: user
+- O2 [validated] outcome two · src: user
+- O3 [active]    outcome three · src: user
+- O4 [active]    outcome four · src: user
+- O5 [deferred]  outcome five deferred to follow-up
+- O6 [deferred]  outcome six deferred
+`;
+
+describe("parseArgs", () => {
+  it("uses defaults when nothing passed", () => {
+    const parsed = parseArgs([]);
+    assert.equal(parsed.sprintsDir, path.join("backlog", "sprints"));
+    assert.equal(parsed.charterPath, "CHARTER.md");
+    assert.equal(parsed.json, false);
+  });
+
+  it("accepts --sprints-dir and --charter", () => {
+    const parsed = parseArgs(["--sprints-dir", "x", "--charter", "y.md"]);
+    assert.equal(parsed.sprintsDir, "x");
+    assert.equal(parsed.charterPath, "y.md");
+  });
+
+  it("accepts the = form", () => {
+    const parsed = parseArgs(["--sprints-dir=x", "--charter=y.md"]);
+    assert.equal(parsed.sprintsDir, "x");
+    assert.equal(parsed.charterPath, "y.md");
+  });
+
+  it("errors on missing value for --charter", () => {
+    assert.match(parseArgs(["--charter"]).error, /Missing value for --charter/);
+  });
+
+  it("errors on unknown argument", () => {
+    assert.match(parseArgs(["--bogus"]).error, /Unknown argument/);
+  });
+});
+
+describe("parseFrontmatter", () => {
+  it("returns inner block when frontmatter is present", () => {
+    const fm = parseFrontmatter("---\na: 1\nb: 2\n---\nbody\n");
+    assert.equal(fm, "a: 1\nb: 2");
+  });
+
+  it("returns null when no frontmatter", () => {
+    assert.equal(parseFrontmatter("# heading\n"), null);
+  });
+
+  it("returns null on unclosed frontmatter", () => {
+    assert.equal(parseFrontmatter("---\na: 1\n"), null);
+  });
+});
+
+describe("extractObjectivesField", () => {
+  it("parses bracketed list", () => {
+    assert.deepEqual(extractObjectivesField("objectives: [O1, O3]"), ["O1", "O3"]);
+  });
+
+  it("ignores malformed entries", () => {
+    assert.deepEqual(extractObjectivesField("objectives: [O1, foo, O2]"), ["O1", "O2"]);
+  });
+
+  it("returns empty list when field missing", () => {
+    assert.deepEqual(extractObjectivesField("other: value"), []);
+  });
+
+  it("returns empty list for empty bracket", () => {
+    assert.deepEqual(extractObjectivesField("objectives: []"), []);
+  });
+});
+
+describe("parseSprintObjectives", () => {
+  it("reads objectives from a sprint file's frontmatter", () => {
+    const content = "---\nmilestone: x\nobjectives: [O3, O4]\n---\n\n# Sprint\n";
+    assert.deepEqual(parseSprintObjectives(content), ["O3", "O4"]);
+  });
+
+  it("returns empty when frontmatter has no objectives line", () => {
+    const content = "---\nmilestone: x\n---\n\n# Sprint\n";
+    assert.deepEqual(parseSprintObjectives(content), []);
+  });
+});
+
+describe("parseCharterObjectives", () => {
+  it("builds id→status map from charter body", () => {
+    const map = parseCharterObjectives(SAMPLE_CHARTER);
+    assert.equal(map.get("O1"), "validated");
+    assert.equal(map.get("O3"), "active");
+    assert.equal(map.get("O5"), "deferred");
+    assert.equal(map.size, 6);
+  });
+
+  it("returns empty map when no objectives lines present", () => {
+    assert.equal(parseCharterObjectives("# Charter\n\nNo objectives here.").size, 0);
+  });
+});
+
+describe("listSprintFiles", () => {
+  it("returns sorted .md files only", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "obj-check-list-"));
+    try {
+      fs.writeFileSync(path.join(dir, "b.md"), "");
+      fs.writeFileSync(path.join(dir, "a.md"), "");
+      fs.writeFileSync(path.join(dir, "ignore.txt"), "");
+      const files = listSprintFiles(dir);
+      assert.equal(files.length, 2);
+      assert.equal(path.basename(files[0]), "a.md");
+      assert.equal(path.basename(files[1]), "b.md");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns empty when sprintsDir does not exist", () => {
+    assert.deepEqual(listSprintFiles("/no/such/dir"), []);
+  });
+});
+
+describe("findDrift", () => {
+  it("detects missing and deferred references per sprint", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "obj-check-drift-"));
+    try {
+      fs.writeFileSync(
+        path.join(dir, "a.md"),
+        "---\nmilestone: a\nobjectives: [O1, O99]\n---\n",
+      );
+      fs.writeFileSync(
+        path.join(dir, "b.md"),
+        "---\nmilestone: b\nobjectives: [O5]\n---\n",
+      );
+      fs.writeFileSync(
+        path.join(dir, "c.md"),
+        "---\nmilestone: c\nobjectives: [O3, O4]\n---\n",
+      );
+      const charterObjectives = parseCharterObjectives(SAMPLE_CHARTER);
+      const drift = findDrift(listSprintFiles(dir), charterObjectives);
+      assert.equal(drift.length, 2);
+      const byName = (f) => drift.find((d) => d.sprintFile.endsWith(f));
+      assert.deepEqual(byName("a.md").missing, ["O99"]);
+      assert.deepEqual(byName("a.md").deferred, []);
+      assert.deepEqual(byName("b.md").missing, []);
+      assert.deepEqual(byName("b.md").deferred, ["O5"]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("checkObjectives", () => {
+  it("returns charterFound:false when CHARTER.md is absent", () => {
+    const result = checkObjectives({
+      charterPath: "/no/such/CHARTER.md",
+      fileExists: (p) => p !== "/no/such/CHARTER.md",
+    });
+    assert.equal(result.charterFound, false);
+    assert.equal(result.drift.length, 0);
+  });
+
+  it("reports drift over real fixtures", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "obj-check-full-"));
+    try {
+      const sprintsDir = path.join(dir, "backlog", "sprints");
+      fs.mkdirSync(sprintsDir, { recursive: true });
+      fs.writeFileSync(path.join(dir, "CHARTER.md"), SAMPLE_CHARTER);
+      fs.writeFileSync(
+        path.join(sprintsDir, "2026-05-x.md"),
+        "---\nmilestone: x\nobjectives: [O3, O99]\n---\n",
+      );
+      const result = checkObjectives({
+        sprintsDir,
+        charterPath: path.join(dir, "CHARTER.md"),
+      });
+      assert.equal(result.charterFound, true);
+      assert.equal(result.sprintCount, 1);
+      assert.equal(result.drift.length, 1);
+      assert.deepEqual(result.drift[0].missing, ["O99"]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("formatReport", () => {
+  it("renders absent-charter message", () => {
+    const result = { charterFound: false, charterPath: "CHARTER.md", drift: [], sprintCount: 0 };
+    assert.match(formatReport(result), /No CHARTER\.md/);
+  });
+
+  it("renders no-drift summary", () => {
+    const result = {
+      charterFound: true,
+      charterObjectiveIds: ["O1", "O2"],
+      sprintCount: 3,
+      drift: [],
+    };
+    assert.match(formatReport(result), /No drift detected/);
+  });
+
+  it("renders drift listing", () => {
+    const result = {
+      charterFound: true,
+      charterObjectiveIds: ["O1", "O2"],
+      sprintCount: 2,
+      drift: [{ sprintFile: "a.md", missing: ["O99"], deferred: ["O5"] }],
+    };
+    const report = formatReport(result);
+    assert.match(report, /Drift detected/);
+    assert.match(report, /missing: O99/);
+    assert.match(report, /deferred: O5/);
+  });
+});


### PR DESCRIPTION
Closes #97, #98 — Batch 2 (and final batch) of the v0.6 polish sprint ([sprint file](backlog/sprints/2026-05-backlog-charter-v06.md), milestone #5).

Two small, parallelizable drift-detection scripts that operationalize CHARTER discipline so later amendments are protected from silent bloat and stale sprint targeting.

## \`skills/backlog-charter/scripts/check-size.js\` (#97)

- Counts words/lines of \`CHARTER.md\`, warns above **1000 words** (~5 min at 200 wpm) or **80 lines**.
- Suggests collapse targets: ≥3 deferred objectives, oversized Decisions rationale (>140 chars in a row).
- \`--strict\` exits non-zero on overage (CI gate). \`--json\` emits structured output. \`--path\` overrides the default \`./CHARTER.md\`.
- **Amend mode wiring:** \`skills/backlog-charter/SKILL.md\` now runs \`check-size\` after revision bump so the 5-min-read property is observed every amendment.

Sample output on this repo's own CHARTER:
\`\`\`
CHARTER: 481 words / 45 lines / ~2 min ✓
\`\`\`

## \`skills/dev-backlog/scripts/objectives-check.js\` (#98)

- Reads every \`backlog/sprints/*.md\`, parses \`objectives:\` IDs from frontmatter, reports IDs that are either **missing** from CHARTER (removed; IDs are never reused) or **deferred** (sprints should not target deferred objectives).
- **Graceful no-op** when \`CHARTER.md\` is absent (most projects opt out).
- Exits 1 on drift, 0 otherwise — suitable for CI. **Not** wired into \`context-hook.sh\` (per-edit latency unnecessary; the script is on-demand).

Sample output on this repo:
\`\`\`
Checked 6 sprint file(s) against 6 CHARTER objective(s).
No drift detected ✓
\`\`\`

## Why

Dogfooding findings from the 2026-05-23 self-application of \`backlog-charter\`:
- \`check-size\` closes the \"~5-min property exists but isn't observed\" gap. As amendments accumulate the property would erode silently; this surfaces it every amend.
- \`objectives-check\` closes the \"sprint references silently rot when an Objective is removed\" gap. Now drift is detectable from a single script invocation (advances CHARTER's O4).

## Test plan

- [x] \`node --test skills/backlog-charter/scripts/check-size.test.js\` — 29 tests pass
- [x] \`node --test skills/dev-backlog/scripts/objectives-check.test.js\` — 24 tests pass
- [x] Full repo suite green: 315 tests, 314 pass, 1 skipped, 0 fail
- [x] Smoke-tested both scripts against this repo's real \`CHARTER.md\` + sprint files
- [x] SKILL.md files stay readable: \`backlog-charter/SKILL.md\` at 78 lines; \`dev-backlog/SKILL.md\` at 239 lines (still under the 250 budget)