### PR TITLE
[codex] emit snapshot v2 relationship edges

### DIFF
--- a/backlog/completed/BACK-189 - enhance-backlog-triage-emit-comment-and-closing-pr-relationship-signals.md
+++ b/backlog/completed/BACK-189 - enhance-backlog-triage-emit-comment-and-closing-pr-relationship-signals.md
@@ -1,7 +1,7 @@
 ---
 id: BACK-189
 title: 'enhance(backlog-triage): emit comment and closing-PR relationship signals'
-status: In Progress
+status: Done
 labels:
   - documentation
   - enhancement
@@ -24,8 +24,8 @@ Suggested signals:
 
 ## Acceptance Criteria
 
-- [ ] Comment mention scanning runs only when issue `comments` arrays are present.
-- [ ] Comment-derived edges carry evidence that identifies comment source separately from issue body evidence.
-- [ ] Closing-PR edges use `closing_prs` and do not imply an automatic close recommendation by themselves.
-- [ ] Missing optional fields degrade cleanly without warnings or undefined-field behavior.
-- [ ] Relationship docs and tests cover both enabled and absent-field paths.
+- [x] Comment mention scanning runs only when issue `comments` arrays are present.
+- [x] Comment-derived edges carry evidence that identifies comment source separately from issue body evidence.
+- [x] Closing-PR edges use `closing_prs` and do not imply an automatic close recommendation by themselves.
+- [x] Missing optional fields degrade cleanly without warnings or undefined-field behavior.
+- [x] Relationship docs and tests cover both enabled and absent-field paths.

--- a/backlog/completed/BACK-73 - enhance-backlog-triage-snapshot-v2-schema-for-closing-prs-comments-and-closed-issue-scan.md
+++ b/backlog/completed/BACK-73 - enhance-backlog-triage-snapshot-v2-schema-for-closing-prs-comments-and-closed-issue-scan.md
@@ -1,7 +1,7 @@
 ---
 id: BACK-73
 title: 'enhance(backlog-triage): snapshot v2 schema for closing PRs, comments, and closed-issue scan'
-status: To Do
+status: Done
 labels:
   - documentation
   - enhancement

--- a/backlog/sprints/2026-05-backlog-triage-snapshot-v2.md
+++ b/backlog/sprints/2026-05-backlog-triage-snapshot-v2.md
@@ -1,6 +1,6 @@
 ---
 milestone: backlog-triage snapshot v2
-status: active
+status: completed
 started: 2026-05-31
 due: TBD
 objectives: [O4]
@@ -15,7 +15,7 @@ Shape and implement #73 so backlog-triage can see closing PR links, optional com
 ## Plan
 Start with a short technical split before implementation. The issue is larger than a doc polish item because it touches collection schema and downstream scanners.
 
-- [ ] #73 enhance(backlog-triage): snapshot v2 schema for closing PRs, comments, and closed-issue scan
+- [x] #73 enhance(backlog-triage): snapshot v2 schema for closing PRs, comments, and closed-issue scan → PR #191 (merged)
 
 ## Running Context
 - Current `triage-relate` and `triage-stale` explicitly defer PR-merged and duplicate-of-closed signals until snapshot v2 fields exist.
@@ -25,3 +25,5 @@ Start with a short technical split before implementation. The issue is larger th
 
 ## Progress
 - 2026-05-31: Open issue set synced locally; #73 mirror created under `backlog/tasks/`. Previous spec-grill dogfood sprint completed after PR #175 landed.
+- 2026-06-06: #73 completed via PR #191. Collector v2 now emits explicit `schema_version: 2`; downstream analyzer work was split into #189 (relationships) and #190 (stale/obsolete signals).
+- 2026-06-06: Sprint closed. 1/1 tasks completed.

--- a/backlog/sprints/2026-06-backlog-triage-relationships.md
+++ b/backlog/sprints/2026-06-backlog-triage-relationships.md
@@ -1,6 +1,6 @@
 ---
 milestone: backlog-triage relationships
-status: active
+status: completed
 started: 2026-06-06
 due: TBD
 objectives: [O4]
@@ -13,7 +13,7 @@ component: "triage-grooming"
 Use snapshot v2 relationship fields in `triage-relate` without turning advisory relationship evidence into automatic close recommendations.
 
 ## Plan
-- [~] #189 enhance(backlog-triage): emit comment and closing-PR relationship signals → branch `codex/close-snapshot-v2-sprint`
+- [x] #189 enhance(backlog-triage): emit comment and closing-PR relationship signals → PR #192
 
 ## Running Context
 - #73 shipped collector-side v2 fields: `closing_prs` by default, `comments` behind `--with-comments`.
@@ -22,3 +22,5 @@ Use snapshot v2 relationship fields in `triage-relate` without turning advisory 
 
 ## Progress
 - 2026-06-06: Started #189 after closing the completed #73 snapshot-v2 sprint locally.
+- 2026-06-06: #189 implemented in PR #192. `triage-relate` now emits `comment-mentions` and advisory `merged-pr-link` edges from snapshot v2 fields.
+- 2026-06-06: Sprint closed. 1/1 tasks completed.

--- a/backlog/sprints/2026-06-backlog-triage-relationships.md
+++ b/backlog/sprints/2026-06-backlog-triage-relationships.md
@@ -1,0 +1,24 @@
+---
+milestone: backlog-triage relationships
+status: active
+started: 2026-06-06
+due: TBD
+objectives: [O4]
+component: "triage-grooming"
+---
+
+# backlog-triage relationships
+
+## Goal
+Use snapshot v2 relationship fields in `triage-relate` without turning advisory relationship evidence into automatic close recommendations.
+
+## Plan
+- [~] #189 enhance(backlog-triage): emit comment and closing-PR relationship signals → branch `codex/close-snapshot-v2-sprint`
+
+## Running Context
+- #73 shipped collector-side v2 fields: `closing_prs` by default, `comments` behind `--with-comments`.
+- Keep #189 non-mutating. Relationship edges may influence review priority, but they must not create stale/close actions.
+- Optional fields must degrade silently when absent so old snapshots remain readable.
+
+## Progress
+- 2026-06-06: Started #189 after closing the completed #73 snapshot-v2 sprint locally.

--- a/backlog/sprints/_context.md
+++ b/backlog/sprints/_context.md
@@ -13,3 +13,4 @@
 - Resolve `progress-sync` metric semantics in `#49` before doing structural refactors in `#50`
 - `progress-sync` and the bash helpers both parse sprint/task markdown, so contract drift needs explicit coverage
 - `sync-pull.js --update` refreshes task frontmatter and, for machine-managed issues whose **incoming GitHub body** starts with the `<!-- dev-backlog:progress-issue month=` marker, also refreshes the markdown body; every other task mirror keeps its existing body so local AC checkbox state is preserved
+- Backlog triage snapshot enrichments stay explicit and bounded: `--with-comments` and `--with-closed-issues` are opt-in, while downstream scanners must gracefully gate on optional fields instead of assuming they exist.

--- a/backlog/sprints/_context.md
+++ b/backlog/sprints/_context.md
@@ -14,3 +14,4 @@
 - `progress-sync` and the bash helpers both parse sprint/task markdown, so contract drift needs explicit coverage
 - `sync-pull.js --update` refreshes task frontmatter and, for machine-managed issues whose **incoming GitHub body** starts with the `<!-- dev-backlog:progress-issue month=` marker, also refreshes the markdown body; every other task mirror keeps its existing body so local AC checkbox state is preserved
 - Backlog triage snapshot enrichments stay explicit and bounded: `--with-comments` and `--with-closed-issues` are opt-in, while downstream scanners must gracefully gate on optional fields instead of assuming they exist.
+- `triage-relate` relationship edges are advisory context. Even a `merged-pr-link` edge must not become a close recommendation unless `triage-stale` implements a separate conservative obsolete signal.

--- a/backlog/tasks/BACK-189 - enhance-backlog-triage-emit-comment-and-closing-pr-relationship-signals.md
+++ b/backlog/tasks/BACK-189 - enhance-backlog-triage-emit-comment-and-closing-pr-relationship-signals.md
@@ -1,0 +1,31 @@
+---
+id: BACK-189
+title: 'enhance(backlog-triage): emit comment and closing-PR relationship signals'
+status: In Progress
+labels:
+  - documentation
+  - enhancement
+priority: medium
+milestone: 
+created_date: '2026-06-06'
+---
+## Description
+## Context
+
+#73 added the snapshot-v2 collector fields needed for richer relationship analysis: per-issue `closing_prs` is present by default and `comments` is available through `--with-comments`. The collector is ready, but `triage-relate.js` still emits only body-based mentions/blocks/depends-on and title duplicate candidates.
+
+## Desired change
+
+Teach `triage-relate.js` to use snapshot-v2 fields conservatively.
+
+Suggested signals:
+- comment-based mentions when `comments` is present
+- a closing-PR relationship signal when `closing_prs` contains merged PR metadata
+
+## Acceptance Criteria
+
+- [ ] Comment mention scanning runs only when issue `comments` arrays are present.
+- [ ] Comment-derived edges carry evidence that identifies comment source separately from issue body evidence.
+- [ ] Closing-PR edges use `closing_prs` and do not imply an automatic close recommendation by themselves.
+- [ ] Missing optional fields degrade cleanly without warnings or undefined-field behavior.
+- [ ] Relationship docs and tests cover both enabled and absent-field paths.

--- a/backlog/tasks/BACK-190 - enhance-backlog-triage-add-stale-signals-for-merged-prs-and-closed-duplicates.md
+++ b/backlog/tasks/BACK-190 - enhance-backlog-triage-add-stale-signals-for-merged-prs-and-closed-duplicates.md
@@ -1,0 +1,32 @@
+---
+id: BACK-190
+title: 'enhance(backlog-triage): add stale signals for merged PRs and closed duplicates'
+status: To Do
+labels:
+  - documentation
+  - enhancement
+priority: medium
+milestone: 
+created_date: '2026-06-06'
+---
+## Description
+## Context
+
+#73 added the collector-side data needed for stronger obsolete-candidate detection: per-issue `closing_prs` and optional top-level `closed_issues`. `triage-stale.js` still uses only inactivity and explicit labels, so the richer snapshot fields are not yet used for stale decisions.
+
+## Desired change
+
+Add conservative stale/obsolete candidates based on snapshot-v2 fields.
+
+Candidate signals:
+- open issue has a merged closing PR in `closing_prs`
+- open issue appears to duplicate a recently closed issue from `closed_issues`
+
+## Acceptance Criteria
+
+- [ ] Merged closing-PR candidates require `closing_prs` evidence and include PR number/url/mergedAt in candidate evidence.
+- [ ] Duplicate-of-closed candidates run only when top-level `closed_issues` is present.
+- [ ] Duplicate-of-closed matching is conservative and tested against false positives.
+- [ ] Missing optional fields degrade cleanly without warnings or undefined-field behavior.
+- [ ] Stale docs and tests cover enabled and absent-field paths.
+

--- a/skills/backlog-triage/references/relationships.md
+++ b/skills/backlog-triage/references/relationships.md
@@ -1,10 +1,12 @@
 # Relationships
 
-**Purpose.** `triage-relate.js` reads a previously collected issue snapshot and emits read-only relationship edges for four snapshot-resident signals:
+**Purpose.** `triage-relate.js` reads a previously collected issue snapshot and emits read-only relationship edges for snapshot-resident signals:
 
 - `mentions` from plain `#123` references in issue bodies
+- `comment-mentions` from plain `#123` references in optional issue comments
 - `blocks` from explicit blocking / closing phrases in issue bodies
 - `depends-on` from explicit dependency phrases in issue bodies
+- `merged-pr-link` from per-issue merged closing PR metadata
 - `duplicate-candidate` from title-token Jaccard overlap
 
 Every emitted edge carries evidence taken directly from the snapshot so downstream report rendering can show why the relationship was inferred without re-fetching from GitHub.
@@ -21,6 +23,23 @@ Every emitted edge carries evidence taken directly from the snapshot so downstre
 - Confidence: `0.75`
 - Evidence:
   - `match`: matched issue reference, for example `#123`
+  - `snippet`: normalized sentence/line fragment containing the match
+
+### `comment-mentions`
+
+- Source: `issue.comments[].body`
+- Gate: runs only when `comments` is present as an array; missing or malformed optional fields emit no edges
+- Match rule: same issue-reference parser as body `mentions`
+- Filters:
+  - ignore self-references
+  - ignore references to issues absent from `snapshot.issues`
+  - ignore fenced-code and URL-fragment noise
+- Confidence: `0.65`
+- Evidence:
+  - `source`: `"comment"`
+  - `author`: comment author when present
+  - `createdAt`: comment timestamp when present
+  - `match`: matched issue reference
   - `snippet`: normalized sentence/line fragment containing the match
 
 ### `blocks`
@@ -45,6 +64,20 @@ Every emitted edge carries evidence taken directly from the snapshot so downstre
 - Evidence:
   - `phrase`: normalized matched phrase, for example `depends on #123`
   - `snippet`: normalized sentence/line fragment containing the phrase
+
+### `merged-pr-link`
+
+- Source: `issue.closing_prs`
+- Gate: runs only when `closing_prs` is present as an array
+- Match rule: emit only entries with `state: "MERGED"` and a non-empty `mergedAt`
+- Confidence: `1`
+- Action semantics: advisory relationship evidence only; this does not imply an automatic close recommendation
+- Evidence:
+  - `source`: `"closing_prs"`
+  - `pr.number`: closing PR number
+  - `pr.state`: closing PR state
+  - `pr.mergedAt`: merge timestamp
+  - `pr.url`: closing PR URL when present
 
 ### `duplicate-candidate`
 
@@ -80,7 +113,7 @@ All edges share the outer shape:
 {
   "from": 100,
   "to": 101,
-  "kind": "mentions|blocks|depends-on|duplicate-candidate",
+  "kind": "mentions|comment-mentions|blocks|depends-on|merged-pr-link|duplicate-candidate",
   "confidence": 0.75,
   "evidence": {}
 }
@@ -97,12 +130,38 @@ Evidence payloads vary by kind:
 }
 ```
 
+- `comment-mentions`
+
+```json
+{
+  "source": "comment",
+  "author": "octocat",
+  "createdAt": "2026-04-18T01:00:00.000Z",
+  "match": "#101",
+  "snippet": "Follow-up lives in #101."
+}
+```
+
 - `blocks` / `depends-on`
 
 ```json
 {
   "phrase": "depends on #101",
   "snippet": "This depends on #101 before rollout."
+}
+```
+
+- `merged-pr-link`
+
+```json
+{
+  "source": "closing_prs",
+  "pr": {
+    "number": 88,
+    "state": "MERGED",
+    "mergedAt": "2026-04-18T01:15:00.000Z",
+    "url": "https://github.com/owner/name/pull/88"
+  }
 }
 ```
 
@@ -121,11 +180,4 @@ Evidence payloads vary by kind:
 
 ## Deferred follow-ups
 
-The snapshot collector now has the raw fields for these signals, but `triage-relate.js` does not emit them yet:
-
-- `comments`-based mention scan
-  - Requires: `--with-comments` snapshot enrichment and a clear edge shape that distinguishes issue-body evidence from comment evidence.
-- `merged-pr-link` edge kind
-  - Requires: interpreting per-issue `closing_prs` without turning every linked PR into a close recommendation.
-
-Tracked in #189.
+`triage-relate.js` is intentionally still read-only. Turning `merged-pr-link` into a stale / obsolete close candidate belongs to `triage-stale.js` and is tracked separately in #190.

--- a/skills/backlog-triage/scripts/triage-relate.js
+++ b/skills/backlog-triage/scripts/triage-relate.js
@@ -157,10 +157,17 @@ function makeEdge({ from, to, kind, confidence, evidence }) {
   return { from, to, kind, confidence, evidence };
 }
 
+function edgeIdentity(edge) {
+  if (edge.kind === "merged-pr-link") {
+    return `${edge.from}:${edge.to}:${edge.kind}:${edge.evidence?.pr?.number || ""}`;
+  }
+  return `${edge.from}:${edge.to}:${edge.kind}`;
+}
+
 function dedupeEdges(edges) {
   const seen = new Set();
   return edges.filter((edge) => {
-    const key = `${edge.from}:${edge.to}:${edge.kind}`;
+    const key = edgeIdentity(edge);
     if (seen.has(key)) return false;
     seen.add(key);
     return true;
@@ -191,6 +198,41 @@ function scanMentions(snapshot) {
           },
         })
       );
+    }
+  }
+
+  return dedupeEdges(edges);
+}
+
+function scanCommentMentions(snapshot) {
+  const edges = [];
+  const openNumbers = snapshotIssueNumbers(snapshot);
+
+  for (const issue of snapshot.issues) {
+    const comments = Array.isArray(issue.comments) ? issue.comments : [];
+
+    for (const comment of comments) {
+      const body = typeof comment?.body === "string" ? comment.body : "";
+      for (const ref of extractIssueRefs(body)) {
+        if (issue.number === ref.number) continue;
+        if (!openNumbers.has(ref.number)) continue;
+
+        edges.push(
+          makeEdge({
+            from: issue.number,
+            to: ref.number,
+            kind: "comment-mentions",
+            confidence: 0.65,
+            evidence: {
+              source: "comment",
+              author: typeof comment?.author === "string" ? comment.author : null,
+              createdAt: typeof comment?.createdAt === "string" ? comment.createdAt : null,
+              match: ref.match,
+              snippet: ref.snippet,
+            },
+          })
+        );
+      }
     }
   }
 
@@ -247,6 +289,39 @@ function scanDependsOn(snapshot) {
     "depends-on",
     1
   );
+}
+
+function scanMergedPrLinks(snapshot) {
+  const edges = [];
+
+  for (const issue of snapshot.issues) {
+    const closingPrs = Array.isArray(issue.closing_prs) ? issue.closing_prs : [];
+
+    for (const pr of closingPrs) {
+      const state = typeof pr?.state === "string" ? pr.state.toUpperCase() : "";
+      if (state !== "MERGED" || typeof pr?.mergedAt !== "string" || !pr.mergedAt) continue;
+
+      edges.push(
+        makeEdge({
+          from: issue.number,
+          to: issue.number,
+          kind: "merged-pr-link",
+          confidence: 1,
+          evidence: {
+            source: "closing_prs",
+            pr: {
+              number: Number.isInteger(pr?.number) ? pr.number : null,
+              state: pr.state,
+              mergedAt: pr.mergedAt,
+              url: typeof pr?.url === "string" ? pr.url : null,
+            },
+          },
+        })
+      );
+    }
+  }
+
+  return dedupeEdges(edges);
 }
 
 function tokenizeTitle(title) {
@@ -369,13 +444,22 @@ function resolveBacklogDir(snapshot) {
 function analyzeSnapshot(snapshot, { config = readTriageConfig(resolveBacklogDir(snapshot)) } = {}) {
   return sortEdges([
     ...scanMentions(snapshot),
+    ...scanCommentMentions(snapshot),
     ...scanBlocks(snapshot),
     ...scanDependsOn(snapshot),
+    ...scanMergedPrLinks(snapshot),
     ...findDuplicateCandidates(snapshot, config),
   ]);
 }
 
 function formatEdge(edge) {
+  if (edge.kind === "merged-pr-link") {
+    const pr = edge.evidence?.pr || {};
+    const prLabel = pr.number ? `PR #${pr.number}` : "merged PR";
+    const mergedAt = pr.mergedAt ? ` merged at ${pr.mergedAt}` : "";
+    return `#${edge.from} ${edge.kind} ${prLabel}${mergedAt}`;
+  }
+
   if (edge.kind === "duplicate-candidate") {
     return `#${edge.from} ${edge.kind} #${edge.to} (${edge.confidence.toFixed(2)}) ${edge.evidence.titles.from} <> ${edge.evidence.titles.to}`;
   }
@@ -422,8 +506,10 @@ module.exports = {
   maskFencedCodeBlocks,
   extractIssueRefs,
   scanMentions,
+  scanCommentMentions,
   scanBlocks,
   scanDependsOn,
+  scanMergedPrLinks,
   findDuplicateCandidates,
   readSnapshotFile,
   analyzeSnapshot,

--- a/skills/backlog-triage/scripts/triage-relate.test.js
+++ b/skills/backlog-triage/scripts/triage-relate.test.js
@@ -7,8 +7,10 @@ const {
   parseArgs,
   extractIssueRefs,
   scanMentions,
+  scanCommentMentions,
   scanBlocks,
   scanDependsOn,
+  scanMergedPrLinks,
   findDuplicateCandidates,
   analyzeSnapshot,
   readSnapshotFile,
@@ -125,6 +127,64 @@ describe("scanMentions", () => {
   });
 });
 
+describe("scanCommentMentions", () => {
+  it("comment-mentions: emits comment references only when comments arrays are present", () => {
+    const snapshot = makeSnapshot({
+      issues: [
+        makeIssue({
+          number: 100,
+          comments: [
+            {
+              author: "octocat",
+              body: "Follow-up lives in #101. Ignore self #100 and closed #999.",
+              createdAt: "2026-04-18T01:00:00.000Z",
+            },
+          ],
+        }),
+        makeIssue({ number: 101, comments: "not an array" }),
+      ],
+    });
+
+    assert.deepEqual(scanCommentMentions(snapshot), [
+      {
+        from: 100,
+        to: 101,
+        kind: "comment-mentions",
+        confidence: 0.65,
+        evidence: {
+          source: "comment",
+          author: "octocat",
+          createdAt: "2026-04-18T01:00:00.000Z",
+          match: "#101",
+          snippet: "Follow-up lives in #101.",
+        },
+      },
+    ]);
+  });
+
+  it("comment-mentions: missing optional comments fields degrade to no edges", () => {
+    const snapshot = makeSnapshot({
+      issues: [
+        makeIssue({ number: 100, body: "See #101." }),
+        makeIssue({ number: 101 }),
+      ],
+    });
+
+    assert.deepEqual(scanCommentMentions(snapshot), []);
+  });
+
+  it("comment-mentions: malformed comment entries degrade to no edges", () => {
+    const snapshot = makeSnapshot({
+      issues: [
+        makeIssue({ number: 100, comments: [null, "not an object", { body: null }] }),
+        makeIssue({ number: 101 }),
+      ],
+    });
+
+    assert.deepEqual(scanCommentMentions(snapshot), []);
+  });
+});
+
 describe("scanBlocks", () => {
   it("blocks: emits blocks and closes phrases with concrete evidence", () => {
     const snapshot = makeSnapshot({
@@ -190,6 +250,57 @@ describe("scanDependsOn", () => {
     assert.match(edges[0].evidence.snippet, /Blocked by #100/);
     assert.match(edges[1].evidence.snippet, /depends on #102/);
     assert.match(edges[2].evidence.snippet, /depends-on #103/);
+  });
+});
+
+describe("scanMergedPrLinks", () => {
+  it("merged-pr-link: emits merged closing PR metadata without implying a close action", () => {
+    const snapshot = makeSnapshot({
+      issues: [
+        makeIssue({
+          number: 100,
+          closing_prs: [
+            { number: 10, state: "OPEN", mergedAt: null, url: "https://github.com/owner/name/pull/10" },
+            { number: 11, state: "MERGED", mergedAt: "2026-04-18T02:00:00.000Z", url: "https://github.com/owner/name/pull/11" },
+          ],
+        }),
+        makeIssue({ number: 101 }),
+      ],
+    });
+
+    assert.deepEqual(scanMergedPrLinks(snapshot), [
+      {
+        from: 100,
+        to: 100,
+        kind: "merged-pr-link",
+        confidence: 1,
+        evidence: {
+          source: "closing_prs",
+          pr: {
+            number: 11,
+            state: "MERGED",
+            mergedAt: "2026-04-18T02:00:00.000Z",
+            url: "https://github.com/owner/name/pull/11",
+          },
+        },
+      },
+    ]);
+  });
+
+  it("merged-pr-link: missing optional closing_prs fields degrade to no edges", () => {
+    const snapshot = makeSnapshot({ issues: [makeIssue({ number: 100 })] });
+
+    assert.deepEqual(scanMergedPrLinks(snapshot), []);
+  });
+
+  it("merged-pr-link: malformed closing_prs entries degrade to no edges", () => {
+    const snapshot = makeSnapshot({
+      issues: [
+        makeIssue({ number: 100, closing_prs: [null, "not an object", { state: "MERGED", mergedAt: null }] }),
+      ],
+    });
+
+    assert.deepEqual(scanMergedPrLinks(snapshot), []);
   });
 });
 

--- a/skills/backlog-triage/scripts/triage-report.js
+++ b/skills/backlog-triage/scripts/triage-report.js
@@ -6,8 +6,8 @@ const { readSnapshot } = require("./triage-stale.js");
 
 const ANCHOR_PATTERN = /<!--\s*triage:([\w-]+)\s+#(\d+)(?:\s+(.*?))?\s*-->/;
 const DEFAULT_REPORT_DIR = path.join("backlog", "triage");
-const DEFERRED_RELATIONSHIPS_MARKER =
-  "_(PR/comment relationship signals deferred — collector fields exist; analyzer rules tracked in #189)_";
+const OPTIONAL_RELATIONSHIPS_MARKER =
+  "_(comment and closing-PR relationship signals run only when snapshot v2 fields are present)_";
 const DEFERRED_OBSOLETE_MARKER =
   "_(closing-PR-already-merged and duplicate-of-closed signals deferred — collector fields exist; stale rules tracked in #190)_";
 
@@ -247,6 +247,13 @@ function formatRelationshipEdge(edge, issueIndex) {
   const left = fromIssue ? issueRef(fromIssue) : `#${edge.from}`;
   const right = toIssue ? issueRef(toIssue) : `#${edge.to}`;
 
+  if (edge.kind === "merged-pr-link") {
+    const pr = edge.evidence?.pr || {};
+    const prLabel = pr.number ? `PR #${pr.number}` : "merged PR";
+    const mergedAt = pr.mergedAt ? `; mergedAt ${pr.mergedAt}` : "";
+    return `- ${left} merged-pr-link ${prLabel}${mergedAt}`;
+  }
+
   if (edge.kind === "duplicate-candidate") {
     const overlap = Array.isArray(edge.evidence?.overlap) && edge.evidence.overlap.length > 0
       ? `; overlap: ${edge.evidence.overlap.join(", ")}`
@@ -262,19 +269,19 @@ function renderRelationships(relate, issueIndex) {
   const lines = ["## Relationships"];
 
   if (!relate) {
-    lines.push("_(no input provided)_", "", DEFERRED_RELATIONSHIPS_MARKER);
+    lines.push("_(no input provided)_", "", OPTIONAL_RELATIONSHIPS_MARKER);
     return lines.join("\n");
   }
 
   if (relate.edges.length === 0) {
-    lines.push("_(none)_", "", DEFERRED_RELATIONSHIPS_MARKER);
+    lines.push("_(none)_", "", OPTIONAL_RELATIONSHIPS_MARKER);
     return lines.join("\n");
   }
 
   for (const edge of [...relate.edges].sort((left, right) => left.from - right.from || left.to - right.to || left.kind.localeCompare(right.kind))) {
     lines.push(formatRelationshipEdge(edge, issueIndex));
   }
-  lines.push("", DEFERRED_RELATIONSHIPS_MARKER);
+  lines.push("", OPTIONAL_RELATIONSHIPS_MARKER);
   return lines.join("\n");
 }
 
@@ -428,7 +435,9 @@ function buildRelationshipCounts(relate) {
 
   for (const edge of relate.edges) {
     counts.set(edge.from, (counts.get(edge.from) || 0) + 1);
-    counts.set(edge.to, (counts.get(edge.to) || 0) + 1);
+    if (edge.to !== edge.from) {
+      counts.set(edge.to, (counts.get(edge.to) || 0) + 1);
+    }
   }
   return counts;
 }
@@ -731,7 +740,7 @@ if (require.main === module) main();
 
 module.exports = {
   ANCHOR_PATTERN,
-  DEFERRED_RELATIONSHIPS_MARKER,
+  OPTIONAL_RELATIONSHIPS_MARKER,
   DEFERRED_OBSOLETE_MARKER,
   usage,
   parseArgs,

--- a/skills/backlog-triage/scripts/triage-report.test.js
+++ b/skills/backlog-triage/scripts/triage-report.test.js
@@ -26,6 +26,21 @@ function makeSnapshot() {
         number: 101,
         title: "OAuth token refresh flow",
         body: "Blocks #102. See #105 for docs follow-up.",
+        comments: [
+          {
+            author: "octocat",
+            body: "Comment follow-up in #103.",
+            createdAt: "2026-04-18T01:00:00.000Z",
+          },
+        ],
+        closing_prs: [
+          {
+            number: 88,
+            state: "MERGED",
+            mergedAt: "2026-04-18T01:15:00.000Z",
+            url: "https://github.com/sungjunlee/dev-backlog/pull/88",
+          },
+        ],
         labels: ["type:feature", "priority:medium"],
         createdAt: "2026-04-10T01:30:00.000Z",
         updatedAt: "2026-04-17T01:30:00.000Z",
@@ -356,7 +371,9 @@ describe("triage-report integration chain", () => {
     assert.match(markdown, /<!-- triage:close #104 reason="inactive\/stale: no activity for 107 days; exceeds stale_days threshold \(60\); no milestone assigned" -->/);
     assert.match(markdown, /<!-- triage:close #105 reason="labeled wontfix; explicit wontfix signal" -->/);
     assert.match(markdown, /<!-- triage:close #106 reason="labeled invalid; explicit invalid signal" -->/);
-    assert.match(markdown, /PR\/comment relationship signals deferred/);
+    assert.match(markdown, /#101 OAuth token refresh flow comment-mentions #103 Audit token rotation docs/);
+    assert.match(markdown, /#101 OAuth token refresh flow merged-pr-link PR #88; mergedAt 2026-04-18T01:15:00.000Z/);
+    assert.match(markdown, /comment and closing-PR relationship signals run only when snapshot v2 fields are present/);
     assert.match(markdown, /closing-PR-already-merged and duplicate-of-closed signals deferred/);
 
     // Classification groups must match Done Criteria: theme / label / age.


### PR DESCRIPTION
## Summary
- close the completed #73 snapshot-v2 sprint locally and sync open issue mirrors
- add `comment-mentions` edges from optional snapshot comments
- add advisory `merged-pr-link` edges from merged closing PR metadata
- render merged PR links without treating them as stale/close actions

Closes #189.

## Validation
- `git diff --check`
- `node --test skills/backlog-triage/scripts/triage-relate.test.js skills/backlog-triage/scripts/triage-report.test.js`
- `node --test skills/dev-backlog/scripts/*.test.js skills/spec-charter/scripts/*.test.js skills/spec-grill/scripts/*.test.js skills/backlog-triage/scripts/*.test.js`
  - 421 passed, 1 skipped, 0 failed
