### PR TITLE
[codex] Simplify reassess docs ownership

### DIFF
--- a/docs/spec-system-design.md
+++ b/docs/spec-system-design.md
@@ -3,7 +3,7 @@
 **Status:** Approved (M tier) · **Date:** 2026-05-23 · **Author:** session capture
 **Supersedes:** — · **Related:** [`CHARTER.md`](../CHARTER.md), [`skills/backlog-charter/`](../skills/backlog-charter/)
 
-A layered, brownfield-friendly project spec system that survives multi-day autonomous agent execution without rubber-stamping itself into uselessness. This doc captures the chosen architecture, the research that grounds it, the build order, and the open questions deferred to follow-up specs.
+A layered, brownfield-friendly project spec system that survives multi-day autonomous agent execution without rubber-stamping itself into uselessness. This doc captures the current architecture, durable policy, research grounding, and historical implementation evidence.
 
 ---
 
@@ -90,6 +90,14 @@ The rule: constrain the address, not the thought. `component:` is a routing hand
 | `spec/capabilities.md` `## Learnings` blocks | **`dev-relay/scripts/append-learnings.js`** | end of every successful relay run with a primary `component:` tag | structurally bounded append between magic markers; rejects anything else |
 | `spec/capabilities.md` `## Decisions` blocks | human | when a capability-level decision is made | append-only by convention; promote to CHARTER Tier 3 if cross-cutting |
 
+### Reassess source-of-truth map
+
+| Artifact | Owns | Does not own |
+|---|---|---|
+| `skills/backlog-charter/SKILL.md` | short dispatch contract: when to invoke modes, no-edit boundary, required reassess report sections | detailed reassess heuristics |
+| `skills/backlog-charter/references/reassess.md` | operational reassess procedure: evidence order, report shape, recommendation rules, Learning Actions, stale-spec failure modes | durable naming policy or historical build notes |
+| `docs/spec-system-design.md` | durable design policy: lifecycle, naming policy, mutation discipline, split/defer triggers, historical rationale | step-by-step skill execution details |
+
 ### Stale-spec lifecycle
 
 Accepted specs are useful only while they still match product reality. The system therefore needs a small reassessment loop, but not autonomous self-editing:
@@ -97,10 +105,23 @@ Accepted specs are useful only while they still match product reality. The syste
 1. **Setpoint:** `CHARTER.md` and `spec/capabilities.md` describe the accepted project/capability contracts.
 2. **Sensor:** relay and sprint execution append bounded observations as `## Learnings` or sprint context.
 3. **Diagnosis:** deterministic scripts report structural signals first (`capabilities-doctor.js`, `component-lint.js`); `backlog-charter reassess` turns those signals into a report.
-4. **Human gate:** accepted changes route through `backlog-charter amend`, `backlog-charter grill <capability>`, or a separate user-approved Learnings compaction edit.
+4. **Human gate:** accepted changes route through `backlog-charter amend`, `backlog-charter grill <capability>`, or a separate user-approved Learning Action.
 5. **No silent controller:** reassess may recommend edits, promotion, or archival, but it must not edit CHARTER direction, capability Goal/Scope/Behaviors/Hard Constraints, Decisions, or Learnings while diagnosing.
 
 This keeps freedom where agents need it (reasoning over evidence) and control where the spec could otherwise rationalize itself into noise.
+
+### Learning Actions
+
+`## Learnings` is a live sensor, not an audit log. Keep the most recent 5-7 entries inline per capability so the file stays useful during agent startup.
+
+Learning Action is the canonical umbrella term for accepted cleanup after reassess:
+
+- **Keep inline** when a recent Learning is still useful startup context.
+- **Promote to capability Decisions** when it describes a durable capability-level rule.
+- **Promote to CHARTER Decisions** when it changes the project-wide axis.
+- **Archive outside the hot `spec/capabilities.md` path** when it is useful history but no longer startup context.
+
+Reassess may recommend a Learning Action, but diagnosis itself does not rewrite Learnings. The edit is a separate user-approved manual change.
 
 ### Command surface and reserved names
 
@@ -151,9 +172,53 @@ Before any capability Behavior or Hard Constraint is committed:
 2. **Distributional axis:** does this predicate hold in unseen code areas / unseen workloads? If no → restate as environment-independent.
 3. **Manipulability axis:** can an agent satisfy this by editing the measurement channel rather than the system? If yes → add a structural restriction outside the spec.
 
+## NOT in scope (deferred with rationale)
+
+| Deferred | Rationale | Promotion trigger |
+|---|---|---|
+| Per-capability files (`spec/components/*.md`) | YAGNI; a compact single file is easier to read and route through while under budget | `spec/capabilities.md` > 500 lines, >15 capabilities, or ownership demands |
+| ADR directory (`spec/decisions/*.md`) | CHARTER Decisions + per-capability `## Decisions` suffice | Cross-cutting decision volume > 10 in a quarter |
+| Adversarial grill subagent (separate context) | Single-context grill is testable now; subagent dispatch is an innovation token | Observed self-rationalization in working agent |
+| Cross-capability dependency graph | Over-engineering; readable from prose | Multiple capability authors complain about silent coupling |
+| Per-capability `revision:` / `last_amended:` | `git blame` is the source of truth | Auditing demand from outside the team |
+| Automated reassess hooks in sprint-close / relay-merge | Manual report-only reassess must prove useful before hooks add noise to execution paths | Repeated manual reassess reports produce the same actionable recommendation |
+| Auto-promotion of Learnings into Decisions or CHARTER | Promotion changes accepted authority and must stay human-gated | Explicit user asks for a promotion pass and reviews the proposed diff |
+
 ---
 
-## Implementation plan (3 PRs, ordered)
+## Design decisions and watchpoints
+
+These are current policy anchors carried forward from implementation. They are not active implementation tasks unless new evidence reopens them.
+
+- **D2** `spec/` location — resolved: root `spec/`, peer of `backlog/`, not `docs/spec/` or `.spec/`.
+- **D3** `spec/capabilities.md` size warning threshold — resolved: warn above 12 capabilities or 400 lines; recommend split above 500 lines, 15 capabilities, or ownership-boundary pressure.
+- **D4** Multi-component sprint task: resolved to one primary capability slug. Secondary touches are prose, not routing metadata.
+- **D5** `component:` tag freeform string vs declared-only enum? Resolved to declared capability slug, with `component-lint.js` catching typos before they reach Learnings.
+
+---
+
+## Migration path to "L tier" (full Approach A) — if needed
+
+Strangler-fig. None of these requires re-architecture, just expansion:
+
+1. `spec/capabilities.md` outgrows comfort → `split-capabilities.js` migrates to `spec/components/<name>.md`. SKILL.md routes the same gates over the new file shape.
+2. Decision volume justifies ADRs → `spec/decisions/<NNNN>-<slug>.md` with a tiny ADR template. Per-capability `## Decisions` sections become a "lite" entry point.
+3. Working agent shows rationalization tells in grill mode → adversarial grill runs as a subagent with separate context. `backlog-charter` SKILL.md gains a `--adversarial-subagent` flag.
+4. Reserved/non-callable names (`spec-grill`, `spec-reassess`, `spec-learn`) become real skills only if the triggers in [Command surface and reserved names](#command-surface-and-reserved-names) fire.
+
+Every L-tier feature is a YAGNI-violating addition until it's not. Defer until signal.
+
+### Learning Actions pointer
+
+Learning Actions are defined in [Learning Actions](#learning-actions). Any future L-tier extension must preserve the rule that reassess recommends and a separate user-approved action edits.
+
+---
+
+## Historical Implementation Notes
+
+This section records how the v0.1 spec system and reassess MVP were built. It is historical context, not current operating policy; current policy lives above.
+
+### v0.1 implementation plan (historical)
 
 ```
 PR-1: template + SKILL.md extension (no executable code)
@@ -179,9 +244,9 @@ PR-3: live-update wiring (cross-repo: dev-backlog + dev-relay)
   └─ Component-tag conflict resolution rule: one primary capability slug; multi-component values fail lint
 ```
 
-### Reassess MVP follow-up
+### Reassess MVP implementation note (completed by PR #142)
 
-After v0.1, the next increment is deliberately smaller than full automation:
+PR #142 implemented the deliberately small follow-up after v0.1:
 
 ```
 PR-4: stale-spec reassess MVP
@@ -197,7 +262,7 @@ Future only if dogfood proves need:
   └─ relay-merge reassess hints
 ```
 
-### Build-order rationale
+### Build-order rationale (historical)
 
 1. **Template first** because the layered structure is the only innovation token; everything else (scripts, hooks) is plumbing. Validate the structure with a real dogfood (writing dev-backlog's own `spec/capabilities.md`) before building scaffolding around it.
 2. **Bootstrap second** because brownfield extraction is the proof that this works on "any real repo, not just greenfield toys." Test against `dev-relay` (rich enough, real enough).
@@ -205,57 +270,9 @@ Future only if dogfood proves need:
 
 ---
 
-## NOT in scope (deferred with rationale)
+## Historical Dogfood Evidence
 
-| Deferred | Rationale | Promotion trigger |
-|---|---|---|
-| Per-capability files (`spec/components/*.md`) | YAGNI; a compact single file is easier to read and route through while under budget | `spec/capabilities.md` > 500 lines, >15 capabilities, or ownership demands |
-| ADR directory (`spec/decisions/*.md`) | CHARTER Decisions + per-capability `## Decisions` suffice | Cross-cutting decision volume > 10 in a quarter |
-| Adversarial grill subagent (separate context) | Single-context grill is testable now; subagent dispatch is an innovation token | Observed self-rationalization in working agent |
-| Cross-capability dependency graph | Over-engineering; readable from prose | Multiple capability authors complain about silent coupling |
-| Per-capability `revision:` / `last_amended:` | `git blame` is the source of truth | Auditing demand from outside the team |
-| Automated reassess hooks in sprint-close / relay-merge | Manual report-only reassess must prove useful before hooks add noise to execution paths | Repeated manual reassess reports produce the same actionable recommendation |
-| Auto-promotion of Learnings into Decisions or CHARTER | Promotion changes accepted authority and must stay human-gated | Explicit user asks for a promotion pass and reviews the proposed diff |
-
----
-
-## Open questions
-
-These are flagged for the implementation PRs, not blockers for committing to M:
-
-- **D2** Naming: `spec/` (root) vs `docs/spec/` vs `.spec/`? Lean root — peer of `backlog/`. Confirm during PR-1.
-- **D3** `spec/capabilities.md` size warning threshold — resolved: warn above 12 capabilities or 400 lines; recommend split above 500 lines, 15 capabilities, or ownership-boundary pressure.
-- **D4** Multi-component sprint task: resolved to one primary capability slug. Secondary touches are prose, not routing metadata.
-- **D5** `component:` tag freeform string vs declared-only enum? Resolved to declared capability slug, with `component-lint.js` catching typos before they reach Learnings.
-
----
-
-## Migration path to "L tier" (full Approach A) — if needed
-
-Strangler-fig. None of these requires re-architecture, just expansion:
-
-1. `spec/capabilities.md` outgrows comfort → `split-capabilities.js` migrates to `spec/components/<name>.md`. SKILL.md routes the same gates over the new file shape.
-2. Decision volume justifies ADRs → `spec/decisions/<NNNN>-<slug>.md` with a tiny ADR template. Per-capability `## Decisions` sections become a "lite" entry point.
-3. Working agent shows rationalization tells in grill mode → adversarial grill runs as a subagent with separate context. `backlog-charter` SKILL.md gains a `--adversarial-subagent` flag.
-4. Reserved/non-callable names (`spec-grill`, `spec-reassess`, `spec-learn`) become real skills only if the triggers in [Command surface and reserved names](#command-surface-and-reserved-names) fire.
-
-Every L-tier feature is a YAGNI-violating addition until it's not. Defer until signal.
-
-### Learnings compaction
-
-`## Learnings` is a live sensor, not an audit log. Keep the most recent 5-7 entries inline per capability so the file stays useful during agent startup. Older entries should be:
-
-- promoted to `## Decisions` when they describe a durable capability-level rule
-- promoted to CHARTER Decisions when they change the project-wide axis
-- archived outside the hot `spec/capabilities.md` path when they are useful history but no longer startup context
-
-Compaction is human-gated or doctor-suggested. Relay's bounded writer may append between markers, but it must not silently delete, rewrite, or archive Learnings.
-
-`backlog-charter reassess` may recommend compaction, promotion, or archival. If the user accepts a Learning Action, reassess ends and the edit happens as a separate user-approved manual change; diagnosis itself does not rewrite Learnings.
-
----
-
-## Dogfood plan
+This section records calibration evidence. It should inform future changes, but it is not the current operating procedure for every reassess run.
 
 The most authentic test of this spec system is applying it to projects we already understand:
 

--- a/skills/backlog-charter/SKILL.md
+++ b/skills/backlog-charter/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: backlog-charter
 argument-hint: "[create|amend|grill|reassess]"
-description: Create, amend, grill, and reassess the project spec axis: CHARTER.md plus spec/capabilities.md. Use to establish or evolve project direction, author capability contracts, review stale specs, recommend Learnings compaction, or decide whether Behaviors/Constraints still match execution evidence. 프로젝트 축, 기준, 헌장, 능력 명세, stale spec, spec reassess.
+description: Create, amend, grill, and reassess the project spec axis: CHARTER.md plus spec/capabilities.md. Use to establish or evolve project direction, author capability contracts, review stale specs, recommend Learning Actions, or decide whether Behaviors/Constraints still match execution evidence. 프로젝트 축, 기준, 헌장, 능력 명세, stale spec, spec reassess.
 compatibility: Requires git. Works on Claude Code and Codex.
 metadata:
   related-skills: "dev-backlog, backlog-triage"
@@ -120,7 +120,7 @@ Grill mode applies the same challenge + confirm + apply discipline used by amend
 
 - Goal / In-scope / Out-of-scope are Tier-1-equivalent: challenge before applying. Default to no change.
 - Behaviors / Hard Constraints are Tier-2-equivalent: each must pass the 3-axis test. The test is the proof gate.
-- `## Learnings` and `## Decisions` are **not** interview targets. Learnings are appended by the bounded `append-learnings` writer between magic markers (`<!-- LEARN:BEGIN -->` / `<!-- LEARN:END -->`); Decisions are append-only by convention. Grill mode never edits either, but it may recommend human-gated compaction when a capability has more than 5-7 inline Learnings.
+- `## Learnings` and `## Decisions` are **not** interview targets. Learnings are appended by the bounded `append-learnings` writer between magic markers (`<!-- LEARN:BEGIN -->` / `<!-- LEARN:END -->`); Decisions are append-only by convention. Grill mode never edits either, but it may recommend a user-approved Learning Action when a capability has more than 5-7 inline Learnings.
 
 ### Writing the File
 
@@ -132,25 +132,16 @@ See `references/capabilities.md` for additional grill heuristics (placeholder on
 
 ## Reassess Mode
 
-Use reassess mode when the user asks whether `CHARTER.md` or `spec/capabilities.md` is stale, asks to review Learnings, or wants a periodic spec health check. Reassess never edits files: it diagnoses drift and recommends next actions, but accepted fixes must be applied by a separate amend, grill, or explicit human-gated compaction pass.
+Use reassess mode when the user asks whether `CHARTER.md` or `spec/capabilities.md` is stale, asks to review Learnings, or wants a periodic spec health check.
 
-Start with bounded deterministic evidence:
+Reassess never edits files. It diagnoses drift and recommends next actions; accepted fixes must run through `backlog-charter amend`, `backlog-charter grill <capability>`, or a separate user-approved Learning Action.
 
-1. Resolve helper scripts from the installed dev-backlog skill directory. In this repo that is `skills/dev-backlog/scripts/`; in another target repo use the installed skill path. If unavailable, report Missing Evidence.
-2. If `spec/capabilities.md` exists, run `node <dev-backlog-skill-dir>/scripts/capabilities-doctor.js --json` when available.
-3. If backlog sprints exist, run `node <dev-backlog-skill-dir>/scripts/component-lint.js --json` when available.
-4. Read `CHARTER.md`, `spec/capabilities.md`, the active sprint, and at most the latest five completed sprint files only as needed to explain the evidence. Do not recursively scan the repo unless the user asks for a deeper audit.
+Dispatch contract:
 
-Emit a structured report with separate evidence and recommendations:
-
-- **No Change** — areas that still look aligned.
-- **Grill Candidates** — capability contracts that may need `backlog-charter grill <capability>`.
-- **Amend Candidates** — CHARTER objectives or direction that may need `backlog-charter amend`.
-- **Learning Actions** — Learnings to keep inline, promote to Decisions, or archive through a human-gated compaction pass.
-- **Missing Evidence** — absent files, skipped scripts, or weak signals that prevent a confident recommendation.
-- **Recommended Next Step** — one action: no change, `backlog-charter grill <capability>`, `backlog-charter amend`, or a separate human-gated Learnings compaction edit.
-
-Accepted changes flow through existing gates: rerun grill for capability contract changes, amend for CHARTER changes, and keep `## Learnings` compaction as a separate user-approved manual edit. See `references/reassess.md` for report heuristics and stale-spec failure modes.
+1. Resolve helper scripts from the installed dev-backlog skill directory; if unavailable, report **Missing Evidence**.
+2. Start with bounded evidence: `capabilities-doctor.js --json`, `component-lint.js --json`, named CHARTER/capability sections, the active sprint, and at most the latest five completed sprint files.
+3. Emit these report sections: **Evidence**, **No Change**, **Grill Candidates**, **Amend Candidates**, **Learning Actions**, **Missing Evidence**, **Recommended Next Step**.
+4. Use `references/reassess.md` as the source of truth for evidence order, report shape, recommendation rules, Learning Actions, and stale-spec failure modes.
 
 ## References
 
@@ -159,5 +150,5 @@ Accepted changes flow through existing gates: rerun grill for capability contrac
 - `references/alignment.md` — shared work↔objective mapping logic consumed by `backlog-triage` and `dev-backlog`.
 - `references/objectives.md` — verifiable-predicate examples (5 good, 5 bad), common rewrite patterns, 30-second test.
 - `references/capabilities.md` — grill-mode heuristics for `spec/capabilities.md` authoring (placeholder; expand as findings accrue).
-- `references/reassess.md` — report-only stale-spec reassessment: evidence sources, output shape, promotion/compaction rules, and failure modes.
+- `references/reassess.md` — report-only stale-spec reassessment: evidence sources, output shape, Learning Actions, and failure modes.
 - `references/spec-system-research.md` — research grounding for the layered spec system (autonomous-agent failure taxonomy, control-theory framing, spec-language stability discipline).

--- a/skills/backlog-charter/references/capabilities.md
+++ b/skills/backlog-charter/references/capabilities.md
@@ -171,27 +171,15 @@ Split later when either trigger is true:
 
 Until then, single-file is easier for agents: one read, one grep surface, fewer paths to rediscover.
 
-## Learnings Compaction
+## Learning Actions
 
-`## Learnings` is recent operational memory, not an endless audit log.
+`## Learnings` is recent operational memory, not an endless audit log. Grill mode may notice that a capability is over its 5-7 Learning budget, but it should recommend a user-approved Learning Action rather than define a separate cleanup workflow here.
 
-Keep inline:
+Use the canonical policy in `docs/spec-system-design.md` and the operational report rules in `references/reassess.md`:
 
-- the most recent 5-7 Learnings that future runs should see at startup
-- measured facts, reusable patterns, or constraints that are still active
+- keep recent Learnings inline when they still help startup context
+- promote durable capability facts to `## Decisions`
+- promote cross-cutting facts to CHARTER Decisions
+- archive older history outside the hot `spec/capabilities.md` path
 
-Promote to `## Decisions`:
-
-- a repeated Learning that has become a durable capability rule
-- a constraint that should stop being rediscovered by future runs
-
-Promote to CHARTER Decisions:
-
-- cross-cutting direction changes
-- rules that affect multiple capabilities or project-wide objectives
-
-Archive:
-
-- useful historical entries that no longer need to be in the startup path
-
-Do not let relay delete or rewrite Learnings. Compaction is a human-gated maintenance action or a doctor warning, not an automatic side effect of a merge.
+Do not let relay delete or rewrite Learnings. A Learning Action is human-gated or doctor-suggested, not an automatic side effect of a merge.

--- a/skills/backlog-charter/references/reassess.md
+++ b/skills/backlog-charter/references/reassess.md
@@ -1,6 +1,12 @@
 # Reassess-Mode Heuristics
 
-Use this reference in `backlog-charter reassess` after reading the Reassess Mode section in `SKILL.md`. The mode is a report-only stale-spec review. It helps the user decide whether to run `backlog-charter amend`, `backlog-charter grill <capability>`, or a separate user-approved Learnings compaction edit.
+Use this reference in `backlog-charter reassess` after reading the Reassess Mode section in `SKILL.md`. The mode is a report-only stale-spec review. It helps the user decide whether to run `backlog-charter amend`, `backlog-charter grill <capability>`, or a separate user-approved Learning Action.
+
+## Policy Ownership
+
+- `SKILL.md` owns the dispatch contract: when to invoke reassess, the no-edit boundary, and the required report sections.
+- This reference owns the operational procedure: evidence order, report shape, recommendation rules, Learning Actions, and stale-spec failure modes.
+- `docs/spec-system-design.md` owns durable design policy: lifecycle, naming policy, source-of-truth map, and historical rationale.
 
 ## Operating Principle
 
@@ -8,12 +14,12 @@ Reassess is the controller review, not the writer.
 
 - Sensors: `## Learnings`, sprint `component:` handles, doctor/lint output, recent sprint context.
 - Diagnosis: the reassess report.
-- Controller action: user-approved `amend`, `grill`, or compaction.
+- Controller action: user-approved `amend`, `grill`, or Learning Action.
 - Forbidden shortcut: silently editing accepted CHARTER direction or capability contracts during reassess.
 
 The default answer can be "no change." Do not manufacture churn just because the user asked for a reassessment.
 
-If the user accepts a Learning Action, end reassess and perform a separate user-approved manual edit. Do not treat that edit as part of reassess diagnosis.
+Learning Actions are the user-gated family for keeping recent Learnings inline, promoting durable facts to Decisions, promoting cross-cutting facts to CHARTER Decisions, or archiving old history outside the hot startup path. If the user accepts one, end reassess and perform a separate user-approved manual edit. Do not treat that edit as part of reassess diagnosis.
 
 ## Evidence Order
 
@@ -48,8 +54,8 @@ Use this structure unless the user asks for a shorter answer:
 
 ### Learning Actions
 - Keep inline: <recent high-signal Learnings>
-- Promote: <Learning> — evidence: <repetition or durable rule>; next: separate user-approved compaction edit
-- Archive: <history no longer needed in startup context> — evidence: <age/no longer active>; next: separate user-approved compaction edit
+- Promote: <Learning> — evidence: <repetition or durable rule>; next: separate user-approved Learning Action
+- Archive: <history no longer needed in startup context> — evidence: <age/no longer active>; next: separate user-approved Learning Action
 
 ### Missing Evidence
 - <what was absent or skipped>
@@ -91,11 +97,13 @@ Do not weaken an Objective so the available proof appears sufficient.
 
 ### Learning Action
 
+Learning Action is the canonical umbrella for accepted Learnings cleanup after reassess. It includes keep-inline, promotion, and archive actions.
+
 Keep recent Learnings inline when they are still useful startup context.
 
 Promote a Learning to `## Decisions` when it has become a durable capability rule. Promote to CHARTER Decisions only when it affects more than one capability or changes the project-wide axis.
 
-Archive older Learnings when they are useful history but no longer startup context. Reassess may recommend archive/compaction, but the actual edit is human-gated.
+Archive older Learnings when they are useful history but no longer startup context. Reassess may recommend a Learning Action, but the actual edit is human-gated.
 
 ## Failure Modes
 
@@ -107,4 +115,4 @@ Archive older Learnings when they are useful history but no longer startup conte
 
 ## Reserved Names
 
-Today the callable skill is `backlog-charter`. The names `spec-grill`, `spec-reassess`, and `spec-learn` are reserved/non-callable future split candidates. Mention them only when discussing naming policy or split triggers, not as commands the user can run.
+Naming policy lives in `docs/spec-system-design.md`. Summary: today the callable skill is `backlog-charter`. The names `spec-grill`, `spec-reassess`, and `spec-learn` are reserved/non-callable future split candidates. Mention them only when discussing naming policy or split triggers, not as commands the user can run.


### PR DESCRIPTION
## Summary

- Slim `backlog-charter` reassess mode into a compact dispatch contract.
- Make `Learning Actions` the canonical umbrella for keep/promote/archive recommendations.
- Add a source-of-truth map for reassess policy and separate current policy from historical implementation/dogfood notes.

## Impact

This preserves the report-only reassess MVP while reducing duplicated policy across `SKILL.md`, `references/reassess.md`, and `docs/spec-system-design.md`. Agents should now have a clearer first-read path and less stale-guidance risk as reassess evolves.

## Validation

- `git diff --check`
- `node --test $(find skills -name '*.test.js' -print | sort)`\n- `node skills/dev-backlog/scripts/capabilities-doctor.js --strict`\n- `node skills/dev-backlog/scripts/component-lint.js --json`\n- Terminology scan for obsolete compaction wording and non-callable `spec-*` mentions\n\nRefs #143.\nRefs #144.\nRefs #145.\nRefs #146.