### PR TITLE
feat(spec-system): enforce strict routing handles

### DIFF
--- a/docs/spec-system-design.md
+++ b/docs/spec-system-design.md
@@ -23,6 +23,7 @@ For autonomous runs that span days, this means: setpoint exists, sensor doesn't,
 - Detail level calibrated to *help* AI agents, not constrain them into Goodhart's law
 - Lower layers can update live without human edit, via structurally bounded channels
 - Interactive "grill-me" mode that pressure-tests specs into verifiable predicates
+- Loose documents, strict handles: prose stays flexible; machine-routing fields stay small and stable
 - Bias to simplicity: one new file family, zero new skill names
 
 ## Non-Goals
@@ -48,7 +49,7 @@ repo/
 │     #   In-scope / Out-of-scope       (frozen — amend-gated)
 │     #   Expected Behaviors            (human-gated, list)
 │     #   Hard Constraints              (anti-adversarial bright-lines)
-│     #   ## Learnings                  (LIVE — relay-merge auto-appends)
+│     #   ## Learnings                  (LIVE once append writer is installed)
 │     #     <!-- LEARN:BEGIN -->
 │     #     - <date> (run #N): <one-line> [PR #X]
 │     #     <!-- LEARN:END -->
@@ -58,6 +59,26 @@ repo/
 └─ src/
 ```
 
+### Loose documents, strict handles
+
+Agents need room to reason in prose. They also need stable coordinates when another agent resumes later. The split:
+
+```
+Free-form reasoning
+  CHARTER prose
+  capability Goal / Scope / Behaviors
+  sprint Plan / Running Context
+
+Strict handles
+  objective IDs: O1, O2
+  capability IDs: sprint-execution
+  sprint component: one primary capability slug
+  LEARN markers
+  append-only Decisions / Learnings
+```
+
+The rule: constrain the address, not the thought. `component:` is a routing handle, so it is one primary capability slug. Multi-capability work belongs in sprint prose or Running Context, where agents can explain the secondary touches without making downstream writers guess.
+
 ### Mutation discipline per layer
 
 | Layer | Who writes | When | Gate |
@@ -66,7 +87,7 @@ repo/
 | `CHARTER.md` Objectives | human via amend; status advance proof-gated | when an objective is added/removed/proven | Tier 2 gate (existing) |
 | `CHARTER.md` Decisions | append-only | when a non-trivial cross-cutting decision is made | Tier 3 (existing) |
 | `spec/capabilities.md` Goal/Scope/Behaviors/HardConstraints per capability | human via `backlog-charter grill` (new mode) | when a capability's contract changes | challenge + confirm + apply |
-| `spec/capabilities.md` `## Learnings` blocks | **`dev-relay/scripts/append-learnings.js`** | end of every successful relay run with a `component:` tag | structurally bounded append between magic markers; rejects anything else |
+| `spec/capabilities.md` `## Learnings` blocks | **`dev-relay/scripts/append-learnings.js`** | end of every successful relay run with a primary `component:` tag | structurally bounded append between magic markers; rejects anything else |
 | `spec/capabilities.md` `## Decisions` blocks | human | when a capability-level decision is made | append-only by convention; promote to CHARTER Tier 3 if cross-cutting |
 
 ### Why single-file, not per-capability
@@ -85,7 +106,7 @@ From Langosco et al. 2022 (goal misgeneralization) + Manheim & Garrabrant 2018 (
 
 - **Misspecification:** the spec is wrong, agent exploits as written. Defense: explicit verifiable predicates.
 - **Goal misgeneralization:** spec is right, but agent's *internalized goal* diverges off-distribution. Defense: distributional robustness check in grill mode.
-- **Adversarial Goodhart:** agent edits the measurement apparatus to satisfy the spec. Defense: structural — agent has zero write access to spec content except the structurally-bounded Learnings append.
+- **Adversarial Goodhart:** agent edits the measurement apparatus to satisfy the spec. Defense: structural — working agents have no write path to spec content except the bounded Learnings append. Until the append writer exists in the target repo, docs must describe this as a contract, not an already-enforced property.
 
 ### 2. Control-theory framing
 
@@ -128,7 +149,7 @@ PR-3: live-update wiring (cross-repo: dev-backlog + dev-relay)
   ├─ skills/dev-backlog/SKILL.md                   (sprint task frontmatter: +component)
   ├─ (dev-relay repo) scripts/append-learnings.js  (NEW, ~50 LOC)
   ├─ (dev-relay repo) relay-merge hook integration
-  └─ Component-tag conflict resolution rule (single-component default; multi → first + warn)
+  └─ Component-tag conflict resolution rule: one primary capability slug; multi-component values fail lint
 ```
 
 ### Build-order rationale
@@ -158,8 +179,8 @@ These are flagged for the implementation PRs, not blockers for committing to M:
 
 - **D2** Naming: `spec/` (root) vs `docs/spec/` vs `.spec/`? Lean root — peer of `backlog/`. Confirm during PR-1.
 - **D3** `spec/capabilities.md` size warning threshold — 500 lines or 700? Tunable in the lint script.
-- **D4** Multi-component sprint task: append to first declared, warn (proposed) vs append to all (rejected: duplication) vs reject the run (rejected: too strict). Confirm in PR-3.
-- **D5** `component:` tag freeform string vs declared-only enum? Lean declared-only with a `--strict` flag default-off, with `component-lint.js` catching typos before they reach Learnings.
+- **D4** Multi-component sprint task: resolved to one primary capability slug. Secondary touches are prose, not routing metadata.
+- **D5** `component:` tag freeform string vs declared-only enum? Resolved to declared capability slug, with `component-lint.js` catching typos before they reach Learnings.
 
 ---
 

--- a/skills/backlog-charter/SKILL.md
+++ b/skills/backlog-charter/SKILL.md
@@ -72,7 +72,7 @@ See `references/amendment.md` for deep challenge and proof-gate heuristics.
 
 ## Grill Mode
 
-Use grill mode to author `spec/capabilities.md`, the middle layer between `CHARTER.md` and the active sprint. Invoked as `backlog-charter grill` (greenfield: no `spec/capabilities.md` yet) or `backlog-charter grill <capability-name>` (rerun: polish one capability without touching others).
+Use grill mode to author `spec/capabilities.md`, the middle layer between `CHARTER.md` and the active sprint. Invoked as `backlog-charter grill` (greenfield: no `spec/capabilities.md` yet) or `backlog-charter grill <capability-slug>` (rerun: polish one capability without touching others). Capability slugs are strict routing handles used by sprint `component:` frontmatter; keep them lowercase and singular, then put nuance in Goal/Scope prose.
 
 **On a brownfield repo** (existing code, no `spec/capabilities.md`), run `node skills/backlog-charter/scripts/extract-signals.js --json` first. It draws from README, CLAUDE.md/AGENTS.md, top-level source dirs, the last 100 commit messages, and `CHARTER.md` Objectives, and proposes capability candidates with signals + draft Goal + draft Scope. Use the draft as the interview seed; grill mode still pressure-tests every Behavior and Hard Constraint through the 3-axis test before commit. The script clusters by code organization (directory names, commit scopes), while real capabilities are functional contracts; expect grill mode to merge, split, or regroup draft candidates rather than adopt them verbatim. The script never writes `spec/capabilities.md` itself — that decision belongs to grill.
 
@@ -105,11 +105,11 @@ Grill mode applies the same challenge + confirm + apply discipline used by amend
 
 - Goal / In-scope / Out-of-scope are Tier-1-equivalent: challenge before applying. Default to no change.
 - Behaviors / Hard Constraints are Tier-2-equivalent: each must pass the 3-axis test. The test is the proof gate.
-- `## Learnings` and `## Decisions` are **not** interview targets. Learnings are appended by `dev-relay/scripts/append-learnings.js` between magic markers (`<!-- LEARN:BEGIN -->` / `<!-- LEARN:END -->`); Decisions are append-only by convention. Grill mode never edits either.
+- `## Learnings` and `## Decisions` are **not** interview targets. Learnings are appended by the bounded `append-learnings` writer between magic markers (`<!-- LEARN:BEGIN -->` / `<!-- LEARN:END -->`); Decisions are append-only by convention. Grill mode never edits either.
 
 ### Writing the File
 
-On first run, copy `templates/capabilities.md` to `spec/capabilities.md` at the repo root, then walk the interview for one capability. On rerun (`grill <capability-name>`), edit only the named capability block; leave the rest of the file untouched. If `spec/capabilities.md` does not exist on a rerun invocation, fall back to greenfield mode and surface the absence.
+On first run, copy `templates/capabilities.md` to `spec/capabilities.md` at the repo root, then walk the interview for one capability. On rerun (`grill <capability-slug>`), edit only the named capability block; leave the rest of the file untouched. If `spec/capabilities.md` does not exist on a rerun invocation, fall back to greenfield mode and surface the absence.
 
 After applying an accepted change, do **not** bump a revision number on `spec/capabilities.md` — `git blame` is the source of truth (per design doc §"NOT in scope"). Note in the conversation which capability was edited.
 

--- a/skills/backlog-charter/references/capabilities.md
+++ b/skills/backlog-charter/references/capabilities.md
@@ -1,25 +1,124 @@
 # Grill-Mode Heuristics for `spec/capabilities.md`
 
-Use this reference in `backlog-charter` grill mode after walking the per-capability interview flow in `SKILL.md`. It is a placeholder on day 1 — expand as real grill sessions surface findings that future authors should not have to re-discover.
+Use this reference in `backlog-charter` grill mode after walking the per-capability interview flow in `SKILL.md`. The flow, 3-axis predicate test, and tier gates live in `SKILL.md`; this file captures concrete dogfood patterns so future grill sessions do not relearn them.
 
-The interview flow itself, the 3-axis predicate test, and the tier-gate discipline live in `SKILL.md`. This doc is for the *deltas* — concrete patterns that work, anti-patterns that look reasonable but burn an agent down the line, examples of capabilities that survived a grill round and ones that did not.
+## Naming: Slug Handle vs. Prose Contract
 
-## What belongs here (planned)
+Capability headings are routing handles:
 
-- **Capability-naming patterns** — when to use a subsystem name (`sync-pull`) vs. a verb-phrase (`pulling open issues`) vs. an outcome (`fresh task mirror`). Bias: name the *contract*, not the implementation.
-- **Goal-line worked examples** — diagnosis-side framing leaking into Goal is the most common first-draft failure. Three or four real grill rewrites of bad Goal lines into good ones.
-- **3-axis test in action** — concrete predicates that fail the manipulability axis (and the structural restriction that fixed each one). Mostly TBD until PR-3 is dogfooded; until then, lean on `references/spec-system-research.md` for the theory.
-- **Hard Constraint anti-patterns** — "never do X unless asked" is not a Hard Constraint (asking is the loophole). Hard Constraints are unconditional; if they have an escape clause, they belong in Behaviors instead.
-- **Rerun protocol details** — what `grill <capability-name>` is allowed to touch and what it must leave alone. Especially: never re-grill `## Learnings` or `## Decisions`.
-- **Capability-count guidance** — at what point this single file should be split via `split-capabilities.js`, and what the migration looks like in practice.
+```md
+## Capability: backlog-sync
+```
 
-## What does not belong here
+Do not use a sentence or comma-separated name:
 
-- **The 3-axis predicate test itself.** Lives in `SKILL.md` so it is always loaded with the skill.
-- **The mutation discipline table.** Lives in `templates/capabilities.md` so authors see it when they open the file.
-- **Research grounding.** Lives in `references/spec-system-research.md` — cite, do not duplicate.
-- **Architecture rationale.** Lives in `docs/spec-system-design.md` — cite, do not duplicate.
+```md
+## Capability: pulling open issues
+## Capability: backlog-sync, task-progress-reporting
+```
 
-## Until this file is rich
+If the work touches several areas, keep the primary slug in sprint frontmatter and put the nuance in prose:
 
-Run grill mode against `SKILL.md` alone. The interview flow, the 3-axis test, and the tier gates are sufficient for the first few capabilities. Capture surprises from real grill sessions back into this doc — the most valuable entries are the ones a single user already had to learn the hard way.
+```yaml
+component: "charter-management"
+```
+
+```md
+Touches: charter-management primarily; also affects backlog-sync docs.
+```
+
+Bias: the slug is the address; Goal/Scope text is the explanation.
+
+## Goal-Line Rewrites
+
+Bad Goal lines usually describe diagnosis, implementation, or an internal tool. Good Goal lines describe what a user or agent can observe.
+
+| Draft | Better |
+|---|---|
+| "Reduce context loss across sprints." | "An agent resuming work mid-session reads the active sprint file and acts on in-flight items without re-asking what is going on." |
+| "`sync-pull.js` mirrors GitHub." | "Open GitHub Issues are mirrored into `backlog/tasks/*.md` without diverging on local AC checkbox state." |
+| "Backlog triage with CHARTER awareness." | "Open Issues are classified, related, flagged stale, and aligned to CHARTER Objectives without humans maintaining a parallel triage spreadsheet." |
+| "Keep CHARTER short." | "A user creates or amends `CHARTER.md` through tier-gated discipline and the file stays a 5-minute read." |
+
+Move diagnosis-side framing to CHARTER Problem. Move scripts and file names to In-scope unless the script is the user-visible surface.
+
+## Behavior vs. Hard Constraint
+
+Use Behaviors for expected positive outcomes. Use Hard Constraints for bright lines that remain true even when a user asks for the tempting shortcut.
+
+| Draft | Put it here | Why |
+|---|---|---|
+| "`sync-pull --update` preserves AC checkbox state." | Expected Behavior | It describes the normal successful outcome. |
+| "Never overwrite a non-machine-managed task body during `--update`." | Hard Constraint | It forbids data loss even if a refresh would be convenient. |
+| "Default triage produces a report and does not mutate GitHub." | Expected Behavior | It is the default flow users see. |
+| "Never close, relabel, or comment without `--apply`." | Hard Constraint | It protects the source of truth from silent mutation. |
+
+Avoid "never do X unless asked" as a Hard Constraint. The phrase "unless asked" is a loophole. If explicit user consent is valid, make it a Behavior with the consent condition.
+
+## 3-Axis Test Examples
+
+### Manipulability failure
+
+Predicate:
+
+> "`component-lint` passes for every sprint."
+
+Problem: an agent can satisfy this by deleting `spec/capabilities.md`, because absence is an opt-in no-op.
+
+Fix: separate the structural handle from the opt-in behavior.
+
+> "When `spec/capabilities.md` exists, every non-empty sprint `component:` value resolves to one declared capability slug."
+
+### Authority failure
+
+Predicate:
+
+> "Every run appends a Learning."
+
+Problem: the agent can append low-signal filler after every run, satisfying the count while polluting future context.
+
+Fix: encode the user intent.
+
+> "A successful relay run appends at most one Learning only when it discovered a reusable pattern, measured fact, or constraint that future runs need."
+
+### Distributional failure
+
+Predicate:
+
+> "`extract-signals` finds all capabilities from top-level dirs."
+
+Problem: it fails on repos whose useful boundaries are commit scopes, packages, or workflows rather than directories.
+
+Fix: scope the claim to draft seeding.
+
+> "`extract-signals` reports deterministic candidates from repo signals and marks whether each candidate is directory-backed or commit-scope-only."
+
+## Rerun Protocol
+
+`backlog-charter grill <capability-slug>` may touch:
+
+- `Goal`
+- `In-scope`
+- `Out-of-scope`
+- `Expected Behaviors`
+- `Hard Constraints`
+
+It must not touch:
+
+- `### Learnings`
+- `### Decisions`
+- other capability blocks
+- `CHARTER.md`, unless the user separately invokes amend mode
+
+If a rerun discovers a cross-cutting decision, append it to the relevant Decisions table or promote it to CHARTER via amend mode. Do not rewrite old Decisions rows.
+
+## Capability Count Guidance
+
+Keep the single-file `spec/capabilities.md` until it becomes hard to scan.
+
+Split later when either trigger is true:
+
+- the file exceeds roughly 500 lines
+- capability ownership boundaries require separate review/merge paths
+
+Until then, single-file is easier for agents: one read, one grep surface, fewer paths to rediscover.

--- a/skills/backlog-charter/references/spec-system-research.md
+++ b/skills/backlog-charter/references/spec-system-research.md
@@ -87,7 +87,7 @@ A multi-day autonomous run with no in-loop ground-truth check is **open-loop con
 
 ### What this means for spec-system v0.1
 
-- The structural defense against adversarial Goodhart (`append-learnings.js` is the only writer between magic markers) is **not** a stylistic choice; it is the only defense the 4-mode taxonomy considers reliable.
+- The structural defense against adversarial Goodhart (`append-learnings.js` is the only writer between magic markers once installed) is **not** a stylistic choice; it is the only defense the 4-mode taxonomy considers reliable.
 - The 3-axis predicate test maps cleanly: authority → IRD, distributional → goal misgeneralization, manipulability → adversarial Goodhart. Each axis defends against one *category* of failure; missing an axis means a category is unprotected.
 - O5 (auto-reassess) is critical-path under control-theory framing, but deferred until enough `## Learnings` data exists to inform what reassessment should do. Premature O5 closes the loop with noise.
 

--- a/skills/backlog-charter/scripts/extract-signals.js
+++ b/skills/backlog-charter/scripts/extract-signals.js
@@ -164,13 +164,18 @@ function summarizeReadme(readme) {
 }
 
 function buildCapability({ name, sourceRootName, signals, readmeSummary, charterObjectives }) {
+  const directorySignal = sourceRootName
+    ? signals.find((signal) => signal === `${sourceRootName}/${name}/`) || null
+    : null;
+  const commitSignals = signals.filter((signal) => signal.startsWith("commit-scope:"));
+
   const candidateGoal = readmeSummary
     ? `Draft (from README): ${readmeSummary} — refine via grill so the Goal names what the user observes when '${name}' works.`
     : `Draft: what the user observes when the '${name}' capability works. Fill in via grill.`;
 
-  const candidateScope = sourceRootName
-    ? `Owns the ${sourceRootName}/${name}/ surface. Out-of-scope deferred to grill.`
-    : `Owns the '${name}' surface. Out-of-scope deferred to grill.`;
+  const candidateScope = directorySignal
+    ? `Owns the ${directorySignal} surface. Out-of-scope deferred to grill.`
+    : `Inferred from commit scope '${name}'. Confirm the owning source surface and out-of-scope boundary in grill.`;
 
   const objectiveHint = charterObjectives.length > 0
     ? ` Candidate CHARTER objective served: ${charterObjectives[0].id} (${charterObjectives[0].predicate.slice(0, 80)}${charterObjectives[0].predicate.length > 80 ? "..." : ""}). Confirm in grill.`
@@ -179,6 +184,10 @@ function buildCapability({ name, sourceRootName, signals, readmeSummary, charter
   return {
     name,
     signals,
+    provenance: {
+      directory: directorySignal,
+      commit_scopes: commitSignals,
+    },
     candidate_goal: candidateGoal + objectiveHint,
     candidate_scope: candidateScope,
   };
@@ -271,6 +280,7 @@ function formatHumanReport(result) {
   }
 
   lines.push(`Capability candidates (${capabilities.length}, top ${Math.min(capabilities.length, SUMMARY_DIR_LIMIT)} shown):`);
+  lines.push("  Note: candidates cluster by repo signals; grill mode turns them into functional contracts.");
   for (const cap of capabilities.slice(0, SUMMARY_DIR_LIMIT)) {
     lines.push(`  - ${cap.name}`);
     lines.push(`      signals: ${cap.signals.join(", ")}`);

--- a/skills/backlog-charter/scripts/extract-signals.test.js
+++ b/skills/backlog-charter/scripts/extract-signals.test.js
@@ -211,6 +211,8 @@ describe("buildCapability", () => {
     });
     assert.match(cap.candidate_goal, /O1/);
     assert.match(cap.candidate_scope, /src\/auth\//);
+    assert.equal(cap.provenance.directory, "src/auth/");
+    assert.deepEqual(cap.provenance.commit_scopes, ["commit-scope:auth (4)"]);
   });
 
   it("falls back to placeholder goal when no readme summary", () => {
@@ -222,6 +224,20 @@ describe("buildCapability", () => {
       charterObjectives: [],
     });
     assert.match(cap.candidate_goal, /Fill in via grill/);
+  });
+
+  it("does not invent a path for commit-scope-only candidates", () => {
+    const cap = buildCapability({
+      name: "progress-sync",
+      sourceRootName: "skills",
+      signals: ["commit-scope:progress-sync (3)"],
+      readmeSummary: null,
+      charterObjectives: [],
+    });
+    assert.equal(cap.provenance.directory, null);
+    assert.deepEqual(cap.provenance.commit_scopes, ["commit-scope:progress-sync (3)"]);
+    assert.doesNotMatch(cap.candidate_scope, /skills\/progress-sync/);
+    assert.match(cap.candidate_scope, /Inferred from commit scope/);
   });
 });
 
@@ -307,8 +323,24 @@ revision: 1
     const ingest = result.capabilities.find((c) => c.name === "ingest");
     assert.ok(ingest.signals.some((s) => s.includes("src/ingest/")));
     assert.ok(ingest.signals.some((s) => s.includes("commit-scope:ingest")));
+    assert.equal(ingest.provenance.directory, "src/ingest/");
     assert.match(ingest.candidate_goal, /logging pipeline/);
     assert.match(ingest.candidate_goal, /O1/);
+  });
+
+  it("brownfield commit-scope-only: keeps provenance explicit without fake ownership", () => {
+    mkdir(repo, "src/worker");
+    const commits = ["feat(progress-sync): one", "fix(progress-sync): two"];
+    const result = extractSignals({
+      repoRoot: repo,
+      exec: () => commits.join("\n"),
+    });
+
+    const progressSync = result.capabilities.find((c) => c.name === "progress-sync");
+    assert.ok(progressSync);
+    assert.equal(progressSync.provenance.directory, null);
+    assert.match(progressSync.candidate_scope, /Confirm the owning source surface/);
+    assert.doesNotMatch(progressSync.candidate_scope, /src\/progress-sync/);
   });
 
   it("brownfield-thin: only src/ + commits, no README/CLAUDE", () => {
@@ -367,6 +399,7 @@ describe("formatHumanReport", () => {
     };
     const report = formatHumanReport(result);
     assert.match(report, /Capability candidates \(2/);
+    assert.match(report, /functional contracts/);
     assert.match(report, /auth/);
     assert.match(report, /billing/);
   });

--- a/skills/backlog-charter/templates/capabilities.md
+++ b/skills/backlog-charter/templates/capabilities.md
@@ -2,20 +2,22 @@
 
 This file is the middle layer between `CHARTER.md` (north star) and the active sprint (this week's tasks). Each capability describes one subsystem buckets-worth of work with a frozen-ish contract and a structurally-bounded live-feedback channel.
 
+Use loose prose and strict handles. Goal, scope, behaviors, sprint Plan, and Running Context are where agents can explain nuance. Capability IDs and sprint `component:` values are routing handles: use one lowercase slug such as `sprint-execution`, not a sentence or comma-separated list.
+
 Mutation discipline (matches the design doc):
 
 | Section | Who writes | When | Gate |
 |---|---|---|---|
 | `Goal`, `In-scope`, `Out-of-scope` | human via `backlog-charter grill` | when the contract changes | challenge + confirm + apply |
 | `Expected Behaviors`, `Hard Constraints` | human via grill | when a behavior or bright-line changes | grill + 3-axis predicate test |
-| `## Learnings` (between magic markers) | `append-learnings.js` only | end of every successful relay run tagged for this capability | structurally bounded append; rejects writes outside markers |
+| `## Learnings` (between magic markers) | `append-learnings.js` only | end of every successful relay run tagged with this primary capability slug | structurally bounded append; rejects writes outside markers |
 | `## Decisions` | human, append-only | when a capability-level decision is made | append-only by convention; promote to CHARTER if cross-cutting |
 
 When this file exceeds ~500 lines, run `split-capabilities.js` to migrate to `spec/components/<name>.md`. Do not pre-split.
 
 ---
 
-## Capability: <name>
+## Capability: <slug>
 
 **Goal:** <one sentence: what the user can observe when this works>
 
@@ -36,7 +38,7 @@ When this file exceeds ~500 lines, run `split-capabilities.js` to migrate to `sp
 
 ### Learnings
 <!-- LEARN:BEGIN -->
-<!-- entries appended by dev-relay/scripts/append-learnings.js after each successful relay run -->
+<!-- entries appended by the bounded append-learnings writer after successful relay runs -->
 <!-- format: - YYYY-MM-DD (run #N): <one-line> [PR #X] -->
 <!-- LEARN:END -->
 

--- a/skills/dev-backlog/SKILL.md
+++ b/skills/dev-backlog/SKILL.md
@@ -62,7 +62,7 @@ backlog/
 
 The sprint file in `backlog/sprints/` is the execution hub. One file per sprint.
 The `objectives` frontmatter field lists the `CHARTER.md` Objective IDs this sprint advances; it is `[]` when the project has no `CHARTER.md`.
-The `component` field names a single capability from `spec/capabilities.md` whose `## Learnings` block receives an entry when a relay run merges. Empty string means no live-update target.
+The `component` field is one primary routing handle from `spec/capabilities.md`. It names the single capability whose `## Learnings` block receives an entry when a relay run merges. Empty string means no live-update target. If a sprint touches secondary areas, mention them in the sprint body or Running Context instead of adding more frontmatter values.
 
 ```markdown
 ---
@@ -239,4 +239,4 @@ All scripts live in `${CLAUDE_SKILL_DIR}/scripts/` (the skill's own directory, n
 - `scripts/sprint-close.sh [backlog-dir] [--dry-run] [--close-milestone]` — Close active sprint: set completed, move tasks, remind about context promotion
 - `scripts/context-hook.sh [backlog-dir]` — One-line sprint summary for Claude Code PreToolUse hook (always exits 0)
 - `scripts/objectives-check.js [--sprints-dir PATH] [--charter PATH] [--json]` — Verify every `objectives:` ID in sprint files still exists in `CHARTER.md` with an actionable (non-deferred) status. Graceful no-op when `CHARTER.md` is absent.
-- `scripts/component-lint.js [--sprints-dir PATH] [--capabilities PATH] [--json]` — Verify every `component:` value in sprint files resolves to a declared capability in `spec/capabilities.md`. Multi-component values (comma-separated) follow design doc D4: first declared wins + warn on secondary entries. Graceful no-op when `spec/capabilities.md` is absent.
+- `scripts/component-lint.js [--sprints-dir PATH] [--capabilities PATH] [--json]` — Verify every `component:` value in sprint files resolves to one declared capability in `spec/capabilities.md`. Comma-separated multi-component values fail because `component:` is the primary routing handle; put secondary touches in sprint prose. Graceful no-op when `spec/capabilities.md` is absent.

--- a/skills/dev-backlog/references/integration-contract.md
+++ b/skills/dev-backlog/references/integration-contract.md
@@ -32,6 +32,23 @@ dev-relay reads and writes specific `## ` sections in the active sprint file.
 
 Extraction: read lines between the matched `## ` heading and the next `## ` heading (or EOF). See `lib.sh:extract_section()` for the canonical implementation.
 
+## Sprint Frontmatter: Component Routing
+
+The optional `component:` field is one primary routing handle into `spec/capabilities.md`.
+
+```yaml
+component: "charter-management"
+```
+
+Rules:
+
+- Empty string means there is no capability Learnings target.
+- Non-empty values must match exactly one `## Capability: <slug>` heading in `spec/capabilities.md`.
+- Comma-separated values are invalid. If a sprint touches secondary areas, write that in `## Running Context` or sprint prose.
+- `component-lint.js` owns validation on the dev-backlog side.
+
+This is intentionally stricter than normal markdown prose. The field is an address for downstream writers, not a place to explain scope.
+
 ## Checkbox States
 
 Sprint plan items use this format:
@@ -119,6 +136,42 @@ When relay-merge completes a task, it updates the active sprint file in these sp
 ```
 - Topic: concise discovery. (e.g., "OAuth2: PKCE flow using jose library")
 ```
+
+## Capability Learnings Append Contract
+
+When `spec/capabilities.md` exists and the active sprint has a primary `component:` value, relay-merge may append one capability-level Learning after a successful run. This is a narrow writer contract, not permission for working agents to edit the capability spec.
+
+Inputs:
+
+| Field | Meaning |
+|---|---|
+| `component` | Primary capability slug from sprint frontmatter |
+| `date` | `YYYY-MM-DD` append date |
+| `run_id` | Relay run identifier, when available |
+| `summary` | One-line observation from the completed run |
+| `pr` | Merged PR number, when available |
+
+Target:
+
+```
+spec/capabilities.md
+  ## Capability: <component>
+    ### Learnings
+    <!-- LEARN:BEGIN -->
+    - YYYY-MM-DD (run <run_id>): <summary> [PR #N]
+    <!-- LEARN:END -->
+```
+
+Required behavior:
+
+- Reject missing `spec/capabilities.md`; do not silently create it.
+- Reject unknown `component` values.
+- Reject duplicate, missing, or nested `LEARN` markers in the target capability block.
+- Reject writes that would modify text outside the marker pair.
+- Prefer idempotency for the same `run_id`; if exact idempotency is impossible, document the rerun behavior in the relay result.
+- If the append succeeds but commit/push does not happen, surface that explicitly. A local-only Learning is not durable project state.
+
+Until the append writer is installed in the target repo, docs should describe this as a contract to implement, not as an already-enforced property.
 
 ### Run-ID Annotation (optional)
 

--- a/skills/dev-backlog/scripts/component-lint.js
+++ b/skills/dev-backlog/scripts/component-lint.js
@@ -6,17 +6,16 @@
  * Usage: ./scripts/component-lint.js [--sprints-dir PATH] [--capabilities PATH] [--json]
  *
  * Behavior:
- *   - Reads spec/capabilities.md and collects "## Capability: <name>" headers.
+ *   - Reads spec/capabilities.md and collects "## Capability: <slug>" headers.
  *   - For each backlog/sprints/*.md, extracts `component:` from frontmatter.
- *   - Reports sprints whose component value (single or comma-separated multi)
- *     does not match any declared capability.
- *   - Per design doc D4: multi-component values use first-declared + warn.
- *     The first value must resolve; subsequent values are flagged as warnings,
- *     not errors.
+ *   - Reports sprints whose component value does not match any declared
+ *     capability.
+ *   - `component:` is one primary routing handle. Comma-separated values fail
+ *     with guidance to keep secondary touches in sprint prose.
  *   - Graceful no-op when spec/capabilities.md is absent (skill is opt-in).
  *
  * Exit codes:
- *   0  no errors (warnings OK), or spec/capabilities.md absent
+ *   0  no errors, or spec/capabilities.md absent
  *   1  one or more component values do not resolve
  */
 
@@ -92,7 +91,7 @@ function parseCapabilityNames(content) {
   const names = new Set();
   const lines = content.split("\n");
   for (const line of lines) {
-    const match = line.match(/^## Capability:\s+(\S+)/);
+    const match = line.match(/^## Capability:\s+([a-z][a-z0-9-]*)\s*$/);
     if (match) names.add(match[1]);
   }
   return names;
@@ -108,19 +107,19 @@ function listSprintFiles(sprintsDir, { readdir = fs.readdirSync, fileExists = fs
 
 function classifyComponents(components, declared) {
   const errors = [];
-  const warnings = [];
-  if (components.length === 0) return { errors, warnings };
+  const invalid = [];
+  if (components.length === 0) return { errors, invalid };
 
-  const [primary, ...rest] = components;
-  if (!declared.has(primary)) errors.push(primary);
-  for (const extra of rest) {
-    if (!declared.has(extra)) {
-      errors.push(extra);
-    } else {
-      warnings.push(extra);
-    }
+  if (components.length > 1) {
+    invalid.push(
+      `multiple component values (${components.join(", ")}); choose one primary capability slug and mention secondary touches in the sprint body`,
+    );
+    return { errors, invalid };
   }
-  return { errors, warnings };
+
+  const [primary] = components;
+  if (!declared.has(primary)) errors.push(primary);
+  return { errors, invalid };
 }
 
 function findIssues(sprintFiles, declared, { readFile = fs.readFileSync } = {}) {
@@ -129,9 +128,9 @@ function findIssues(sprintFiles, declared, { readFile = fs.readFileSync } = {}) 
     const content = readFile(file, "utf-8");
     const components = parseSprintComponents(content);
     if (components.length === 0) continue;
-    const { errors, warnings } = classifyComponents(components, declared);
-    if (errors.length === 0 && warnings.length === 0) continue;
-    issues.push({ sprintFile: file, components, unknown: errors, secondary: warnings });
+    const { errors, invalid } = classifyComponents(components, declared);
+    if (errors.length === 0 && invalid.length === 0) continue;
+    issues.push({ sprintFile: file, components, unknown: errors, invalid });
   }
   return issues;
 }
@@ -162,7 +161,7 @@ function lintComponents({
 }
 
 function hasErrors(result) {
-  return result.issues.some((issue) => issue.unknown.length > 0);
+  return result.issues.some((issue) => issue.unknown.length > 0 || (issue.invalid || []).length > 0);
 }
 
 function formatReport(result) {
@@ -181,8 +180,8 @@ function formatReport(result) {
     if (issue.unknown.length > 0) {
       lines.push(`    - unknown component(s): ${issue.unknown.join(", ")}`);
     }
-    if (issue.secondary.length > 0) {
-      lines.push(`    - warning: secondary component(s) ignored per D4 (first-wins): ${issue.secondary.join(", ")}`);
+    if (issue.invalid.length > 0) {
+      for (const invalid of issue.invalid) lines.push(`    - invalid component: ${invalid}`);
     }
   }
   return lines.join("\n");

--- a/skills/dev-backlog/scripts/component-lint.test.js
+++ b/skills/dev-backlog/scripts/component-lint.test.js
@@ -125,6 +125,11 @@ describe("parseCapabilityNames", () => {
   it("returns empty set when no Capability headers", () => {
     assert.equal(parseCapabilityNames("# Just a heading").size, 0);
   });
+
+  it("does not treat prose headings as capability slugs", () => {
+    const names = parseCapabilityNames("## Capability: pulling open issues\n");
+    assert.equal(names.size, 0);
+  });
 });
 
 describe("listSprintFiles", () => {
@@ -151,32 +156,33 @@ describe("listSprintFiles", () => {
 describe("classifyComponents", () => {
   const declared = new Set(["sprint-execution", "backlog-sync", "charter-management"]);
 
-  it("returns empty errors/warnings for empty input", () => {
-    assert.deepEqual(classifyComponents([], declared), { errors: [], warnings: [] });
+  it("returns empty errors for empty input", () => {
+    assert.deepEqual(classifyComponents([], declared), { errors: [], invalid: [] });
   });
 
   it("primary unknown is an error", () => {
     const r = classifyComponents(["unknown-cap"], declared);
     assert.deepEqual(r.errors, ["unknown-cap"]);
-    assert.deepEqual(r.warnings, []);
+    assert.deepEqual(r.invalid, []);
   });
 
   it("primary known is silent", () => {
     const r = classifyComponents(["sprint-execution"], declared);
     assert.deepEqual(r.errors, []);
-    assert.deepEqual(r.warnings, []);
+    assert.deepEqual(r.invalid, []);
   });
 
-  it("secondary known is a warning per D4 (first-wins)", () => {
+  it("secondary known is invalid because component is one primary routing handle", () => {
     const r = classifyComponents(["sprint-execution", "backlog-sync"], declared);
     assert.deepEqual(r.errors, []);
-    assert.deepEqual(r.warnings, ["backlog-sync"]);
+    assert.equal(r.invalid.length, 1);
+    assert.match(r.invalid[0], /choose one primary capability slug/);
   });
 
-  it("secondary unknown is an error AND signals a typo", () => {
+  it("secondary unknown is invalid before typo classification", () => {
     const r = classifyComponents(["sprint-execution", "typo-cap"], declared);
-    assert.deepEqual(r.errors, ["typo-cap"]);
-    assert.deepEqual(r.warnings, []);
+    assert.deepEqual(r.errors, []);
+    assert.equal(r.invalid.length, 1);
   });
 });
 
@@ -195,7 +201,7 @@ describe("findIssues", () => {
 
       const byName = (name) => issues.find((i) => i.sprintFile.endsWith(name));
       assert.deepEqual(byName("bad.md").unknown, ["typo-cap"]);
-      assert.deepEqual(byName("multi.md").secondary, ["backlog-sync"]);
+      assert.match(byName("multi.md").invalid[0], /multiple component values/);
       assert.deepEqual(byName("multi.md").unknown, []);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
@@ -234,15 +240,32 @@ describe("lintComponents", () => {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("accepts a real sprint file with a valid single component", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "comp-lint-valid-"));
+    try {
+      const sprintsDir = path.join(dir, "backlog", "sprints");
+      const capPath = path.join(dir, "spec", "capabilities.md");
+      fs.mkdirSync(sprintsDir, { recursive: true });
+      fs.mkdirSync(path.dirname(capPath), { recursive: true });
+      fs.writeFileSync(capPath, SAMPLE_CAPABILITIES);
+      fs.writeFileSync(
+        path.join(sprintsDir, "2026-05-routing.md"),
+        "---\ncomponent: sprint-execution\n---\nbody",
+      );
+      const result = lintComponents({ sprintsDir, capabilitiesPath: capPath });
+      assert.equal(result.capabilitiesFound, true);
+      assert.equal(result.sprintCount, 1);
+      assert.deepEqual(result.issues, []);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("hasErrors", () => {
   it("true when any issue has unknown components", () => {
-    assert.equal(hasErrors({ issues: [{ unknown: ["x"], secondary: [] }] }), true);
-  });
-
-  it("false when only warnings", () => {
-    assert.equal(hasErrors({ issues: [{ unknown: [], secondary: ["y"] }] }), false);
+    assert.equal(hasErrors({ issues: [{ unknown: ["x"], invalid: [] }] }), true);
   });
 
   it("false when no issues", () => {
@@ -267,15 +290,33 @@ describe("formatReport", () => {
     assert.match(formatReport(result), /All component values resolve/);
   });
 
-  it("renders issue listing with errors and warnings", () => {
+  it("renders issue listing with errors", () => {
     const result = {
       capabilitiesFound: true,
       capabilitiesPath: "spec/capabilities.md",
       declaredCapabilities: ["a", "b"],
       sprintCount: 2,
-      issues: [{ sprintFile: "x.md", components: ["typo", "b"], unknown: ["typo"], secondary: [] }],
+      issues: [{ sprintFile: "x.md", components: ["typo", "b"], unknown: ["typo"], invalid: [] }],
     };
     const report = formatReport(result);
     assert.match(report, /unknown component\(s\): typo/);
+  });
+
+  it("renders invalid multi-component guidance", () => {
+    const result = {
+      capabilitiesFound: true,
+      capabilitiesPath: "spec/capabilities.md",
+      declaredCapabilities: ["a", "b"],
+      sprintCount: 1,
+      issues: [{
+        sprintFile: "x.md",
+        components: ["a", "b"],
+        unknown: [],
+        invalid: ["multiple component values (a, b); choose one primary capability slug"],
+      }],
+    };
+    const report = formatReport(result);
+    assert.match(report, /invalid component/);
+    assert.match(report, /choose one primary capability slug/);
   });
 });

--- a/spec/capabilities.md
+++ b/spec/capabilities.md
@@ -2,7 +2,9 @@
 
 The middle layer between [`CHARTER.md`](../CHARTER.md) and the active sprint. Each block describes one subsystem-worth of work with a frozen-ish contract and a structurally bounded live-feedback channel.
 
-Mutation discipline matches [`docs/spec-system-design.md`](../docs/spec-system-design.md): Goal/Scope/Behaviors/HardConstraints are human-gated via `backlog-charter grill`; `## Learnings` is appended only by `dev-relay/scripts/append-learnings.js` between magic markers; `## Decisions` is append-only by convention.
+Mutation discipline matches [`docs/spec-system-design.md`](../docs/spec-system-design.md): Goal/Scope/Behaviors/HardConstraints are human-gated via `backlog-charter grill`; `## Learnings` is appended only by a bounded `append-learnings` writer between magic markers; `## Decisions` is append-only by convention.
+
+Capability headings are strict routing handles. Use one lowercase slug after `## Capability:` and point sprint `component:` frontmatter at exactly one of those slugs. Put secondary touches in sprint prose, not in frontmatter.
 
 ---
 


### PR DESCRIPTION
## Summary

This PR implements the loose-documents / strict-handles direction for the spec system. Agents keep freedom in prose, but machine-routing handles are now small, stable, and lintable.

## Changes

- Make sprint `component:` a single primary capability slug and fail comma-separated values in `component-lint.js`.
- Require capability headings to be slug handles when linting `spec/capabilities.md`.
- Add provenance to `extract-signals.js` so commit-scope-only candidates no longer invent fake source paths.
- Document the bounded Learnings append contract and downgrade claims that depend on the writer until it exists.
- Replace placeholder grill heuristics with concrete dogfood examples for naming, Goal rewrites, Behavior vs Hard Constraint, 3-axis failures, rerun protocol, and capability count.

## Validation

- `node --test skills/backlog-charter/scripts/*.test.js skills/dev-backlog/scripts/*.test.js skills/backlog-triage/scripts/*.test.js`
- `node skills/dev-backlog/scripts/component-lint.js`
- `node skills/backlog-charter/scripts/check-size.js`
- `git diff --check`

## Issues

Closes #120
Closes #121
Refs #122
Closes #123
Closes #124
