### PR TITLE
docs: dogfood spec/capabilities.md for dev-backlog itself (#105)

### DIFF
--- a/spec/capabilities.md
+++ b/spec/capabilities.md
@@ -1,0 +1,175 @@
+# dev-backlog Capabilities
+
+The middle layer between [`CHARTER.md`](../CHARTER.md) and the active sprint. Each block describes one subsystem-worth of work with a frozen-ish contract and a structurally bounded live-feedback channel.
+
+Mutation discipline matches [`docs/spec-system-design.md`](../docs/spec-system-design.md): Goal/Scope/Behaviors/HardConstraints are human-gated via `backlog-charter grill`; `## Learnings` is appended only by `dev-relay/scripts/append-learnings.js` between magic markers; `## Decisions` is append-only by convention.
+
+---
+
+## Capability: sprint-execution
+
+**Goal:** An agent or human resuming work mid-session reads the active sprint file and acts on its in-flight items without re-asking what is going on.
+
+**In-scope:**
+- `backlog/sprints/*.md` body + frontmatter (status, milestone, objectives)
+- Checkbox state machine: `[ ]` not started → `[~]` in flight → `[x]` done
+- `sprint-init.js`, `sprint-close.sh`, `find_active_sprint`, `next.sh`, `status.sh`
+
+**Out-of-scope:**
+- Tasks outside the active sprint (those live in `backlog/tasks/`)
+- Sprint *content* authoring — humans write the Plan; this capability runs it
+- Backlog grooming or stale-issue detection (`triage-grooming` capability)
+
+### Expected Behaviors
+- Exactly one sprint file with `status: active` exists per `backlog/sprints/` at all times — concurrent actives fail loud (find_active_sprint surfaces the conflict).
+- Every `[~]` line carries a PR or branch ref in-line, or an explicit "no work yet" annotation — never an unmoored `[~]`.
+- Closing a sprint via `sprint-close.sh` is atomic: the sprint flips `status: completed` AND its done-checkbox issues move into `backlog/completed/` in one invocation, not in two steps.
+
+### Hard Constraints
+- Never mutate a sprint's `status: completed` back to `active`; completed sprints are immutable history.
+- Never silently delete sprint Plan items — strike them with a Progress entry or convert to `[~]` with a parking note instead.
+
+### Learnings
+<!-- LEARN:BEGIN -->
+<!-- LEARN:END -->
+
+### Decisions
+| date | decision | rationale | supersedes |
+| --- | --- | --- | --- |
+
+---
+
+## Capability: backlog-sync
+
+**Goal:** Open GitHub Issues are mirrored into `backlog/tasks/*.md` without diverging on local AC checkbox state.
+
+**In-scope:**
+- `sync-pull.js` (with and without `--update`), task-file frontmatter (number, title, labels, milestone, assignees)
+- AC checkbox preservation in task bodies for non-machine-managed issues
+- Idempotent re-runs against unchanged GitHub state
+
+**Out-of-scope:**
+- Writing to GitHub (this capability is read-only; mutations live elsewhere)
+- Monthly progress-issue lifecycle (`task-progress-reporting` capability)
+- Cross-repo mirroring
+
+### Expected Behaviors
+- `sync-pull` on a fresh checkout produces `backlog/tasks/*.md` with no token prompt beyond `gh auth` already being valid.
+- `sync-pull --update` refreshes frontmatter while leaving AC checkbox state intact, **except** for issues whose incoming body starts with the `<!-- dev-backlog:progress-issue month= -->` marker — those are intentionally overwritten because their bodies are machine-managed.
+- Running `sync-pull` twice against unchanged GitHub state produces byte-identical task files on the second run.
+
+### Hard Constraints
+- Never call any `gh` subcommand that writes to GitHub from this capability — it is structurally read-only.
+- Never overwrite a non-machine-managed task body during `--update`; only frontmatter is replaced.
+
+### Learnings
+<!-- LEARN:BEGIN -->
+<!-- LEARN:END -->
+
+### Decisions
+| date | decision | rationale | supersedes |
+| --- | --- | --- | --- |
+| 2026-05-23 | `--update` preserves AC bodies for everything except machine-managed `progress-issue` markers | local AC checkboxes are user state; machine-managed bodies have no user state to lose | — |
+
+---
+
+## Capability: charter-management
+
+**Goal:** A user creates or amends `CHARTER.md` through tier-gated discipline (no rubber-stamp) and the file stays a 5-minute read.
+
+**In-scope:**
+- `backlog-charter` create + amend modes
+- Three-tier discipline (Direction / Predicates / History) and the proof gate for Objective status advances
+- `check-size.js` budget enforcement after every amend
+- `grill` mode is in this capability's scope as the authoring path for the middle layer (`spec/capabilities.md`)
+
+**Out-of-scope:**
+- Per-capability content of `spec/capabilities.md` (that lives in this file, not in `backlog-charter`)
+- Charter deletion — no supported path
+- Reading `CHARTER.md` from sibling skills (each does it directly; this capability does not gate reads)
+
+### Expected Behaviors
+- After `amend` lands a real diff, `revision` increments by exactly 1 and `last_amended` advances to that day; a no-op invocation never bumps either field.
+- Every Objective status advance (`active` → `validated` / `deferred`) is refused unless a cited PR, check, or relay run whose Done Criteria match the predicate is provided in the same invocation.
+- `check-size.js` runs at the end of every successful amend and emits the size summary line; if word or line budgets exceed, the script also emits at least one actionable suggestion.
+
+### Hard Constraints
+- Never edit or delete an existing Decisions row — reversal is a new row with `supersedes`, never a mutation.
+- Never auto-advance an Objective's status without cited evidence, even when explicitly asked. The proof gate is unconditional.
+
+### Learnings
+<!-- LEARN:BEGIN -->
+<!-- LEARN:END -->
+
+### Decisions
+| date | decision | rationale | supersedes |
+| --- | --- | --- | --- |
+| 2026-05-22 | CHARTER is a separate file at repo root, not merged into `_context.md` | Yardstick must stay <5-min; HOW-knowledge would dilute it | — |
+| 2026-05-22 | `backlog-charter` is a third sibling skill, not folded into `dev-backlog` | Different concern (axis lifecycle vs. execution) | — |
+
+---
+
+## Capability: triage-grooming
+
+**Goal:** Open Issues are classified, related, flagged stale, and aligned to CHARTER Objectives without humans maintaining a parallel triage spreadsheet.
+
+**In-scope:**
+- `backlog-triage` collect / relate / stale / report / apply pipeline
+- CHARTER-aware Alignment Check (Issue → active Objective mapping)
+- Triage snapshots (v2 collector) and the advisory triage report artifact
+
+**Out-of-scope:**
+- Deleting Issues (no path provided)
+- Cross-repo triage (this capability operates against one repo at a time)
+- Automatic mutation without explicit consent (see Hard Constraints)
+
+### Expected Behaviors
+- Default `backlog-triage` invocation is **advisory** — it produces a markdown report and never mutates GitHub state. Mutation requires `--apply`.
+- Alignment Check maps every open Issue to ≥1 active Objective OR surfaces it as an orphan in the report — no silent drops.
+- A `triage-collect` snapshot is reproducible: against unchanged GitHub state, two invocations produce a byte-identical snapshot modulo `collected_at` timestamp.
+
+### Hard Constraints
+- Never close, relabel, or comment on an Issue from the triage pipeline without the explicit `--apply` flag — read-only by structural default.
+- Never propose closing an Issue that is referenced in an active sprint's Plan or Running Context, regardless of how stale it looks.
+
+### Learnings
+<!-- LEARN:BEGIN -->
+<!-- LEARN:END -->
+
+### Decisions
+| date | decision | rationale | supersedes |
+| --- | --- | --- | --- |
+| 2026-05-22 | Alignment Check is prompt-driven inside `backlog-triage`, not a new `triage-*.js` | Issue → Objective mapping is semantic, unlike the deterministic relate/stale scripts | — |
+
+---
+
+## Capability: task-progress-reporting
+
+**Goal:** A monthly GitHub Progress issue exists with append-only entries from sprint activity, and closes idempotently at month-end.
+
+**In-scope:**
+- `progress-sync.js` and the github/relay/render helpers
+- Per-month Progress issue body (markers + appended entries)
+- `--finalize` month-end behavior
+
+**Out-of-scope:**
+- Per-PR comments (separate concern, lives in dev-relay)
+- Non-monthly cadences (weekly, quarterly)
+- Reactions, likes, or any non-text engagement
+
+### Expected Behaviors
+- Against unchanged sprint state, two `progress-sync` invocations produce a byte-identical Progress issue body — idempotent within the month.
+- `--finalize` adds the month-end block **and** closes the target month's issue exactly once; a second `--finalize` is a no-op on an already-closed issue.
+- Every appended Progress entry carries a sprint reference and a date; bare prose entries are rejected at write time.
+
+### Hard Constraints
+- Never overwrite an existing Progress entry once appended — corrections land as a new entry that references the original by date.
+- Never `--finalize` a Progress issue whose target month is still the current calendar month.
+
+### Learnings
+<!-- LEARN:BEGIN -->
+<!-- LEARN:END -->
+
+### Decisions
+| date | decision | rationale | supersedes |
+| --- | --- | --- | --- |


### PR DESCRIPTION
Closes #105 — first real \`spec/capabilities.md\` produced via the \`backlog-charter grill\` flow that landed in #101 (PR #108). Validates the layered structure on a project we know cold; second dogfood (dev-relay) is its own follow-up.

## What lands

\`spec/capabilities.md\` (175 lines, under the 200-line budget per AC; well under the 500-line warn threshold from design doc D3). Five capability blocks, **organized by functional contract** rather than by skill directory — which is itself the first dogfood finding:

| Capability | Lines | Spans |
|---|---|---|
| \`sprint-execution\` | 23 | active sprint loop (read / update / close) |
| \`backlog-sync\` | 24 | GitHub Issues ↔ \`backlog/tasks/\` mirror (sync-pull family) |
| \`charter-management\` | 26 | CHARTER create + amend + grill, proof gate, size budget |
| \`triage-grooming\` | 24 | \`backlog-triage\` collect/relate/stale/report/apply |
| \`task-progress-reporting\` | 30 | monthly GitHub Progress issue lifecycle |

\`## Learnings\` sections are empty at landing — they fill in via \`append-learnings.js\` once PR-3 (#103 + #104) ships and relay runs start tagging capabilities. \`## Decisions\` sections seeded with cross-references to existing CHARTER Decisions where the rationale already lives there (\`charter-management\`, \`triage-grooming\`, \`backlog-sync\`).

## 3-axis predicate test in action

Every Expected Behavior was pressure-tested through the authority + distributional + manipulability axes per SKILL.md grill-mode discipline. Two predicates were rewritten after failing an axis on first pass:

1. **sprint-execution Behavior 1** — first draft: *\"An agent reading the sprint resumes prior in-flight work.\"* Failed the **manipulability axis** (agent could just guess from the prose and call it resumption). Rewrite: *\"Every \`[~]\` line carries a PR or branch ref in-line, or an explicit 'no work yet' annotation — never an unmoored \`[~]\`.\"* Structural backing: the format itself makes resumption factual, not interpretive.
2. **triage-grooming Behavior 1** — first draft: *\"Default invocation does not mutate state.\"* Failed the **authority axis** (\"does not\" is policy, not a structural restriction; a future refactor could regress silently). Rewrite: *\"Default \`backlog-triage\` invocation is **advisory**... Mutation requires \`--apply\`.\"* Flag-gated structural restriction.

The other 13 Behaviors passed all three axes on first pass — the test is fast for predicates that are already grounded in concrete behavior.

## Acceptance criteria

- [x] \`spec/capabilities.md\` exists at repo root
- [x] Five capability blocks present, each ≤30 lines (23 / 24 / 26 / 24 / 30)
- [x] Total file under 200 lines (175)
- [x] Every Behavior passes the 3-axis predicate test; rewrites documented above
- [x] Every Hard Constraint is a bright-line \"never X\" — not a positive expectation
- [ ] Dogfooding findings filed as separate issues under \`spec-system v0.1 dogfood polish\` milestone — **follow-up after this PR opens** so the filings can reference the merged file

## Dogfood findings (to be filed)

Five findings surfaced during the grilling. They get filed as issues under a new milestone after this PR lands:

1. **\`extract-signals\` clusters by code, not by capability.** The script surfaced 5 by-name candidates (3 skills + \`progress-sync\` + \`sync-pull\` commit scopes) but the right grouping is 5 *functional* capabilities. The script's draft is a useful seed, but grill mode does the real work. SKILL.md could note this expectation.
2. **Behavior vs. Hard Constraint stylistic tiebreaker is missing.** Some predicates work as either (e.g., \"default is read-only\" → Behavior, or \"never mutate without --apply\" → Hard Constraint). Grill mode should give a tiebreaker rule (positive framing → Behavior; bright-line negation → Hard Constraint).
3. **3-axis test scope is unclear for Goal lines.** SKILL.md says Behaviors/HardConstraints are 3-axis-tested but is silent on Goal. Goals are observable but not verifiable predicates; the test should be explicitly scoped to Behaviors/Constraints, with a different (lighter) check for Goals.
4. **Decisions seeding pattern is fuzzy.** I seeded three of the five capabilities from CHARTER cross-refs; two had no obvious CHARTER decision to mirror. Guidance is needed: when does a CHARTER Decision get echoed at capability level vs. just referenced by date?
5. **Capability-count guidance missing.** Five capabilities for a small repo of three skills feels right. But how do you know when you have too many or too few? \`references/capabilities.md\` should grow a heuristic (\"one capability per testable contract surface,\" or similar).

## Test plan

- [x] No code changes — no test suite to run
- [x] \`spec/capabilities.md\` lints clean (no broken markdown table separators, frontmatter omitted intentionally per design doc)
- [x] Cross-references to \`CHARTER.md\`, \`docs/spec-system-design.md\`, and the magic-marker conventions all resolve
- [ ] Verified after follow-up issues filed: the dogfood-findings milestone exists and contains all five

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 새로운 사양 문서를 추가하여 시스템 기능과 운영 규칙을 정의했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-backlog/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->