### PR TITLE
[codex] Fix backlog-charter skill metadata

### DIFF
--- a/skills/backlog-charter/SKILL.md
+++ b/skills/backlog-charter/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: backlog-charter
 argument-hint: "[create|amend|grill|reassess]"
-description: Create, amend, grill, and reassess the project spec axis: CHARTER.md plus spec/capabilities.md. Use to establish or evolve project direction, author capability contracts, review stale specs, recommend Learning Actions, or decide whether Behaviors/Constraints still match execution evidence. 프로젝트 축, 기준, 헌장, 능력 명세, stale spec, spec reassess.
+description: "Create, amend, grill, and reassess the project spec axis: CHARTER.md plus spec/capabilities.md. Use to establish or evolve project direction, author capability contracts, review stale specs, recommend Learning Actions, or decide whether Behaviors/Constraints still match execution evidence. 프로젝트 축, 기준, 헌장, 능력 명세, stale spec, spec reassess."
 compatibility: Requires git. Works on Claude Code and Codex.
 metadata:
   related-skills: "dev-backlog, backlog-triage"


### PR DESCRIPTION
## Summary

Fixes the `backlog-charter` skill metadata so `npx skills add` can discover and install it.

## Root Cause

The `description` field in `skills/backlog-charter/SKILL.md` contained an unquoted `: ` sequence (`axis: CHARTER.md ...`). The `skills` CLI parses frontmatter as YAML, so that line failed YAML parsing and the CLI silently excluded the skill from discovery.

## Validation

- `npx --yes skills add . -l` now reports 3 skills including `backlog-charter`
- `node --test skills/backlog-charter/scripts/*.test.js`
- `git diff --check --cached`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * YAML 메타데이터 형식 정규화를 통해 일관성 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sungjunlee/dev-backlog/pull/156?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->