### PR TITLE
feat(dev-backlog): component frontmatter + component-lint.js (#103)

### DIFF
--- a/skills/dev-backlog/SKILL.md
+++ b/skills/dev-backlog/SKILL.md
@@ -62,6 +62,7 @@ backlog/
 
 The sprint file in `backlog/sprints/` is the execution hub. One file per sprint.
 The `objectives` frontmatter field lists the `CHARTER.md` Objective IDs this sprint advances; it is `[]` when the project has no `CHARTER.md`.
+The `component` field names a single capability from `spec/capabilities.md` whose `## Learnings` block receives an entry when a relay run merges. Empty string means no live-update target.
 
 ```markdown
 ---
@@ -70,6 +71,7 @@ status: active
 started: 2026-03-22
 due: 2026-03-28
 objectives: [O1, O3]
+component: "auth"
 ---
 
 # Auth + API Foundation
@@ -237,3 +239,4 @@ All scripts live in `${CLAUDE_SKILL_DIR}/scripts/` (the skill's own directory, n
 - `scripts/sprint-close.sh [backlog-dir] [--dry-run] [--close-milestone]` — Close active sprint: set completed, move tasks, remind about context promotion
 - `scripts/context-hook.sh [backlog-dir]` — One-line sprint summary for Claude Code PreToolUse hook (always exits 0)
 - `scripts/objectives-check.js [--sprints-dir PATH] [--charter PATH] [--json]` — Verify every `objectives:` ID in sprint files still exists in `CHARTER.md` with an actionable (non-deferred) status. Graceful no-op when `CHARTER.md` is absent.
+- `scripts/component-lint.js [--sprints-dir PATH] [--capabilities PATH] [--json]` — Verify every `component:` value in sprint files resolves to a declared capability in `spec/capabilities.md`. Multi-component values (comma-separated) follow design doc D4: first declared wins + warn on secondary entries. Graceful no-op when `spec/capabilities.md` is absent.

--- a/skills/dev-backlog/scripts/component-lint.js
+++ b/skills/dev-backlog/scripts/component-lint.js
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+/**
+ * Verify that every `component:` value referenced by a sprint file resolves
+ * to a declared capability in spec/capabilities.md.
+ *
+ * Usage: ./scripts/component-lint.js [--sprints-dir PATH] [--capabilities PATH] [--json]
+ *
+ * Behavior:
+ *   - Reads spec/capabilities.md and collects "## Capability: <name>" headers.
+ *   - For each backlog/sprints/*.md, extracts `component:` from frontmatter.
+ *   - Reports sprints whose component value (single or comma-separated multi)
+ *     does not match any declared capability.
+ *   - Per design doc D4: multi-component values use first-declared + warn.
+ *     The first value must resolve; subsequent values are flagged as warnings,
+ *     not errors.
+ *   - Graceful no-op when spec/capabilities.md is absent (skill is opt-in).
+ *
+ * Exit codes:
+ *   0  no errors (warnings OK), or spec/capabilities.md absent
+ *   1  one or more component values do not resolve
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const DEFAULT_SPRINTS_DIR = path.join("backlog", "sprints");
+const DEFAULT_CAPABILITIES_PATH = path.join("spec", "capabilities.md");
+
+function usage() {
+  return "Usage: component-lint.js [--sprints-dir PATH] [--capabilities PATH] [--json]";
+}
+
+function parseArgs(args) {
+  const options = {
+    sprintsDir: DEFAULT_SPRINTS_DIR,
+    capabilitiesPath: DEFAULT_CAPABILITIES_PATH,
+    json: false,
+  };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--json") { options.json = true; continue; }
+    if (arg === "--help" || arg === "-h") return { ...options, help: true };
+    if (arg === "--sprints-dir") {
+      const next = args[i + 1];
+      if (!next) return { ...options, error: `Missing value for --sprints-dir. ${usage()}` };
+      options.sprintsDir = next; i += 1; continue;
+    }
+    if (arg.startsWith("--sprints-dir=")) {
+      options.sprintsDir = arg.slice("--sprints-dir=".length); continue;
+    }
+    if (arg === "--capabilities") {
+      const next = args[i + 1];
+      if (!next) return { ...options, error: `Missing value for --capabilities. ${usage()}` };
+      options.capabilitiesPath = next; i += 1; continue;
+    }
+    if (arg.startsWith("--capabilities=")) {
+      options.capabilitiesPath = arg.slice("--capabilities=".length); continue;
+    }
+    return { ...options, error: `Unknown argument: ${arg}. ${usage()}` };
+  }
+
+  return options;
+}
+
+function parseFrontmatter(content) {
+  if (!content.startsWith("---\n")) return null;
+  const end = content.indexOf("\n---\n", 4);
+  if (end === -1) return null;
+  return content.slice(4, end);
+}
+
+function parseComponentField(frontmatter) {
+  if (!frontmatter) return [];
+  const match = frontmatter.match(/^component:\s*(.*)$/m);
+  if (!match) return [];
+  let raw = match[1].trim();
+  if (raw.startsWith('"') && raw.endsWith('"')) raw = raw.slice(1, -1);
+  if (raw.startsWith("'") && raw.endsWith("'")) raw = raw.slice(1, -1);
+  if (raw === "") return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function parseSprintComponents(content) {
+  return parseComponentField(parseFrontmatter(content));
+}
+
+function parseCapabilityNames(content) {
+  const names = new Set();
+  const lines = content.split("\n");
+  for (const line of lines) {
+    const match = line.match(/^## Capability:\s+(\S+)/);
+    if (match) names.add(match[1]);
+  }
+  return names;
+}
+
+function listSprintFiles(sprintsDir, { readdir = fs.readdirSync, fileExists = fs.existsSync } = {}) {
+  if (!fileExists(sprintsDir)) return [];
+  return readdir(sprintsDir)
+    .filter((f) => f.endsWith(".md") && !f.startsWith("_"))
+    .map((f) => path.join(sprintsDir, f))
+    .sort();
+}
+
+function classifyComponents(components, declared) {
+  const errors = [];
+  const warnings = [];
+  if (components.length === 0) return { errors, warnings };
+
+  const [primary, ...rest] = components;
+  if (!declared.has(primary)) errors.push(primary);
+  for (const extra of rest) {
+    if (!declared.has(extra)) {
+      errors.push(extra);
+    } else {
+      warnings.push(extra);
+    }
+  }
+  return { errors, warnings };
+}
+
+function findIssues(sprintFiles, declared, { readFile = fs.readFileSync } = {}) {
+  const issues = [];
+  for (const file of sprintFiles) {
+    const content = readFile(file, "utf-8");
+    const components = parseSprintComponents(content);
+    if (components.length === 0) continue;
+    const { errors, warnings } = classifyComponents(components, declared);
+    if (errors.length === 0 && warnings.length === 0) continue;
+    issues.push({ sprintFile: file, components, unknown: errors, secondary: warnings });
+  }
+  return issues;
+}
+
+function lintComponents({
+  sprintsDir = DEFAULT_SPRINTS_DIR,
+  capabilitiesPath = DEFAULT_CAPABILITIES_PATH,
+  readFile = fs.readFileSync,
+  fileExists = fs.existsSync,
+  readdir = fs.readdirSync,
+} = {}) {
+  if (!fileExists(capabilitiesPath)) {
+    return { capabilitiesFound: false, capabilitiesPath, issues: [], sprintCount: 0 };
+  }
+  const capsContent = readFile(capabilitiesPath, "utf-8");
+  const declared = parseCapabilityNames(capsContent);
+
+  const sprintFiles = listSprintFiles(sprintsDir, { readdir, fileExists });
+  const issues = findIssues(sprintFiles, declared, { readFile });
+
+  return {
+    capabilitiesFound: true,
+    capabilitiesPath,
+    declaredCapabilities: [...declared].sort(),
+    sprintCount: sprintFiles.length,
+    issues,
+  };
+}
+
+function hasErrors(result) {
+  return result.issues.some((issue) => issue.unknown.length > 0);
+}
+
+function formatReport(result) {
+  if (!result.capabilitiesFound) {
+    return `No spec/capabilities.md at ${result.capabilitiesPath} — nothing to lint.`;
+  }
+  const lines = [
+    `Linted ${result.sprintCount} sprint file(s) against ${result.declaredCapabilities.length} declared capability/capabilities.`,
+  ];
+  if (result.issues.length === 0) {
+    lines.push("All component values resolve ✓");
+    return lines.join("\n");
+  }
+  for (const issue of result.issues) {
+    lines.push(`  ${issue.sprintFile}`);
+    if (issue.unknown.length > 0) {
+      lines.push(`    - unknown component(s): ${issue.unknown.join(", ")}`);
+    }
+    if (issue.secondary.length > 0) {
+      lines.push(`    - warning: secondary component(s) ignored per D4 (first-wins): ${issue.secondary.join(", ")}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+  if (parsed.error) { console.error(parsed.error); process.exit(1); }
+  if (parsed.help) { console.log(usage()); return; }
+
+  const result = lintComponents(parsed);
+
+  if (parsed.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(formatReport(result));
+  }
+
+  if (result.capabilitiesFound && hasErrors(result)) process.exit(1);
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  parseArgs,
+  parseFrontmatter,
+  parseComponentField,
+  parseSprintComponents,
+  parseCapabilityNames,
+  listSprintFiles,
+  classifyComponents,
+  findIssues,
+  lintComponents,
+  hasErrors,
+  formatReport,
+};

--- a/skills/dev-backlog/scripts/component-lint.test.js
+++ b/skills/dev-backlog/scripts/component-lint.test.js
@@ -1,0 +1,281 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const {
+  parseArgs,
+  parseFrontmatter,
+  parseComponentField,
+  parseSprintComponents,
+  parseCapabilityNames,
+  listSprintFiles,
+  classifyComponents,
+  findIssues,
+  lintComponents,
+  hasErrors,
+  formatReport,
+} = require("./component-lint.js");
+
+const SAMPLE_CAPABILITIES = `# Project Capabilities
+
+## Capability: sprint-execution
+Goal etc.
+
+## Capability: backlog-sync
+Goal etc.
+
+## Capability: charter-management
+Goal etc.
+`;
+
+describe("parseArgs", () => {
+  it("uses defaults", () => {
+    const parsed = parseArgs([]);
+    assert.equal(parsed.sprintsDir, path.join("backlog", "sprints"));
+    assert.equal(parsed.capabilitiesPath, path.join("spec", "capabilities.md"));
+    assert.equal(parsed.json, false);
+  });
+
+  it("accepts --sprints-dir and --capabilities", () => {
+    const parsed = parseArgs(["--sprints-dir", "x", "--capabilities", "y.md"]);
+    assert.equal(parsed.sprintsDir, "x");
+    assert.equal(parsed.capabilitiesPath, "y.md");
+  });
+
+  it("accepts the = form", () => {
+    const parsed = parseArgs(["--sprints-dir=x", "--capabilities=y.md"]);
+    assert.equal(parsed.sprintsDir, "x");
+    assert.equal(parsed.capabilitiesPath, "y.md");
+  });
+
+  it("errors on missing value for --capabilities", () => {
+    assert.match(parseArgs(["--capabilities"]).error, /Missing value/);
+  });
+
+  it("errors on unknown argument", () => {
+    assert.match(parseArgs(["--bogus"]).error, /Unknown argument/);
+  });
+});
+
+describe("parseFrontmatter", () => {
+  it("returns inner block when present", () => {
+    assert.equal(parseFrontmatter("---\na: 1\n---\nbody"), "a: 1");
+  });
+
+  it("returns null when no frontmatter", () => {
+    assert.equal(parseFrontmatter("# heading"), null);
+  });
+
+  it("returns null on unclosed frontmatter", () => {
+    assert.equal(parseFrontmatter("---\nfoo: bar\n"), null);
+  });
+});
+
+describe("parseComponentField", () => {
+  it("returns single-value array for a plain string", () => {
+    assert.deepEqual(parseComponentField('component: sprint-execution'), ["sprint-execution"]);
+  });
+
+  it("strips surrounding double quotes", () => {
+    assert.deepEqual(parseComponentField('component: "sprint-execution"'), ["sprint-execution"]);
+  });
+
+  it("strips surrounding single quotes", () => {
+    assert.deepEqual(parseComponentField("component: 'sprint-execution'"), ["sprint-execution"]);
+  });
+
+  it("returns empty array on empty value", () => {
+    assert.deepEqual(parseComponentField('component: ""'), []);
+    assert.deepEqual(parseComponentField('component:'), []);
+  });
+
+  it("splits comma-separated multi-component values", () => {
+    assert.deepEqual(
+      parseComponentField("component: sprint-execution, backlog-sync"),
+      ["sprint-execution", "backlog-sync"],
+    );
+  });
+
+  it("returns empty array when no component line", () => {
+    assert.deepEqual(parseComponentField("milestone: x\nobjectives: []"), []);
+  });
+});
+
+describe("parseSprintComponents", () => {
+  it("reads component from a sprint file's frontmatter", () => {
+    const content = "---\nmilestone: x\ncomponent: sprint-execution\n---\nbody";
+    assert.deepEqual(parseSprintComponents(content), ["sprint-execution"]);
+  });
+
+  it("returns empty when sprint has no component line", () => {
+    assert.deepEqual(parseSprintComponents("---\nmilestone: x\n---\nbody"), []);
+  });
+});
+
+describe("parseCapabilityNames", () => {
+  it("collects all ## Capability: <name> headers", () => {
+    const names = parseCapabilityNames(SAMPLE_CAPABILITIES);
+    assert.equal(names.size, 3);
+    assert.ok(names.has("sprint-execution"));
+    assert.ok(names.has("backlog-sync"));
+    assert.ok(names.has("charter-management"));
+  });
+
+  it("returns empty set when no Capability headers", () => {
+    assert.equal(parseCapabilityNames("# Just a heading").size, 0);
+  });
+});
+
+describe("listSprintFiles", () => {
+  it("returns sorted .md files; skips _context.md", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "comp-lint-list-"));
+    try {
+      fs.writeFileSync(path.join(dir, "b.md"), "");
+      fs.writeFileSync(path.join(dir, "a.md"), "");
+      fs.writeFileSync(path.join(dir, "_context.md"), "");
+      fs.writeFileSync(path.join(dir, "ignore.txt"), "");
+      const files = listSprintFiles(dir);
+      assert.equal(files.length, 2);
+      assert.equal(path.basename(files[0]), "a.md");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns empty when dir is missing", () => {
+    assert.deepEqual(listSprintFiles("/no/such/dir"), []);
+  });
+});
+
+describe("classifyComponents", () => {
+  const declared = new Set(["sprint-execution", "backlog-sync", "charter-management"]);
+
+  it("returns empty errors/warnings for empty input", () => {
+    assert.deepEqual(classifyComponents([], declared), { errors: [], warnings: [] });
+  });
+
+  it("primary unknown is an error", () => {
+    const r = classifyComponents(["unknown-cap"], declared);
+    assert.deepEqual(r.errors, ["unknown-cap"]);
+    assert.deepEqual(r.warnings, []);
+  });
+
+  it("primary known is silent", () => {
+    const r = classifyComponents(["sprint-execution"], declared);
+    assert.deepEqual(r.errors, []);
+    assert.deepEqual(r.warnings, []);
+  });
+
+  it("secondary known is a warning per D4 (first-wins)", () => {
+    const r = classifyComponents(["sprint-execution", "backlog-sync"], declared);
+    assert.deepEqual(r.errors, []);
+    assert.deepEqual(r.warnings, ["backlog-sync"]);
+  });
+
+  it("secondary unknown is an error AND signals a typo", () => {
+    const r = classifyComponents(["sprint-execution", "typo-cap"], declared);
+    assert.deepEqual(r.errors, ["typo-cap"]);
+    assert.deepEqual(r.warnings, []);
+  });
+});
+
+describe("findIssues", () => {
+  it("flags only sprints whose component fails to resolve", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "comp-lint-find-"));
+    try {
+      fs.writeFileSync(path.join(dir, "ok.md"), "---\ncomponent: sprint-execution\n---\n");
+      fs.writeFileSync(path.join(dir, "bad.md"), "---\ncomponent: typo-cap\n---\n");
+      fs.writeFileSync(path.join(dir, "multi.md"), "---\ncomponent: sprint-execution, backlog-sync\n---\n");
+      fs.writeFileSync(path.join(dir, "noop.md"), "---\nmilestone: x\n---\n");
+
+      const declared = parseCapabilityNames(SAMPLE_CAPABILITIES);
+      const issues = findIssues(listSprintFiles(dir), declared);
+      assert.equal(issues.length, 2);
+
+      const byName = (name) => issues.find((i) => i.sprintFile.endsWith(name));
+      assert.deepEqual(byName("bad.md").unknown, ["typo-cap"]);
+      assert.deepEqual(byName("multi.md").secondary, ["backlog-sync"]);
+      assert.deepEqual(byName("multi.md").unknown, []);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("lintComponents", () => {
+  it("returns capabilitiesFound:false when spec/capabilities.md is absent", () => {
+    const result = lintComponents({
+      capabilitiesPath: "/no/such/spec/capabilities.md",
+      fileExists: (p) => p !== "/no/such/spec/capabilities.md",
+    });
+    assert.equal(result.capabilitiesFound, false);
+    assert.equal(result.issues.length, 0);
+  });
+
+  it("flags real fixture drift end-to-end", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "comp-lint-full-"));
+    try {
+      const sprintsDir = path.join(dir, "backlog", "sprints");
+      const capPath = path.join(dir, "spec", "capabilities.md");
+      fs.mkdirSync(sprintsDir, { recursive: true });
+      fs.mkdirSync(path.dirname(capPath), { recursive: true });
+      fs.writeFileSync(capPath, SAMPLE_CAPABILITIES);
+      fs.writeFileSync(
+        path.join(sprintsDir, "2026-05-x.md"),
+        "---\ncomponent: typo-cap\n---\nbody",
+      );
+      const result = lintComponents({ sprintsDir, capabilitiesPath: capPath });
+      assert.equal(result.capabilitiesFound, true);
+      assert.equal(result.declaredCapabilities.length, 3);
+      assert.equal(result.issues.length, 1);
+      assert.deepEqual(result.issues[0].unknown, ["typo-cap"]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("hasErrors", () => {
+  it("true when any issue has unknown components", () => {
+    assert.equal(hasErrors({ issues: [{ unknown: ["x"], secondary: [] }] }), true);
+  });
+
+  it("false when only warnings", () => {
+    assert.equal(hasErrors({ issues: [{ unknown: [], secondary: ["y"] }] }), false);
+  });
+
+  it("false when no issues", () => {
+    assert.equal(hasErrors({ issues: [] }), false);
+  });
+});
+
+describe("formatReport", () => {
+  it("renders absent-spec message", () => {
+    const result = { capabilitiesFound: false, capabilitiesPath: "spec/capabilities.md", issues: [], sprintCount: 0 };
+    assert.match(formatReport(result), /No spec\/capabilities\.md/);
+  });
+
+  it("renders clean summary", () => {
+    const result = {
+      capabilitiesFound: true,
+      capabilitiesPath: "spec/capabilities.md",
+      declaredCapabilities: ["a", "b"],
+      sprintCount: 3,
+      issues: [],
+    };
+    assert.match(formatReport(result), /All component values resolve/);
+  });
+
+  it("renders issue listing with errors and warnings", () => {
+    const result = {
+      capabilitiesFound: true,
+      capabilitiesPath: "spec/capabilities.md",
+      declaredCapabilities: ["a", "b"],
+      sprintCount: 2,
+      issues: [{ sprintFile: "x.md", components: ["typo", "b"], unknown: ["typo"], secondary: [] }],
+    };
+    const report = formatReport(result);
+    assert.match(report, /unknown component\(s\): typo/);
+  });
+});

--- a/skills/dev-backlog/scripts/sprint-init.js
+++ b/skills/dev-backlog/scripts/sprint-init.js
@@ -59,6 +59,7 @@ status: active
 started: ${started}
 due: ${due}
 objectives: []
+component: ""
 ---
 
 # ${topic}

--- a/skills/dev-backlog/scripts/sprint-init.test.js
+++ b/skills/dev-backlog/scripts/sprint-init.test.js
@@ -72,7 +72,7 @@ describe("buildSprintContent", () => {
     assert.match(content, /milestone: Sprint W13/);
     assert.match(content, /started: 2026-04-05/);
     assert.match(content, /due: 2026-04-12/);
-    assert.match(content, /due: 2026-04-12\nobjectives: \[\]\n---/);
+    assert.match(content, /due: 2026-04-12\nobjectives: \[\]\ncomponent: ""\n---/);
     assert.match(content, /# auth-system/);
     assert.match(content, /- \[ \] #42 OAuth2 flow \(~1hr\)/);
   });
@@ -111,7 +111,7 @@ describe("createSprintFile", () => {
 
     const written = fs.readFileSync(result.sprintFile, "utf-8");
     assert.equal(written, result.content);
-    assert.match(written, /due: 2026-04-12\nobjectives: \[\]\n---/);
+    assert.match(written, /due: 2026-04-12\nobjectives: \[\]\ncomponent: ""\n---/);
   });
 
   it("returns placeholder metadata on dry-run when milestone has no issues", () => {
@@ -250,6 +250,7 @@ describe("createSprintFile", () => {
     // Frontmatter must have status: active on its own line (what find_active_sprint greps for)
     assert.match(content, /^status: active$/m);
     assert.match(content, /^objectives: \[\]$/m);
+    assert.match(content, /^component: ""$/m);
     // Checkbox must match the integration contract regex
     assert.match(content, /^- \[ \] #\d+/m);
   });


### PR DESCRIPTION
Closes #103 — PR-3 (part A) of spec-system v0.1. Part B (cross-repo: dev-relay's \`append-learnings.js\` + relay-merge hook) lives under #104 and lands separately in the dev-relay repo.

Sprint files gain an optional \`component:\` frontmatter field that names the \`spec/capabilities.md\` capability whose \`## Learnings\` block will receive an entry when a relay run for this sprint merges. The lint catches typos before they reach the Learnings append surface.

## What lands

**\`skills/dev-backlog/scripts/sprint-init.js\`** — frontmatter template gains \`component: \"\"\` (empty default) alongside the existing \`objectives: []\`. Existing sprints continue to work; empty/missing means \"no live-update target.\"

**\`skills/dev-backlog/scripts/component-lint.js\`** (~190 LOC including the standard arg/parse/format helpers):
- Reads \`spec/capabilities.md\`; collects \`## Capability: <name>\` headers as the declared set.
- For each \`backlog/sprints/*.md\` (skipping \`_context.md\`), parses \`component:\` from frontmatter and validates against declared names.
- **Multi-component handling (design doc D4 — first-wins):** comma-separated values pass when the *primary* (first) resolves; secondary entries that resolve are warnings (per-D4 they will be ignored at append time); secondary entries that do not resolve are errors (treated as typos).
- **Graceful no-op** when \`spec/capabilities.md\` is absent (capability spec is opt-in).
- Exit 1 on errors, 0 otherwise.

**\`skills/dev-backlog/SKILL.md\`** — Sprint File Format section documents the new \`component:\` field; Scripts list adds \`component-lint.js\` with the D4 rule inline.

**\`backlog/sprints/2026-05-spec-system-v01.md\`** — proof-of-concept: the active sprint sets \`component: \"charter-management\"\` and lints clean against the 5 capabilities declared in \`spec/capabilities.md\` (added in PR #110).

## Smoke test on this repo

\`\`\`
$ node skills/dev-backlog/scripts/component-lint.js
Linted 6 sprint file(s) against 5 declared capability/capabilities.
All component values resolve ✓
\`\`\`

## Acceptance criteria

- [x] \`sprint-init.js\` emits \`component:\` field; \`sprint-init.test.js\` updated (3 assertions adjusted, 15 tests still pass)
- [x] \`component-lint.js\` detects typos against declared capabilities
- [x] Graceful when \`spec/capabilities.md\` is absent (returns \`capabilitiesFound: false\`, exit 0)
- [x] \`node --test skills/dev-backlog/scripts/component-lint.test.js\` passes — **34 tests**
- [x] SKILL.md documents the field semantics + multi-component first-wins rule
- [x] Compatible with #98 (\`objectives-check.js\`) — same shape, no collision

## Test plan

- [x] 34 new tests pass for \`component-lint.js\`
- [x] \`sprint-init.test.js\` updated for the new frontmatter shape; all 15 still pass
- [x] Full repo suite green: **380 pass / 1 skipped / 0 fail** (+34 from this PR, +20 from PR #110 dogfood adding sprint files in tests is N/A)
- [x] Smoke-tested on this repo: 6 sprints linted against 5 capabilities, all resolve

## Follows up

- **#104** lives in [\`sungjunlee/dev-relay\`](https://github.com/sungjunlee/dev-relay) — \`append-learnings.js\` + relay-merge hook is the consumer of the \`component:\` value this PR introduces. Cross-repo mirror issue will be filed once this lands so the dev-relay PR can link both sides.