### PR TITLE
Align spec-system harness signals

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           node-version: '20'
 
       - name: Node tests
-        run: node --test skills/dev-backlog/scripts/*.test.js
+        run: node --test skills/*/scripts/*.test.js
 
       - name: Bash smoke tests
         run: bash skills/dev-backlog/scripts/smoke-test.sh

--- a/docs/spec-system-design.md
+++ b/docs/spec-system-design.md
@@ -110,6 +110,12 @@ Accepted specs are useful only while they still match product reality. The syste
 
 This keeps freedom where agents need it (reasoning over evidence) and control where the spec could otherwise rationalize itself into noise.
 
+Run this loop after major model/tool/harness releases that change agent behavior, and every 3-6 months on active spec-system projects. The cadence is a review trigger only; it does not authorize automatic edits.
+
+### Operational validation
+
+Anthropic's May 14, 2026 large-codebase Claude Code guidance independently supports the same operating pattern: lean layered context, on-demand skills, deterministic hooks/scripts, and periodic context maintenance. Treat that post as external validation for this design's shape, not as a new dependency or a reason to add LSP, MCP, plugin, or auto-reassess machinery to dev-backlog.
+
 ### Learning Actions
 
 `## Learnings` is a live sensor, not an audit log. Keep the most recent 5-7 entries inline per capability so the file stays useful during agent startup.

--- a/skills/backlog-charter/SKILL.md
+++ b/skills/backlog-charter/SKILL.md
@@ -49,7 +49,7 @@ Absence is supported. Projects opt in by creating the file; other skills degrade
 |------|---------------------|
 | `CHARTER.md` | What good looks like / why (the yardstick) |
 | `_context.md` | Operational facts you would otherwise rediscover (HOW-knowledge) |
-| `CLAUDE.md` | How to work in this repo (conventions) |
+| `CLAUDE.md` / `AGENTS.md` | How agents work in this repo (development harness; not product authority by default) |
 | `README.md` | Outward-facing introduction |
 
 ## 3 Tiers
@@ -66,7 +66,7 @@ A stable core makes the moving parts meaningful. This tiering prevents the axis 
 
 Use create mode when `CHARTER.md` is absent at the repo root, or when invoked as `backlog-charter create` and no charter exists.
 
-1. Draft from repo signals: `README.md` ≻ `CLAUDE.md` ≻ open epics/issues ≻ recent commits ≻ `CHANGELOG.md`. When signals conflict, surface the conflict in the interview rather than picking silently.
+1. Draft from repo signals: product/user-facing signals (`README.md`, open epics/issues, `CHANGELOG.md`) before development-harness signals (`CLAUDE.md`, `AGENTS.md`). Harness files may inform workflow conventions, local commands, and repo-specific guardrails, but they do not override README, CHARTER, issues, code structure, or user interview answers for product/capability authority unless they explicitly describe product boundaries. When signals conflict, surface the conflict in the interview rather than picking silently.
 2. Interview the user to fill and sharpen Problem, Approach, Non-Goals, and initial Objectives. Follow the checklist in `references/create.md` — Problem framing options, the wedge test for Approach, Non-Goals elicitation, and Objective framing that cites `references/objectives.md`.
 3. Write repo-root `CHARTER.md` from `templates/charter.md` with `revision: 1` and today's `last_amended`. The Decisions table may be left empty — seed 3–5 rows only when prior design docs, ADRs, or notable merged PRs already record direction; remember that whatever lands becomes immutable from revision 2.
 
@@ -102,7 +102,7 @@ See `references/amendment.md` for deep challenge and proof-gate heuristics.
 
 Use grill mode to author `spec/capabilities.md`, the middle layer between `CHARTER.md` and the active sprint. Invoked as `backlog-charter grill` (greenfield: no `spec/capabilities.md` yet) or `backlog-charter grill <capability-slug>` (rerun: polish one capability without touching others). Capability slugs are strict routing handles used by sprint `component:` frontmatter; keep them lowercase and singular, then put nuance in Goal/Scope prose.
 
-**On a brownfield repo** (existing code, no `spec/capabilities.md`), run `extract-signals.js --repo-root <target-repo> --json` from the installed skill's `scripts/` directory first. It draws from README, CLAUDE.md/AGENTS.md, top-level source dirs, the last 100 commit messages, and `CHARTER.md` Objectives, and reports raw capability signals with draft Goal + draft Scope. Use the draft as interview seed only; grill mode still pressure-tests every admitted capability through the admission test and then pressure-tests every Behavior and Hard Constraint through the 3-axis test before commit. The script clusters by code organization (directory names, commit scopes), while real capabilities are functional contracts; expect grill mode to merge, split, or regroup raw signals rather than adopt them verbatim. The script never writes `spec/capabilities.md` itself — that decision belongs to grill.
+**On a brownfield repo** (existing code, no `spec/capabilities.md`), run `extract-signals.js --repo-root <target-repo> --json` from the installed skill's `scripts/` directory first. It draws from README, CLAUDE.md/AGENTS.md, top-level source dirs, the last 100 commit messages, and `CHARTER.md` Objectives, and reports raw capability signals with draft Goal + draft Scope. Use the draft as interview seed only; grill mode still pressure-tests every admitted capability through the admission test and then pressure-tests every Behavior and Hard Constraint through the 3-axis test before commit. The script labels signal authority: README/CHARTER/issues are product authority, source directories are repo-structure evidence, commit scopes are history, and CLAUDE.md/AGENTS.md are development-harness context. Harness context can seed questions about conventions and workflow, but it must not create accepted capability boundaries by itself. The script clusters by code organization (directory names, commit scopes), while real capabilities are functional contracts; expect grill mode to merge, split, or regroup raw signals rather than adopt them verbatim. The script never writes `spec/capabilities.md` itself — that decision belongs to grill.
 
 `spec/capabilities.md` lives at the target repo root in `spec/`. Layout, mutation rules, and rationale are in [`docs/spec-system-design.md`](../../docs/spec-system-design.md). The single-file shape is intentional while the spec remains compact: target 5-10 capabilities, warn above 12 capabilities or 400 lines, and split only above 500 lines, above 15 capabilities, or when ownership boundaries demand separate review paths.
 
@@ -160,7 +160,7 @@ See `references/capabilities.md` for additional grill heuristics (placeholder on
 
 ## Reassess Mode
 
-Use reassess mode when the user asks whether `CHARTER.md` or `spec/capabilities.md` is stale, asks to review Learnings, or wants a periodic spec health check.
+Use reassess mode when the user asks whether `CHARTER.md` or `spec/capabilities.md` is stale, asks to review Learnings, wants a periodic spec health check, or when major model/tool/harness changes could alter how agents interpret repo context.
 
 Reassess never edits files. It diagnoses drift and recommends next actions; accepted fixes must run through `backlog-charter amend`, `backlog-charter grill <capability>`, or a separate user-approved Learning Action.
 

--- a/skills/backlog-charter/references/create.md
+++ b/skills/backlog-charter/references/create.md
@@ -9,10 +9,10 @@ Create mode step 1 draws from repo signals. When signals are rich, weight them b
 ### Priority order
 
 1. **`README.md`** — outward-facing problem framing, audience, and approach. Highest fidelity for Problem and Approach.
-2. **`CLAUDE.md`** (or `AGENTS.md`, `GEMINI.md`) — internal working conventions; second-highest for Approach + Non-Goals.
-3. **Open epics and issues** — current execution surface; useful for Objectives and active scope.
-4. **Recent commits** (last ~30 merged PRs) — what is actually being built; corrects for stale README.
-5. **`CHANGELOG.md`** — shipped reality; useful when commits are noisy.
+2. **Open epics and issues** — current execution surface; useful for Objectives and active scope.
+3. **Recent commits** (last ~30 merged PRs) — what is actually being built; corrects for stale README.
+4. **`CHANGELOG.md`** — shipped reality; useful when commits are noisy.
+5. **`CLAUDE.md`** (or `AGENTS.md`, `GEMINI.md`) — development-harness conventions: local commands, agent workflow, and guardrails.
 
 Stop at the first three signals that produce a coherent draft. More signals beyond that mean diminishing returns and longer interview prep.
 
@@ -23,6 +23,8 @@ Stop at the first three signals that produce a coherent draft. More signals beyo
 - Surface the absence in the interview: "There is no README — I drafted Problem from issue titles; correct me where I'm wrong."
 
 ### Conflict handling
+
+`CLAUDE.md` / `AGENTS.md` can explain how to work in the repo, but they are not product authority by default. Use them to seed questions about conventions and workflow; do not let them override README, issues, shipped behavior, or user answers unless they explicitly describe product boundaries.
 
 When signals disagree (e.g., README says "CLI tool," CLAUDE.md says "web app," commits show both), do not pick silently.
 

--- a/skills/backlog-charter/references/reassess.md
+++ b/skills/backlog-charter/references/reassess.md
@@ -21,6 +21,15 @@ The default answer can be "no change." Do not manufacture churn just because the
 
 Learning Actions are the user-gated family for keeping recent Learnings inline, promoting durable facts to Decisions, promoting cross-cutting facts to CHARTER Decisions, or archiving old history outside the hot startup path. If the user accepts one, end reassess and perform a separate user-approved manual edit. Do not treat that edit as part of reassess diagnosis.
 
+## Cadence Triggers
+
+Run a lightweight reassess pass when either condition applies:
+
+- A major model, coding-agent tool, or repo harness change affects how agents read instructions, call tools, or preserve context.
+- An active project has used the spec-system for 3-6 months without a spec health review.
+
+Keep this low-noise: the review can still conclude "no change," and it does not create an automatic edit path. Treat `CLAUDE.md` / `AGENTS.md` as development-harness context during this pass. They can explain local commands, agent workflow, and guardrails, but they do not override README, CHARTER, issues, code structure, or accepted capability contracts as product authority.
+
 ## Evidence Order
 
 Prefer bounded evidence before broad reading:
@@ -29,7 +38,8 @@ Prefer bounded evidence before broad reading:
 2. `component-lint.js --json` for sprint `component:` routing drift.
 3. `CHARTER.md` Objectives and Decisions when a recommendation could affect project-wide direction.
 4. `spec/capabilities.md` capability blocks named by the evidence.
-5. Latest five completed sprint files, plus the active sprint when it exists.
+5. `CLAUDE.md` / `AGENTS.md` only when the reassess question involves harness behavior, local commands, or agent context loading.
+6. Latest five completed sprint files, plus the active sprint when it exists.
 
 If a script is missing, say it was skipped and continue with file reads. Missing `CHARTER.md` or `spec/capabilities.md` is not an error; it is an opt-in state with a next-step recommendation.
 

--- a/skills/backlog-charter/scripts/extract-signals.js
+++ b/skills/backlog-charter/scripts/extract-signals.js
@@ -4,17 +4,15 @@
  *
  * Usage: ./scripts/extract-signals.js [--repo-root PATH] [--commit-limit N] [--dry-run] [--json]
  *
- * Reads repo signals in priority order and reports raw capability seeds that
+ * Reads repo signals and reports raw capability seeds that
  * grill mode can interview against. Does not write spec/capabilities.md —
  * grill mode owns admission, merging, splitting, and naming.
  *
- * Signals (priority):
- *   1. README.md                — top-level product framing
- *   2. CLAUDE.md / AGENTS.md    — development-harness conventions
- *   3. Top-level source dirs    — src/, lib/, app/, packages/, skills/
- *                                 (each subdir is a capability candidate)
- *   4. Last N commit messages   — conventional-commit scopes cluster usage
- *   5. CHARTER.md Objectives    — capabilities should serve at least one
+ * Signal authority:
+ *   - README.md / CHARTER.md    — product authority
+ *   - Top-level source dirs     — repo-structure evidence
+ *   - CLAUDE.md / AGENTS.md     — development-harness conventions
+ *   - Last N commit messages    — history
  *
  * Output: JSON of shape
  *   {
@@ -33,7 +31,7 @@ const SOURCE_ROOT_CANDIDATES = ["src", "lib", "app", "packages", "skills"];
 const SUMMARY_DIR_LIMIT = 5;
 const DEFAULT_COMMIT_LIMIT = 100;
 
-function buildSignalAuthority({ readmeFound, harnessFiles, sourceRoot, commitsScanned, charterObjectiveCount }) {
+function buildSignalAuthority({ readmeFound, charterFound, harnessFiles, sourceRoot, commitsScanned }) {
   return [
     {
       signal: "README.md",
@@ -44,7 +42,7 @@ function buildSignalAuthority({ readmeFound, harnessFiles, sourceRoot, commitsSc
     {
       signal: "CHARTER.md",
       authority: "product",
-      found: charterObjectiveCount > 0,
+      found: charterFound,
       note: "Accepted project axis; Objectives can constrain capability candidates.",
     },
     {
@@ -267,6 +265,7 @@ function extractSignals({
   const deps = { readFile, fileExists, statSync, readdir, exec };
 
   const readme = readOptionalFile(path.join(repoRoot, "README.md"), deps);
+  const charter = readOptionalFile(path.join(repoRoot, "CHARTER.md"), deps);
   const claudeMd = readOptionalFile(path.join(repoRoot, "CLAUDE.md"), deps);
   const agentsMd = readOptionalFile(path.join(repoRoot, "AGENTS.md"), deps);
   const harnessFiles = [
@@ -283,6 +282,7 @@ function extractSignals({
   const inventory = {
     repoRoot: path.resolve(repoRoot),
     readmeFound: readme !== null,
+    charterFound: charter !== null,
     claudeMdFound: harnessFiles.length > 0,
     harnessFiles,
     sourceRoot: sourceRoot ? sourceRoot.name : null,
@@ -293,10 +293,10 @@ function extractSignals({
   };
   const signalAuthority = buildSignalAuthority({
     readmeFound: readme !== null,
+    charterFound: charter !== null,
     harnessFiles,
     sourceRoot,
     commitsScanned: commitMessages.length,
-    charterObjectiveCount: charterObjectives.length,
   });
 
   const candidates = sourceRoot ? mergeCandidates({ sourceRoot, dirNames, scopeCounts }) : [];
@@ -320,10 +320,10 @@ function formatHumanReport(result) {
   lines.push(`Repo: ${inventory.repoRoot}`);
   lines.push("Signals:");
   lines.push(`  - README.md: ${inventory.readmeFound ? "found" : "missing"}`);
-  lines.push(`  - CLAUDE.md/AGENTS.md: ${inventory.claudeMdFound ? `found (${inventory.harnessFiles.join(", ")})` : "missing"}; authority: development-harness`);
+  lines.push(`  - CHARTER.md: ${inventory.charterFound ? "found" : "missing"}; objectives: ${inventory.charterObjectiveCount}`);
+  lines.push(`  - CLAUDE.md/AGENTS.md: ${inventory.claudeMdFound ? `found (${(inventory.harnessFiles || []).join(", ")})` : "missing"}; authority: development-harness`);
   lines.push(`  - source root: ${inventory.sourceRoot ?? "none detected"} (${inventory.sourceDirCount} dir(s))`);
   lines.push(`  - commits scanned: ${inventory.commitsScanned}; scopes seen: ${inventory.commitScopeCount}`);
-  lines.push(`  - CHARTER objectives: ${inventory.charterObjectiveCount}`);
   lines.push("");
 
   if (capabilities.length === 0) {

--- a/skills/backlog-charter/scripts/extract-signals.js
+++ b/skills/backlog-charter/scripts/extract-signals.js
@@ -10,14 +10,17 @@
  *
  * Signals (priority):
  *   1. README.md                — top-level product framing
- *   2. CLAUDE.md / AGENTS.md    — explicit conventions and capability hints
+ *   2. CLAUDE.md / AGENTS.md    — development-harness conventions
  *   3. Top-level source dirs    — src/, lib/, app/, packages/, skills/
  *                                 (each subdir is a capability candidate)
  *   4. Last N commit messages   — conventional-commit scopes cluster usage
  *   5. CHARTER.md Objectives    — capabilities should serve at least one
  *
  * Output: JSON of shape
- *   { capabilities: [{ name, signals, candidate_goal, candidate_scope }] }
+ *   {
+ *     signal_authority: [{ signal, authority, found, note }],
+ *     capabilities: [{ name, signals, candidate_goal, candidate_scope }]
+ *   }
  *
  * Same inputs produce the same draft (deterministic ordering).
  */
@@ -29,6 +32,41 @@ const { execFileSync } = require("child_process");
 const SOURCE_ROOT_CANDIDATES = ["src", "lib", "app", "packages", "skills"];
 const SUMMARY_DIR_LIMIT = 5;
 const DEFAULT_COMMIT_LIMIT = 100;
+
+function buildSignalAuthority({ readmeFound, harnessFiles, sourceRoot, commitsScanned, charterObjectiveCount }) {
+  return [
+    {
+      signal: "README.md",
+      authority: "product",
+      found: readmeFound,
+      note: "User-facing product framing; can seed Problem, Approach, and capability goals.",
+    },
+    {
+      signal: "CHARTER.md",
+      authority: "product",
+      found: charterObjectiveCount > 0,
+      note: "Accepted project axis; Objectives can constrain capability candidates.",
+    },
+    {
+      signal: "CLAUDE.md/AGENTS.md",
+      authority: "development-harness",
+      found: harnessFiles.length > 0,
+      note: "Agent workflow and repo conventions; does not create product capability boundaries by itself.",
+    },
+    {
+      signal: sourceRoot ? `${sourceRoot.name}/` : "source root",
+      authority: "repo-structure",
+      found: sourceRoot !== null,
+      note: "Code organization evidence; useful as raw candidate surface, not final capability authority.",
+    },
+    {
+      signal: "git commit scopes",
+      authority: "history",
+      found: commitsScanned > 0,
+      note: "Recent work history; clusters usage but does not override accepted specs.",
+    },
+  ];
+}
 
 function usage() {
   return "Usage: extract-signals.js [--repo-root PATH] [--commit-limit N] [--dry-run] [--json]";
@@ -229,9 +267,12 @@ function extractSignals({
   const deps = { readFile, fileExists, statSync, readdir, exec };
 
   const readme = readOptionalFile(path.join(repoRoot, "README.md"), deps);
-  const claudeMd =
-    readOptionalFile(path.join(repoRoot, "CLAUDE.md"), deps) ||
-    readOptionalFile(path.join(repoRoot, "AGENTS.md"), deps);
+  const claudeMd = readOptionalFile(path.join(repoRoot, "CLAUDE.md"), deps);
+  const agentsMd = readOptionalFile(path.join(repoRoot, "AGENTS.md"), deps);
+  const harnessFiles = [
+    ["CLAUDE.md", claudeMd],
+    ["AGENTS.md", agentsMd],
+  ].filter(([, content]) => content !== null).map(([name]) => name);
   const sourceRoot = detectSourceRoot(repoRoot, deps);
   const dirNames = listCapabilityCandidates(sourceRoot, deps);
   const commitMessages = getRecentCommitMessages(repoRoot, commitLimit, deps);
@@ -242,13 +283,21 @@ function extractSignals({
   const inventory = {
     repoRoot: path.resolve(repoRoot),
     readmeFound: readme !== null,
-    claudeMdFound: claudeMd !== null,
+    claudeMdFound: harnessFiles.length > 0,
+    harnessFiles,
     sourceRoot: sourceRoot ? sourceRoot.name : null,
     sourceDirCount: dirNames.length,
     commitsScanned: commitMessages.length,
     commitScopeCount: scopeCounts.size,
     charterObjectiveCount: charterObjectives.length,
   };
+  const signalAuthority = buildSignalAuthority({
+    readmeFound: readme !== null,
+    harnessFiles,
+    sourceRoot,
+    commitsScanned: commitMessages.length,
+    charterObjectiveCount: charterObjectives.length,
+  });
 
   const candidates = sourceRoot ? mergeCandidates({ sourceRoot, dirNames, scopeCounts }) : [];
 
@@ -262,7 +311,7 @@ function extractSignals({
     }),
   );
 
-  return { inventory, capabilities };
+  return { inventory, signal_authority: signalAuthority, capabilities };
 }
 
 function formatHumanReport(result) {
@@ -271,7 +320,7 @@ function formatHumanReport(result) {
   lines.push(`Repo: ${inventory.repoRoot}`);
   lines.push("Signals:");
   lines.push(`  - README.md: ${inventory.readmeFound ? "found" : "missing"}`);
-  lines.push(`  - CLAUDE.md/AGENTS.md: ${inventory.claudeMdFound ? "found" : "missing"}`);
+  lines.push(`  - CLAUDE.md/AGENTS.md: ${inventory.claudeMdFound ? `found (${inventory.harnessFiles.join(", ")})` : "missing"}; authority: development-harness`);
   lines.push(`  - source root: ${inventory.sourceRoot ?? "none detected"} (${inventory.sourceDirCount} dir(s))`);
   lines.push(`  - commits scanned: ${inventory.commitsScanned}; scopes seen: ${inventory.commitScopeCount}`);
   lines.push(`  - CHARTER objectives: ${inventory.charterObjectiveCount}`);
@@ -319,6 +368,7 @@ function main() {
 if (require.main === module) main();
 
 module.exports = {
+  buildSignalAuthority,
   parseArgs,
   detectSourceRoot,
   listCapabilityCandidates,

--- a/skills/backlog-charter/scripts/extract-signals.test.js
+++ b/skills/backlog-charter/scripts/extract-signals.test.js
@@ -224,16 +224,30 @@ describe("buildSignalAuthority", () => {
   it("labels CLAUDE.md/AGENTS.md as development-harness authority", () => {
     const authority = buildSignalAuthority({
       readmeFound: true,
+      charterFound: true,
       harnessFiles: ["CLAUDE.md", "AGENTS.md"],
       sourceRoot: { name: "src", path: "/repo/src" },
       commitsScanned: 4,
-      charterObjectiveCount: 1,
     });
 
     const harness = authority.find((entry) => entry.signal === "CLAUDE.md/AGENTS.md");
     assert.equal(harness.authority, "development-harness");
     assert.equal(harness.found, true);
     assert.match(harness.note, /does not create product capability boundaries/);
+  });
+
+  it("labels an objective-empty CHARTER.md as found product authority", () => {
+    const authority = buildSignalAuthority({
+      readmeFound: false,
+      charterFound: true,
+      harnessFiles: [],
+      sourceRoot: null,
+      commitsScanned: 0,
+    });
+
+    const charter = authority.find((entry) => entry.signal === "CHARTER.md");
+    assert.equal(charter.authority, "product");
+    assert.equal(charter.found, true);
   });
 });
 
@@ -347,6 +361,7 @@ revision: 1
     });
 
     assert.equal(result.inventory.readmeFound, true);
+    assert.equal(result.inventory.charterFound, true);
     assert.equal(result.inventory.claudeMdFound, true);
     assert.deepEqual(result.inventory.harnessFiles, ["CLAUDE.md"]);
     assert.equal(result.inventory.sourceRoot, "src");
@@ -368,6 +383,22 @@ revision: 1
     const harness = result.signal_authority.find((entry) => entry.signal === "CLAUDE.md/AGENTS.md");
     assert.equal(harness.authority, "development-harness");
     assert.equal(harness.found, true);
+  });
+
+  it("reports CHARTER.md as found even when it has no Objectives", () => {
+    write(repo, "CHARTER.md", "# Charter\n\n## Decisions\n");
+
+    const result = extractSignals({
+      repoRoot: repo,
+      exec: () => "",
+    });
+
+    assert.equal(result.inventory.charterFound, true);
+    assert.equal(result.inventory.charterObjectiveCount, 0);
+    assert.equal(
+      result.signal_authority.find((entry) => entry.signal === "CHARTER.md").found,
+      true,
+    );
   });
 
   it("development harness files do not create capability candidates by themselves", () => {
@@ -477,7 +508,7 @@ describe("formatHumanReport", () => {
   it("renders the greenfield path", () => {
     const result = {
       inventory: {
-        repoRoot: "/x", readmeFound: false, claudeMdFound: false,
+        repoRoot: "/x", readmeFound: false, charterFound: false, claudeMdFound: false,
         sourceRoot: null, sourceDirCount: 0,
         commitsScanned: 0, commitScopeCount: 0, charterObjectiveCount: 0,
       },
@@ -489,7 +520,7 @@ describe("formatHumanReport", () => {
   it("renders raw capability signals under the summary limit", () => {
     const result = {
       inventory: {
-        repoRoot: "/x", readmeFound: true, claudeMdFound: false,
+        repoRoot: "/x", readmeFound: true, charterFound: false, claudeMdFound: false,
         sourceRoot: "src", sourceDirCount: 2,
         commitsScanned: 10, commitScopeCount: 2, charterObjectiveCount: 0,
       },

--- a/skills/backlog-charter/scripts/extract-signals.test.js
+++ b/skills/backlog-charter/scripts/extract-signals.test.js
@@ -418,6 +418,22 @@ revision: 1
     );
   });
 
+  it("AGENTS.md-only is treated as development-harness without creating capabilities", () => {
+    write(repo, "AGENTS.md", "# Agent Rules\n\nUse npm run lint.\n");
+
+    const result = extractSignals({
+      repoRoot: repo,
+      exec: () => "",
+    });
+
+    assert.equal(result.inventory.claudeMdFound, true);
+    assert.deepEqual(result.inventory.harnessFiles, ["AGENTS.md"]);
+    assert.deepEqual(result.capabilities, []);
+    const harness = result.signal_authority.find((entry) => entry.signal === "CLAUDE.md/AGENTS.md");
+    assert.equal(harness.authority, "development-harness");
+    assert.equal(harness.found, true);
+  });
+
   it("brownfield commit-scope-only: keeps provenance explicit without fake ownership", () => {
     mkdir(repo, "src/worker");
     const commits = ["feat(progress-sync): one", "fix(progress-sync): two"];

--- a/skills/backlog-charter/scripts/extract-signals.test.js
+++ b/skills/backlog-charter/scripts/extract-signals.test.js
@@ -11,6 +11,7 @@ const {
   readOptionalFile,
   readCharterObjectives,
   summarizeReadme,
+  buildSignalAuthority,
   buildCapability,
   mergeCandidates,
   extractSignals,
@@ -219,6 +220,23 @@ Tamgu Note helps parents discover children's hidden talents through AI-powered a
   });
 });
 
+describe("buildSignalAuthority", () => {
+  it("labels CLAUDE.md/AGENTS.md as development-harness authority", () => {
+    const authority = buildSignalAuthority({
+      readmeFound: true,
+      harnessFiles: ["CLAUDE.md", "AGENTS.md"],
+      sourceRoot: { name: "src", path: "/repo/src" },
+      commitsScanned: 4,
+      charterObjectiveCount: 1,
+    });
+
+    const harness = authority.find((entry) => entry.signal === "CLAUDE.md/AGENTS.md");
+    assert.equal(harness.authority, "development-harness");
+    assert.equal(harness.found, true);
+    assert.match(harness.note, /does not create product capability boundaries/);
+  });
+});
+
 describe("buildCapability", () => {
   it("includes a CHARTER objective hint when objectives are present", () => {
     const cap = buildCapability({
@@ -330,6 +348,7 @@ revision: 1
 
     assert.equal(result.inventory.readmeFound, true);
     assert.equal(result.inventory.claudeMdFound, true);
+    assert.deepEqual(result.inventory.harnessFiles, ["CLAUDE.md"]);
     assert.equal(result.inventory.sourceRoot, "src");
     assert.equal(result.inventory.sourceDirCount, 2);
     assert.equal(result.inventory.commitsScanned, 5);
@@ -345,6 +364,27 @@ revision: 1
     assert.equal(ingest.provenance.directory, "src/ingest/");
     assert.match(ingest.candidate_goal, /logging pipeline/);
     assert.match(ingest.candidate_goal, /O1/);
+
+    const harness = result.signal_authority.find((entry) => entry.signal === "CLAUDE.md/AGENTS.md");
+    assert.equal(harness.authority, "development-harness");
+    assert.equal(harness.found, true);
+  });
+
+  it("development harness files do not create capability candidates by themselves", () => {
+    write(repo, "CLAUDE.md", "# Development\n\nUse pnpm. Keep PRs small.\n");
+
+    const result = extractSignals({
+      repoRoot: repo,
+      exec: () => "",
+    });
+
+    assert.equal(result.inventory.claudeMdFound, true);
+    assert.deepEqual(result.inventory.harnessFiles, ["CLAUDE.md"]);
+    assert.deepEqual(result.capabilities, []);
+    assert.equal(
+      result.signal_authority.find((entry) => entry.signal === "CLAUDE.md/AGENTS.md").authority,
+      "development-harness",
+    );
   });
 
   it("brownfield commit-scope-only: keeps provenance explicit without fake ownership", () => {


### PR DESCRIPTION
## Summary
- Clarify that `CLAUDE.md` / `AGENTS.md` are development-harness context, not product authority by default, in backlog-charter create/grill/reassess docs.
- Add `signal_authority` metadata to `extract-signals` so grill mode can distinguish product, repo-structure, development-harness, and history signals.
- Add reassess cadence guidance for model/tool/harness changes and a terse Anthropic operational-validation note.
- Expand CI Node tests from dev-backlog-only to all shipped skill script tests.

## Issue coverage
- Closes #151 — documentation-only development-harness authority boundary.
- Closes #152 — extraction output now labels harness authority and tests prove CLAUDE.md-only conventions do not create capabilities.
- Closes #153 — reassess docs include model/tool/harness cadence and spec design records Anthropic guidance as validation, not dependency.
- Closes #154 — CI runs `node --test skills/*/scripts/*.test.js` while preserving the bash smoke test.
- Refs #150 — all child issues are implemented and verified.

## Verification
- `node --test skills/backlog-charter/scripts/extract-signals.test.js`
- `node --test skills/*/scripts/*.test.js && bash skills/dev-backlog/scripts/smoke-test.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **테스트**
  * 테스트 실행 범위를 확장하여 더 광범위한 기술 디렉토리의 스크립트를 검증합니다.

* **문서**
  * 시스템 설계 문서에 운영 검증 섹션을 추가했습니다.
  * 신호 우선순위 및 재평가 기준에 대한 지침을 정렬했습니다.

* **개선사항**
  * 신호 수집 및 검증 프로세스를 개선하여 더 정확한 권한 분류를 지원합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-backlog/pull/155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->