### PR TITLE
feat(backlog-charter): extract-signals.js — brownfield capability draft (#102)

### DIFF
--- a/skills/backlog-charter/SKILL.md
+++ b/skills/backlog-charter/SKILL.md
@@ -74,6 +74,8 @@ See `references/amendment.md` for deep challenge and proof-gate heuristics.
 
 Use grill mode to author `spec/capabilities.md`, the middle layer between `CHARTER.md` and the active sprint. Invoked as `backlog-charter grill` (greenfield: no `spec/capabilities.md` yet) or `backlog-charter grill <capability-name>` (rerun: polish one capability without touching others).
 
+**On a brownfield repo** (existing code, no `spec/capabilities.md`), run `node skills/backlog-charter/scripts/extract-signals.js --json` first. It draws from README, CLAUDE.md/AGENTS.md, top-level source dirs, the last 100 commit messages, and `CHARTER.md` Objectives, and proposes capability candidates with signals + draft Goal + draft Scope. Use the draft as the interview seed; grill mode still pressure-tests every Behavior and Hard Constraint through the 3-axis test before commit. The script never writes `spec/capabilities.md` itself — that decision belongs to grill.
+
 `spec/capabilities.md` lives at the target repo root in `spec/`. Layout, mutation rules, and rationale are in [`docs/spec-system-design.md`](../../docs/spec-system-design.md). The single-file shape is intentional for projects with under ~20 capabilities; `split-capabilities.js` migrates to per-capability files once that threshold is crossed.
 
 ### Per-Capability Interview Flow

--- a/skills/backlog-charter/scripts/extract-signals.js
+++ b/skills/backlog-charter/scripts/extract-signals.js
@@ -1,0 +1,320 @@
+#!/usr/bin/env node
+/**
+ * Brownfield bootstrap for spec/capabilities.md.
+ *
+ * Usage: ./scripts/extract-signals.js [--repo-root PATH] [--commit-limit N] [--dry-run] [--json]
+ *
+ * Reads repo signals in priority order and proposes a capability draft that
+ * grill mode can interview against. Does not write spec/capabilities.md —
+ * grill mode owns that decision.
+ *
+ * Signals (priority):
+ *   1. README.md                — top-level product framing
+ *   2. CLAUDE.md / AGENTS.md    — explicit conventions and capability hints
+ *   3. Top-level source dirs    — src/, lib/, app/, packages/, skills/
+ *                                 (each subdir is a capability candidate)
+ *   4. Last N commit messages   — conventional-commit scopes cluster usage
+ *   5. CHARTER.md Objectives    — capabilities should serve at least one
+ *
+ * Output: JSON of shape
+ *   { capabilities: [{ name, signals, candidate_goal, candidate_scope }] }
+ *
+ * Same inputs produce the same draft (deterministic ordering).
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { execFileSync } = require("child_process");
+
+const SOURCE_ROOT_CANDIDATES = ["src", "lib", "app", "packages", "skills"];
+const SUMMARY_DIR_LIMIT = 5;
+const DEFAULT_COMMIT_LIMIT = 100;
+
+function usage() {
+  return "Usage: extract-signals.js [--repo-root PATH] [--commit-limit N] [--dry-run] [--json]";
+}
+
+function parseArgs(args) {
+  const options = {
+    repoRoot: ".",
+    commitLimit: DEFAULT_COMMIT_LIMIT,
+    dryRun: false,
+    json: false,
+  };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--dry-run") { options.dryRun = true; continue; }
+    if (arg === "--json")    { options.json = true;   continue; }
+    if (arg === "--help" || arg === "-h") return { ...options, help: true };
+
+    if (arg === "--repo-root") {
+      const next = args[i + 1];
+      if (!next) return { ...options, error: `Missing value for --repo-root. ${usage()}` };
+      options.repoRoot = next; i += 1; continue;
+    }
+    if (arg.startsWith("--repo-root=")) {
+      options.repoRoot = arg.slice("--repo-root=".length); continue;
+    }
+    if (arg === "--commit-limit") {
+      const next = args[i + 1];
+      if (!next || !/^\d+$/.test(next)) {
+        return { ...options, error: `--commit-limit expects a positive integer. ${usage()}` };
+      }
+      options.commitLimit = Number(next); i += 1; continue;
+    }
+    if (arg.startsWith("--commit-limit=")) {
+      const raw = arg.slice("--commit-limit=".length);
+      if (!/^\d+$/.test(raw)) {
+        return { ...options, error: `--commit-limit expects a positive integer. ${usage()}` };
+      }
+      options.commitLimit = Number(raw); continue;
+    }
+    return { ...options, error: `Unknown argument: ${arg}. ${usage()}` };
+  }
+
+  return options;
+}
+
+function detectSourceRoot(repoRoot, { fileExists = fs.existsSync, statSync = fs.statSync } = {}) {
+  for (const candidate of SOURCE_ROOT_CANDIDATES) {
+    const candidatePath = path.join(repoRoot, candidate);
+    if (fileExists(candidatePath) && statSync(candidatePath).isDirectory()) {
+      return { name: candidate, path: candidatePath };
+    }
+  }
+  return null;
+}
+
+function listCapabilityCandidates(sourceRoot, { readdir = fs.readdirSync, statSync = fs.statSync } = {}) {
+  if (!sourceRoot) return [];
+  return readdir(sourceRoot.path)
+    .filter((entry) => {
+      if (entry.startsWith(".") || entry.startsWith("_")) return false;
+      try {
+        return statSync(path.join(sourceRoot.path, entry)).isDirectory();
+      } catch {
+        return false;
+      }
+    })
+    .sort();
+}
+
+function extractCommitScopes(commitMessages) {
+  const scopes = new Map();
+  for (const message of commitMessages) {
+    const match = message.match(/^[a-z]+\(([a-z][\w.\-,/ ]*)\)[!:]/);
+    if (!match) continue;
+    for (const raw of match[1].split(",")) {
+      const scope = raw.trim();
+      if (!scope) continue;
+      scopes.set(scope, (scopes.get(scope) || 0) + 1);
+    }
+  }
+  return scopes;
+}
+
+function getRecentCommitMessages(repoRoot, limit, { exec = execFileSync } = {}) {
+  try {
+    const out = exec(
+      "git",
+      ["-C", repoRoot, "log", `-n`, String(limit), "--pretty=%s"],
+      { encoding: "utf-8", maxBuffer: 10 * 1024 * 1024 },
+    );
+    return out.split("\n").filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function readOptionalFile(filePath, { readFile = fs.readFileSync, fileExists = fs.existsSync } = {}) {
+  if (!fileExists(filePath)) return null;
+  try {
+    return readFile(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+function readCharterObjectives(repoRoot, deps = {}) {
+  const charterPath = path.join(repoRoot, "CHARTER.md");
+  const content = readOptionalFile(charterPath, deps);
+  if (!content) return [];
+  const objectives = [];
+  for (const line of content.split("\n")) {
+    const match = line.match(/^- (O\d+) \[(validated|active|deferred)\]\s+(.*?)(?:\s+·\s+src:|\s*$)/);
+    if (match) {
+      objectives.push({ id: match[1], status: match[2], predicate: match[3].trim() });
+    }
+  }
+  return objectives;
+}
+
+function summarizeReadme(readme) {
+  if (!readme) return null;
+  for (const line of readme.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (trimmed.startsWith("#")) continue;
+    if (trimmed.startsWith("[!")) continue;
+    if (trimmed.startsWith("<!--")) continue;
+    return trimmed.length > 240 ? `${trimmed.slice(0, 237)}...` : trimmed;
+  }
+  return null;
+}
+
+function buildCapability({ name, sourceRootName, signals, readmeSummary, charterObjectives }) {
+  const candidateGoal = readmeSummary
+    ? `Draft (from README): ${readmeSummary} — refine via grill so the Goal names what the user observes when '${name}' works.`
+    : `Draft: what the user observes when the '${name}' capability works. Fill in via grill.`;
+
+  const candidateScope = sourceRootName
+    ? `Owns the ${sourceRootName}/${name}/ surface. Out-of-scope deferred to grill.`
+    : `Owns the '${name}' surface. Out-of-scope deferred to grill.`;
+
+  const objectiveHint = charterObjectives.length > 0
+    ? ` Candidate CHARTER objective served: ${charterObjectives[0].id} (${charterObjectives[0].predicate.slice(0, 80)}${charterObjectives[0].predicate.length > 80 ? "..." : ""}). Confirm in grill.`
+    : "";
+
+  return {
+    name,
+    signals,
+    candidate_goal: candidateGoal + objectiveHint,
+    candidate_scope: candidateScope,
+  };
+}
+
+function mergeCandidates({ sourceRoot, dirNames, scopeCounts }) {
+  const merged = new Map();
+
+  for (const name of dirNames) {
+    const signals = [`${sourceRoot.name}/${name}/`];
+    const count = scopeCounts.get(name) ?? 0;
+    if (count > 0) signals.push(`commit-scope:${name} (${count})`);
+    merged.set(name, signals);
+  }
+
+  for (const [scope, count] of scopeCounts.entries()) {
+    if (merged.has(scope)) continue;
+    if (count < 2) continue;
+    merged.set(scope, [`commit-scope:${scope} (${count})`]);
+  }
+
+  return [...merged.entries()]
+    .sort(([a], [b]) => a.localeCompare(b));
+}
+
+function extractSignals({
+  repoRoot = ".",
+  commitLimit = DEFAULT_COMMIT_LIMIT,
+  readFile = fs.readFileSync,
+  fileExists = fs.existsSync,
+  readdir = fs.readdirSync,
+  statSync = fs.statSync,
+  exec = execFileSync,
+} = {}) {
+  const deps = { readFile, fileExists, statSync, readdir, exec };
+
+  const readme = readOptionalFile(path.join(repoRoot, "README.md"), deps);
+  const claudeMd =
+    readOptionalFile(path.join(repoRoot, "CLAUDE.md"), deps) ||
+    readOptionalFile(path.join(repoRoot, "AGENTS.md"), deps);
+  const sourceRoot = detectSourceRoot(repoRoot, deps);
+  const dirNames = listCapabilityCandidates(sourceRoot, deps);
+  const commitMessages = getRecentCommitMessages(repoRoot, commitLimit, deps);
+  const scopeCounts = extractCommitScopes(commitMessages);
+  const charterObjectives = readCharterObjectives(repoRoot, deps);
+  const readmeSummary = summarizeReadme(readme);
+
+  const inventory = {
+    repoRoot: path.resolve(repoRoot),
+    readmeFound: readme !== null,
+    claudeMdFound: claudeMd !== null,
+    sourceRoot: sourceRoot ? sourceRoot.name : null,
+    sourceDirCount: dirNames.length,
+    commitsScanned: commitMessages.length,
+    commitScopeCount: scopeCounts.size,
+    charterObjectiveCount: charterObjectives.length,
+  };
+
+  const candidates = sourceRoot ? mergeCandidates({ sourceRoot, dirNames, scopeCounts }) : [];
+
+  const capabilities = candidates.map(([name, signals]) =>
+    buildCapability({
+      name,
+      sourceRootName: sourceRoot ? sourceRoot.name : null,
+      signals,
+      readmeSummary,
+      charterObjectives,
+    }),
+  );
+
+  return { inventory, capabilities };
+}
+
+function formatHumanReport(result) {
+  const { inventory, capabilities } = result;
+  const lines = [];
+  lines.push(`Repo: ${inventory.repoRoot}`);
+  lines.push("Signals:");
+  lines.push(`  - README.md: ${inventory.readmeFound ? "found" : "missing"}`);
+  lines.push(`  - CLAUDE.md/AGENTS.md: ${inventory.claudeMdFound ? "found" : "missing"}`);
+  lines.push(`  - source root: ${inventory.sourceRoot ?? "none detected"} (${inventory.sourceDirCount} dir(s))`);
+  lines.push(`  - commits scanned: ${inventory.commitsScanned}; scopes seen: ${inventory.commitScopeCount}`);
+  lines.push(`  - CHARTER objectives: ${inventory.charterObjectiveCount}`);
+  lines.push("");
+
+  if (capabilities.length === 0) {
+    lines.push("No capability candidates detected.");
+    lines.push("Grill mode will run in greenfield mode (interview from scratch).");
+    return lines.join("\n");
+  }
+
+  lines.push(`Capability candidates (${capabilities.length}, top ${Math.min(capabilities.length, SUMMARY_DIR_LIMIT)} shown):`);
+  for (const cap of capabilities.slice(0, SUMMARY_DIR_LIMIT)) {
+    lines.push(`  - ${cap.name}`);
+    lines.push(`      signals: ${cap.signals.join(", ")}`);
+  }
+  if (capabilities.length > SUMMARY_DIR_LIMIT) {
+    lines.push(`  ... and ${capabilities.length - SUMMARY_DIR_LIMIT} more (use --json for full draft)`);
+  }
+  lines.push("");
+  lines.push("Next: invoke `backlog-charter grill` to interview each capability into spec/capabilities.md.");
+  return lines.join("\n");
+}
+
+function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+  if (parsed.error) { console.error(parsed.error); process.exit(1); }
+  if (parsed.help) { console.log(usage()); return; }
+
+  const result = extractSignals(parsed);
+
+  if (parsed.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  console.log(formatHumanReport(result));
+  if (parsed.dryRun) {
+    console.log("");
+    console.log("[dry-run] No files written. extract-signals never writes; the flag is a no-op for parity with sibling scripts.");
+  }
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  parseArgs,
+  detectSourceRoot,
+  listCapabilityCandidates,
+  extractCommitScopes,
+  getRecentCommitMessages,
+  readOptionalFile,
+  readCharterObjectives,
+  summarizeReadme,
+  buildCapability,
+  mergeCandidates,
+  extractSignals,
+  formatHumanReport,
+};

--- a/skills/backlog-charter/scripts/extract-signals.test.js
+++ b/skills/backlog-charter/scripts/extract-signals.test.js
@@ -1,0 +1,373 @@
+const { describe, it, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const {
+  parseArgs,
+  detectSourceRoot,
+  listCapabilityCandidates,
+  extractCommitScopes,
+  readOptionalFile,
+  readCharterObjectives,
+  summarizeReadme,
+  buildCapability,
+  mergeCandidates,
+  extractSignals,
+  formatHumanReport,
+} = require("./extract-signals.js");
+
+function makeRepo() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "extract-signals-"));
+}
+
+function write(repo, relPath, content) {
+  const full = path.join(repo, relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+function mkdir(repo, relPath) {
+  fs.mkdirSync(path.join(repo, relPath), { recursive: true });
+}
+
+describe("parseArgs", () => {
+  it("uses defaults when no args", () => {
+    const parsed = parseArgs([]);
+    assert.equal(parsed.repoRoot, ".");
+    assert.equal(parsed.commitLimit, 100);
+    assert.equal(parsed.dryRun, false);
+    assert.equal(parsed.json, false);
+  });
+
+  it("accepts --repo-root, --commit-limit, --dry-run, --json", () => {
+    const parsed = parseArgs(["--repo-root", "/x", "--commit-limit", "25", "--dry-run", "--json"]);
+    assert.equal(parsed.repoRoot, "/x");
+    assert.equal(parsed.commitLimit, 25);
+    assert.equal(parsed.dryRun, true);
+    assert.equal(parsed.json, true);
+  });
+
+  it("accepts the = form", () => {
+    const parsed = parseArgs(["--repo-root=/x", "--commit-limit=25"]);
+    assert.equal(parsed.repoRoot, "/x");
+    assert.equal(parsed.commitLimit, 25);
+  });
+
+  it("errors on unknown argument", () => {
+    assert.match(parseArgs(["--bogus"]).error, /Unknown argument/);
+  });
+
+  it("errors on non-numeric --commit-limit", () => {
+    assert.match(parseArgs(["--commit-limit", "abc"]).error, /positive integer/);
+  });
+
+  it("errors on missing --repo-root value", () => {
+    assert.match(parseArgs(["--repo-root"]).error, /Missing value/);
+  });
+});
+
+describe("detectSourceRoot", () => {
+  let repo;
+  beforeEach(() => { repo = makeRepo(); });
+  afterEach(() => { fs.rmSync(repo, { recursive: true, force: true }); });
+
+  it("returns null when no source-root candidate exists", () => {
+    assert.equal(detectSourceRoot(repo), null);
+  });
+
+  it("prefers src/ over the others (priority order)", () => {
+    mkdir(repo, "src");
+    mkdir(repo, "lib");
+    assert.equal(detectSourceRoot(repo).name, "src");
+  });
+
+  it("falls back to skills/ when canonical roots are absent", () => {
+    mkdir(repo, "skills");
+    assert.equal(detectSourceRoot(repo).name, "skills");
+  });
+});
+
+describe("listCapabilityCandidates", () => {
+  let repo;
+  beforeEach(() => { repo = makeRepo(); });
+  afterEach(() => { fs.rmSync(repo, { recursive: true, force: true }); });
+
+  it("lists directory entries alphabetically and skips dotfiles", () => {
+    mkdir(repo, "src/zeta");
+    mkdir(repo, "src/alpha");
+    mkdir(repo, "src/.hidden");
+    write(repo, "src/index.js", "");
+    const result = listCapabilityCandidates({ name: "src", path: path.join(repo, "src") });
+    assert.deepEqual(result, ["alpha", "zeta"]);
+  });
+
+  it("returns empty when source root is null", () => {
+    assert.deepEqual(listCapabilityCandidates(null), []);
+  });
+});
+
+describe("extractCommitScopes", () => {
+  it("aggregates conventional-commit scopes", () => {
+    const messages = [
+      "feat(auth): add login",
+      "fix(auth): retry on token expiry",
+      "docs(auth): clarify flow",
+      "chore(api): bump deps",
+      "feat: scopeless commit",
+      "feat(api,auth): combined scope",
+    ];
+    const scopes = extractCommitScopes(messages);
+    assert.equal(scopes.get("auth"), 4);
+    assert.equal(scopes.get("api"), 2);
+  });
+
+  it("returns empty map for an empty input", () => {
+    assert.equal(extractCommitScopes([]).size, 0);
+  });
+
+  it("ignores non-conventional commit messages", () => {
+    const scopes = extractCommitScopes(["random merge commit", "WIP something"]);
+    assert.equal(scopes.size, 0);
+  });
+});
+
+describe("readOptionalFile", () => {
+  let repo;
+  beforeEach(() => { repo = makeRepo(); });
+  afterEach(() => { fs.rmSync(repo, { recursive: true, force: true }); });
+
+  it("returns null when the file is missing", () => {
+    assert.equal(readOptionalFile(path.join(repo, "no.md")), null);
+  });
+
+  it("returns content when the file exists", () => {
+    write(repo, "README.md", "hello");
+    assert.equal(readOptionalFile(path.join(repo, "README.md")), "hello");
+  });
+});
+
+describe("readCharterObjectives", () => {
+  let repo;
+  beforeEach(() => { repo = makeRepo(); });
+  afterEach(() => { fs.rmSync(repo, { recursive: true, force: true }); });
+
+  it("returns empty when CHARTER.md is absent", () => {
+    assert.deepEqual(readCharterObjectives(repo), []);
+  });
+
+  it("parses validated/active/deferred objectives", () => {
+    const charter = `---
+revision: 1
+---
+
+# Charter
+
+## Objectives
+- O1 [validated] outcome one · src: user
+- O2 [active]    outcome two · src: user
+- O3 [deferred]  outcome three deferred to follow-up
+`;
+    write(repo, "CHARTER.md", charter);
+    const objectives = readCharterObjectives(repo);
+    assert.equal(objectives.length, 3);
+    assert.equal(objectives[0].id, "O1");
+    assert.equal(objectives[0].status, "validated");
+    assert.match(objectives[0].predicate, /outcome one/);
+  });
+});
+
+describe("summarizeReadme", () => {
+  it("returns the first non-heading prose line", () => {
+    const readme = "# Project\n\n[![badge](url)](#)\n\nA tool that does X for Y.";
+    assert.equal(summarizeReadme(readme), "A tool that does X for Y.");
+  });
+
+  it("truncates very long prose with an ellipsis", () => {
+    const long = "x ".repeat(300);
+    const out = summarizeReadme(`# T\n\n${long}`);
+    assert.ok(out.length <= 240);
+    assert.ok(out.endsWith("..."));
+  });
+
+  it("returns null when there is no prose", () => {
+    assert.equal(summarizeReadme("# Only headings\n\n## Subhead\n"), null);
+  });
+
+  it("returns null for an empty readme", () => {
+    assert.equal(summarizeReadme(null), null);
+    assert.equal(summarizeReadme(""), null);
+  });
+});
+
+describe("buildCapability", () => {
+  it("includes a CHARTER objective hint when objectives are present", () => {
+    const cap = buildCapability({
+      name: "auth",
+      sourceRootName: "src",
+      signals: ["src/auth/", "commit-scope:auth (4)"],
+      readmeSummary: "Auth thing",
+      charterObjectives: [{ id: "O1", predicate: "users can log in" }],
+    });
+    assert.match(cap.candidate_goal, /O1/);
+    assert.match(cap.candidate_scope, /src\/auth\//);
+  });
+
+  it("falls back to placeholder goal when no readme summary", () => {
+    const cap = buildCapability({
+      name: "auth",
+      sourceRootName: "src",
+      signals: ["src/auth/"],
+      readmeSummary: null,
+      charterObjectives: [],
+    });
+    assert.match(cap.candidate_goal, /Fill in via grill/);
+  });
+});
+
+describe("mergeCandidates", () => {
+  it("merges dir candidates with commit-scope counts", () => {
+    const sourceRoot = { name: "src", path: "/repo/src" };
+    const scopeCounts = new Map([["auth", 4], ["api", 3], ["billing", 5]]);
+    const merged = mergeCandidates({
+      sourceRoot,
+      dirNames: ["auth", "api"],
+      scopeCounts,
+    });
+    const names = merged.map(([n]) => n);
+    assert.deepEqual(names, ["api", "auth", "billing"]);
+    const auth = merged.find(([n]) => n === "auth")[1];
+    assert.ok(auth.includes("src/auth/"));
+    assert.ok(auth.some((s) => s.includes("commit-scope:auth")));
+  });
+
+  it("requires >=2 commits to surface a scope without a dir", () => {
+    const sourceRoot = { name: "src", path: "/repo/src" };
+    const merged = mergeCandidates({
+      sourceRoot,
+      dirNames: ["existing"],
+      scopeCounts: new Map([["existing", 5], ["onehit", 1]]),
+    });
+    assert.equal(merged.length, 1);
+    assert.equal(merged[0][0], "existing");
+  });
+});
+
+describe("extractSignals — integration fixtures", () => {
+  let repo;
+  beforeEach(() => { repo = makeRepo(); });
+  afterEach(() => { fs.rmSync(repo, { recursive: true, force: true }); });
+
+  it("greenfield: no README, no source root, no commits → empty capabilities + degraded inventory", () => {
+    const result = extractSignals({ repoRoot: repo, exec: () => { throw new Error("no git"); } });
+    assert.equal(result.inventory.readmeFound, false);
+    assert.equal(result.inventory.claudeMdFound, false);
+    assert.equal(result.inventory.sourceRoot, null);
+    assert.equal(result.inventory.sourceDirCount, 0);
+    assert.equal(result.inventory.commitsScanned, 0);
+    assert.equal(result.capabilities.length, 0);
+  });
+
+  it("brownfield-full: README + CLAUDE.md + src/ + commits + CHARTER", () => {
+    write(repo, "README.md", "# Project\n\nA logging pipeline.\n");
+    write(repo, "CLAUDE.md", "# Conventions\n\nUse pino.\n");
+    mkdir(repo, "src/ingest");
+    mkdir(repo, "src/storage");
+    write(repo, "CHARTER.md", `---
+revision: 1
+---
+## Objectives
+- O1 [active] users see fresh logs · src: user
+`);
+
+    const commitMessages = [
+      "feat(ingest): add backpressure",
+      "fix(ingest): handle null events",
+      "feat(storage): add disk tier",
+      "chore: bump deps",
+      "feat(api): unrelated scope",
+    ];
+
+    const result = extractSignals({
+      repoRoot: repo,
+      exec: () => commitMessages.join("\n"),
+    });
+
+    assert.equal(result.inventory.readmeFound, true);
+    assert.equal(result.inventory.claudeMdFound, true);
+    assert.equal(result.inventory.sourceRoot, "src");
+    assert.equal(result.inventory.sourceDirCount, 2);
+    assert.equal(result.inventory.commitsScanned, 5);
+    assert.equal(result.inventory.charterObjectiveCount, 1);
+
+    const names = result.capabilities.map((c) => c.name);
+    assert.ok(names.includes("ingest"));
+    assert.ok(names.includes("storage"));
+
+    const ingest = result.capabilities.find((c) => c.name === "ingest");
+    assert.ok(ingest.signals.some((s) => s.includes("src/ingest/")));
+    assert.ok(ingest.signals.some((s) => s.includes("commit-scope:ingest")));
+    assert.match(ingest.candidate_goal, /logging pipeline/);
+    assert.match(ingest.candidate_goal, /O1/);
+  });
+
+  it("brownfield-thin: only src/ + commits, no README/CLAUDE", () => {
+    mkdir(repo, "src/worker");
+    const commits = ["feat(worker): initial scaffold", "fix(worker): race"];
+    const result = extractSignals({
+      repoRoot: repo,
+      exec: () => commits.join("\n"),
+    });
+
+    assert.equal(result.inventory.readmeFound, false);
+    assert.equal(result.inventory.claudeMdFound, false);
+    assert.equal(result.inventory.sourceRoot, "src");
+    assert.equal(result.capabilities.length, 1);
+    assert.equal(result.capabilities[0].name, "worker");
+    assert.match(result.capabilities[0].candidate_goal, /Fill in via grill/);
+  });
+
+  it("is deterministic: same inputs → same output", () => {
+    write(repo, "README.md", "# Project\n\nLine.\n");
+    mkdir(repo, "src/a");
+    mkdir(repo, "src/b");
+    const commits = ["feat(a): one", "feat(b): two", "feat(a): three"];
+    const stub = { exec: () => commits.join("\n") };
+
+    const r1 = extractSignals({ repoRoot: repo, ...stub });
+    const r2 = extractSignals({ repoRoot: repo, ...stub });
+    assert.deepEqual(r1, r2);
+  });
+});
+
+describe("formatHumanReport", () => {
+  it("renders the greenfield path", () => {
+    const result = {
+      inventory: {
+        repoRoot: "/x", readmeFound: false, claudeMdFound: false,
+        sourceRoot: null, sourceDirCount: 0,
+        commitsScanned: 0, commitScopeCount: 0, charterObjectiveCount: 0,
+      },
+      capabilities: [],
+    };
+    assert.match(formatHumanReport(result), /greenfield/);
+  });
+
+  it("renders capability candidates under the summary limit", () => {
+    const result = {
+      inventory: {
+        repoRoot: "/x", readmeFound: true, claudeMdFound: false,
+        sourceRoot: "src", sourceDirCount: 2,
+        commitsScanned: 10, commitScopeCount: 2, charterObjectiveCount: 0,
+      },
+      capabilities: [
+        { name: "auth",     signals: ["src/auth/", "commit-scope:auth (4)"],     candidate_goal: "", candidate_scope: "" },
+        { name: "billing",  signals: ["src/billing/", "commit-scope:billing (2)"], candidate_goal: "", candidate_scope: "" },
+      ],
+    };
+    const report = formatHumanReport(result);
+    assert.match(report, /Capability candidates \(2/);
+    assert.match(report, /auth/);
+    assert.match(report, /billing/);
+  });
+});


### PR DESCRIPTION
Closes #102 — PR-2 of spec-system v0.1 ([sprint file](backlog/sprints/2026-05-spec-system-v01.md), milestone #6).

Brownfield bootstrap: when invoked on an existing repo without \`spec/capabilities.md\`, propose a capability draft from repo signals so grill mode has something concrete to interview against.

## What lands

**\`skills/backlog-charter/scripts/extract-signals.js\`** (~270 LOC including helpers and JSDoc)

Signals collected in priority order:
1. \`README.md\` — top-level product framing → first prose line becomes the \`candidate_goal\` seed
2. \`CLAUDE.md\` / \`AGENTS.md\` — explicit conventions
3. Top-level source root (\`src\` ≻ \`lib\` ≻ \`app\` ≻ \`packages\` ≻ \`skills\`) — each subdir is a capability candidate
4. Last 100 commit messages — conventional-commit scopes (\`feat(auth):\` etc.) cluster active surface area
5. \`CHARTER.md\` Objectives — appended as candidate-objective hints on each capability

Output (JSON or human-readable):
\`\`\`
{
  inventory: { repoRoot, readmeFound, claudeMdFound, sourceRoot, sourceDirCount,
               commitsScanned, commitScopeCount, charterObjectiveCount },
  capabilities: [{ name, signals, candidate_goal, candidate_scope }]
}
\`\`\`

**Behavior:**
- **Deterministic** — sorted dir/scope iteration, objectives parsed in file order; same inputs always produce the same draft.
- **Graceful degradation** — missing README, missing CLAUDE.md, no source root, no commits all handled without throwing.
- \`--json\` prints the full draft for grill-mode consumption.
- \`--dry-run\` is a parity no-op (the script never writes anything — grill mode owns the \`spec/capabilities.md\` decision). Flag is kept for sibling-script consistency.

**\`skills/backlog-charter/SKILL.md\`** grill-mode section now references \`extract-signals\` as the brownfield entry point and reiterates that the script never writes the spec file. SKILL.md at 125 lines (still well under the 250-line agent-contract budget).

## Smoke test

Run against this repo (\`dev-backlog\`) itself:
\`\`\`
Repo: /Users/sjlee/workspace/active/harness-stack/dev-backlog
Signals:
  - README.md: found
  - CLAUDE.md/AGENTS.md: found
  - source root: skills (3 dir(s))
  - commits scanned: 85; scopes seen: 9
  - CHARTER objectives: 6

Capability candidates (5, top 5 shown):
  - backlog-charter   (skills/backlog-charter/, commit-scope:backlog-charter (6))
  - backlog-triage    (skills/backlog-triage/, commit-scope:backlog-triage (13))
  - dev-backlog       (skills/dev-backlog/, commit-scope:dev-backlog (2))
  - progress-sync     (commit-scope:progress-sync (7))
  - sync-pull         (commit-scope:sync-pull (2))
\`\`\`

The three sibling skills are the obvious capabilities; \`progress-sync\` and \`sync-pull\` are commit-only candidates that grill mode in #105 will decide to either fold into \`dev-backlog\` or surface as their own capability.

## Acceptance criteria

- [x] Runs deterministically; same inputs → same draft
- [x] Graceful degradation: missing README, missing CLAUDE.md, empty src/, no commits all handled
- [x] \`--dry-run\` and \`--json\` flags
- [x] Test fixtures cover greenfield (empty), brownfield-full (README + CLAUDE.md + src/ + commits + CHARTER), brownfield-thin (only src/ + commits)
- [x] \`node --test skills/backlog-charter/scripts/extract-signals.test.js\` passes — **32 tests**
- [x] SKILL.md grill mode references the script as the brownfield entry point

## Test plan

- [x] 32 new tests pass
- [x] Full repo suite stays green: 346 pass / 1 skipped / 0 fail
- [x] Smoke-tested on dev-backlog itself (output above)
- [ ] Dogfood: drive against dev-relay (brownfield: real code, no CHARTER) — follow-up sprint task
- [ ] Use the draft as input to grill mode for dev-backlog's own \`spec/capabilities.md\` (#105)