### PR TITLE
Complete execution guard and stale signal milestone

### DIFF
--- a/backlog/sprints/2026-06-execution-guard-and-stale-signals.md
+++ b/backlog/sprints/2026-06-execution-guard-and-stale-signals.md
@@ -1,0 +1,35 @@
+---
+milestone: 2026-06 execution guard and stale signals
+status: active
+started: 2026-06-17
+due: TBD
+objectives: [O4]
+component: "sprint-execution"
+---
+
+# Execution Guard And Stale Signals
+
+## Goal
+Agents can resume dev-backlog work from local sprint/task state without being misled by ambiguous active sprints, and backlog-triage can flag conservative obsolete candidates without turning advisory relationship evidence into unsafe mutations.
+
+## Plan
+### Batch 1 - execution-state guard
+- [x] #193 fix(dev-backlog): fail loud on ambiguous active sprint state (~30min)
+
+### Batch 2 - conservative stale/obsolete signals
+- [x] #190 enhance(backlog-triage): add stale signals for merged PRs and closed duplicates (~20min)
+
+### Batch 3 - spec/docs cleanup
+- [x] #194 docs(spec): refresh spec-series tracking and boundary docs (~20min)
+
+## Running Context
+- Keep explicit sync: no background git pull and no silent GitHub mutation.
+- Relationship evidence is advisory unless `triage-stale` explicitly converts it into a conservative obsolete signal.
+- Active sprint references are protected from close / close-duplicate proposals.
+- Relay runtime scripts are not present in this repo checkout, so this run uses direct implementation plus local review/verification.
+
+## Progress
+- 2026-06-18: Started `/goal` execution for milestone #9. Created active sprint from GitHub milestone and reordered work as #193 -> #190 -> #194.
+- 2026-06-18: Implemented #193 active-sprint ambiguity guards across lib/next/status/context-hook/sprint-close/sprint-init and added smoke + node tests.
+- 2026-06-18: Implemented #190 merged closing-PR and duplicate-of-closed stale signals, advisory-only merged-pr-link planning behavior, and active-sprint close protection.
+- 2026-06-18: Completed #194 spec-series doc refresh; craft-critique pass found no follow-up edits. Verification: smoke-test, full node test suite, capabilities-doctor --strict, component-lint all pass.

--- a/backlog/tasks/BACK-190 - enhance-backlog-triage-add-stale-signals-for-merged-prs-and-closed-duplicates.md
+++ b/backlog/tasks/BACK-190 - enhance-backlog-triage-add-stale-signals-for-merged-prs-and-closed-duplicates.md
@@ -1,13 +1,13 @@
 ---
 id: BACK-190
 title: 'enhance(backlog-triage): add stale signals for merged PRs and closed duplicates'
-status: To Do
+status: Done
 labels:
   - documentation
   - enhancement
 priority: medium
-milestone: 
-created_date: '2026-06-06'
+milestone: 2026-06 execution guard and stale signals
+created_date: '2026-06-17'
 ---
 ## Description
 ## Context
@@ -22,11 +22,14 @@ Candidate signals:
 - open issue has a merged closing PR in `closing_prs`
 - open issue appears to duplicate a recently closed issue from `closed_issues`
 
+Keep relationship evidence advisory unless `triage-stale` explicitly turns it into a conservative stale/obsolete signal. A `merged-pr-link` edge by itself must not boost planning priority or sprint assignment.
+
 ## Acceptance Criteria
 
-- [ ] Merged closing-PR candidates require `closing_prs` evidence and include PR number/url/mergedAt in candidate evidence.
-- [ ] Duplicate-of-closed candidates run only when top-level `closed_issues` is present.
-- [ ] Duplicate-of-closed matching is conservative and tested against false positives.
-- [ ] Missing optional fields degrade cleanly without warnings or undefined-field behavior.
-- [ ] Stale docs and tests cover enabled and absent-field paths.
-
+- [x] Merged closing-PR candidates require `closing_prs` evidence and include PR number/url/mergedAt in candidate evidence.
+- [x] Duplicate-of-closed candidates run only when top-level `closed_issues` is present.
+- [x] Duplicate-of-closed matching is conservative and tested against false positives.
+- [x] Missing optional fields degrade cleanly without warnings or undefined-field behavior.
+- [x] `merged-pr-link` relationship edges alone do not generate `set-priority` or `assign-milestone` proposals.
+- [x] Issues referenced in the active sprint Plan or Running Context never receive close or close-duplicate proposals, even when stale/obsolete signals match.
+- [x] Stale docs and tests cover enabled, absent-field, advisory-only, and active-sprint-protected paths.

--- a/backlog/tasks/BACK-193 - fix-dev-backlog-fail-loud-on-ambiguous-active-sprint-state.md
+++ b/backlog/tasks/BACK-193 - fix-dev-backlog-fail-loud-on-ambiguous-active-sprint-state.md
@@ -1,0 +1,31 @@
+---
+id: BACK-193
+title: 'fix(dev-backlog): fail loud on ambiguous active sprint state'
+status: Done
+labels:
+  - bug
+  - documentation
+  - enhancement
+priority: medium
+milestone: 2026-06 execution guard and stale signals
+created_date: '2026-06-17'
+---
+## Description
+## Context
+
+gosu-review and eng-review found a dogfood failure mode: a stale local checkout can make `status.sh` / `next.sh` point an agent at already-completed work. The current helper also treats “one active sprint” as a document invariant, but `find_active_sprint` can silently pick the first match with `head -1`.
+
+This undermines dev-backlog's core contract: an agent should be able to orient from the active sprint without confidently doing the wrong work.
+
+## Desired change
+
+Make sprint execution state fail loud when it is ambiguous or stale enough to mislead an agent.
+
+## Acceptance Criteria
+
+- [x] `find_active_sprint` distinguishes 0, 1, and more than 1 active sprint files instead of silently choosing the first active file.
+- [x] `next.sh` and `status.sh` surface multiple-active-sprint conflicts clearly and do not print a misleading next task in that state.
+- [x] `sprint-init.js` refuses to create a new active sprint when another active sprint already exists, unless a deliberate explicit override is introduced and documented.
+- [x] Tests cover 0 active, 1 active, multiple active, and sprint-init-with-existing-active cases.
+- [x] The implementation preserves the explicit-sync model: no background pull or silent GitHub mutation.
+- [x] `skills/dev-backlog/SKILL.md` and/or references document the fail-loud behavior if command output changes.

--- a/backlog/tasks/BACK-194 - docs-spec-refresh-spec-series-tracking-and-boundary-docs.md
+++ b/backlog/tasks/BACK-194 - docs-spec-refresh-spec-series-tracking-and-boundary-docs.md
@@ -1,0 +1,31 @@
+---
+id: BACK-194
+title: 'docs(spec): refresh spec-series tracking and boundary docs'
+status: Done
+labels:
+  - documentation
+  - enhancement
+priority: medium
+milestone: 2026-06 execution guard and stale signals
+created_date: '2026-06-17'
+---
+## Description
+## Context
+
+The current spec layer is structurally healthy, but a few tracking docs now lag behind the accepted shape:
+
+- `skills/spec-charter/references/reassess.md` says callable spec-series skills are only `spec-charter` and `spec-grill`, omitting `spec-system-map`.
+- `spec/system-map.md` still presents accepted capability handles under `Candidate Capability Boundaries`, including uncertainty that has since been resolved or moved into `spec/capabilities.md`.
+- `docs/spec-system-design.md` historical dogfood numbers mention an older six-capability / 214-line snapshot while current `capabilities-doctor` reports seven capabilities / 258 lines.
+
+## Desired change
+
+Refresh spec-series docs without broad rewriting. Keep durable specs compact and avoid copying task-specific acceptance criteria into `spec/*`.
+
+## Acceptance Criteria
+
+- [x] `reassess.md` names the current callable spec-series surface: `spec-charter`, `spec-system-map`, and `spec-grill`.
+- [x] `spec/system-map.md` no longer reads like accepted capabilities are still merely candidates; it points to `spec/capabilities.md` for accepted contracts and keeps only genuinely unresolved boundary questions.
+- [x] `docs/spec-system-design.md` dogfood evidence is updated or explicitly marked historical so current health checks do not appear contradictory.
+- [x] No task-specific AC, relay Done Criteria, or issue checklist text is copied into durable `spec/*` contracts.
+- [x] `capabilities-doctor --strict` and `component-lint` remain clean.

--- a/docs/spec-system-design.md
+++ b/docs/spec-system-design.md
@@ -175,7 +175,7 @@ The names `spec-reassess` and `spec-learn` are reserved/non-callable future spli
 
 One `spec/capabilities.md` is the default because it is easy to read, grep, and hand to an agent in one shot. The budget is about scanability, not feature count: target 5-10 capabilities, warn above 12 capabilities or 400 lines, and split only when the file exceeds 500 lines, has more than 15 capabilities, or ownership boundaries demand separate review paths.
 
-Dogfood calibrated this rule. dev-backlog has six capabilities and produces a 214-line spec. tamgu_note, a larger Flutter/Firebase app, has 15+ feature surfaces plus workflow scopes like `e2e`, `test`, `sprint`, and `backlog`; treating every folder or commit scope as a capability would exceed the split trigger immediately. Capabilities are durable contract boundaries, not directory names.
+Dogfood calibrated this rule. dev-backlog currently has seven capabilities and produces a 258-line spec, still within the compactness budget. tamgu_note, a larger Flutter/Firebase app, has 15+ feature surfaces plus workflow scopes like `e2e`, `test`, `sprint`, and `backlog`; treating every folder or commit scope as a capability would exceed the split trigger immediately. Capabilities are durable contract boundaries, not directory names.
 
 When the hard trigger fires, `split-capabilities.js` migrates to `spec/components/<name>.md`. Until then, keep the compact single-file shape. Make-the-change-easy, then make the easy change (Beck).
 
@@ -330,8 +330,8 @@ Manual reassess evidence was checked before adding a new seed script:
 
 | Repo | Command | Result | Reassess implication |
 |---|---|---|---|
-| dev-backlog | `node skills/dev-backlog/scripts/capabilities-doctor.js --json` | 6 capabilities, 214 lines, 0 warnings, 0 hard failures | compactness and Learnings marker evidence is sufficient for a no-change structural finding |
-| dev-backlog | `node skills/dev-backlog/scripts/component-lint.js --json` | 6 declared capabilities, 0 sprint files, 0 issues | routing evidence is sufficient; no sprint data means no usage-frequency inference |
+| dev-backlog | `node skills/dev-backlog/scripts/capabilities-doctor.js --json` | 7 capabilities, 258 lines, 0 warnings, 0 hard failures | compactness and Learnings marker evidence is sufficient for a no-change structural finding |
+| dev-backlog | `node skills/dev-backlog/scripts/component-lint.js --json` | 7 declared capabilities, 10 sprint files, 1 active sprint, 0 issues | routing evidence is sufficient; legacy/unrouted sprint files do not imply capability drift |
 | tamgu_note | `node <dev-backlog-skill-dir>/scripts/capabilities-doctor.js --capabilities spec/capabilities.md --json` | 7 capabilities, 232 lines, 0 warnings, 0 hard failures | large-repo-shaped spec remains within budget |
 | tamgu_note | `node <dev-backlog-skill-dir>/scripts/component-lint.js --sprints-dir backlog/sprints --capabilities spec/capabilities.md --json` | 19 sprint files, 0 component issues | routing evidence is sufficient on a larger real repo shape |
 

--- a/skills/backlog-triage/SKILL.md
+++ b/skills/backlog-triage/SKILL.md
@@ -222,8 +222,8 @@ All scripts live in `${CLAUDE_SKILL_DIR}/scripts/` and run from the target proje
 
 - `scripts/triage-collect.js [--repo OWNER/REPO] [--limit N] [--json] [--dry-run]` — fetch open issues, write snapshot to `backlog/triage/.cache/<ISO-timestamp>.json`. Read-only.
 - `scripts/triage-relate.js --snapshot PATH [--json]` — detect mentions / blocks / depends-on / duplicates. Errors if snapshot missing or malformed.
-- `scripts/triage-stale.js --snapshot PATH [--since N] [--json]` — flag stale / obsolete candidates with evidence.
-- `scripts/triage-report.js --snapshot PATH [--relate PATH] [--stale PATH] [--out PATH] [--json]` — render the markdown report with anchor comments. Re-runnable; creates `.bak` on overwrite.
+- `scripts/triage-stale.js --snapshot PATH [--since N] [--json]` — flag stale / obsolete candidates with evidence, including optional v2 merged-PR and duplicate-of-closed signals.
+- `scripts/triage-report.js --snapshot PATH [--relate PATH] [--stale PATH] [--active-sprint PATH] [--out PATH] [--json]` — render the markdown report with anchor comments. Re-runnable; creates `.bak` on overwrite.
 - `scripts/triage-apply.js <report.md> [--apply] [--yes] [--json]` — parse anchor+checkbox pairs, execute accepted actions via `gh`. Default dry-run. Idempotent. Appends to `backlog/triage/<date>-apply.log` (JSONL).
 - `scripts/triage-apply.integration.test.js` — opt-in live integration coverage for `triage-apply.js` against the disposable sandbox repo `sungjunlee/triage-apply-sandbox`. Requires `TRIAGE_APPLY_INTEGRATION=1` and `GH_TOKEN` with write access.
 

--- a/skills/backlog-triage/references/relationships.md
+++ b/skills/backlog-triage/references/relationships.md
@@ -71,7 +71,7 @@ Every emitted edge carries evidence taken directly from the snapshot so downstre
 - Gate: runs only when `closing_prs` is present as an array
 - Match rule: emit only entries with `state: "MERGED"` and a non-empty `mergedAt`
 - Confidence: `1`
-- Action semantics: advisory relationship evidence only; this does not imply an automatic close recommendation
+- Action semantics: advisory relationship evidence only; it does not independently create priority or milestone proposals. `triage-stale.js` is responsible for turning the same snapshot metadata into an explicit close candidate.
 - Evidence:
   - `source`: `"closing_prs"`
   - `pr.number`: closing PR number
@@ -178,6 +178,4 @@ Evidence payloads vary by kind:
 }
 ```
 
-## Deferred follow-ups
-
-`triage-relate.js` is intentionally still read-only. Turning `merged-pr-link` into a stale / obsolete close candidate belongs to `triage-stale.js` and is tracked separately in #190.
+`triage-relate.js` is intentionally still read-only. Close or duplicate proposals belong to `triage-stale.js` and still require report review plus an accepted apply checkbox before any GitHub mutation.

--- a/skills/backlog-triage/references/stale.md
+++ b/skills/backlog-triage/references/stale.md
@@ -9,6 +9,8 @@
 | `inactive` | `updatedAt` is at least `stale_days` old and `milestone` is null | `inactive/stale: no activity for <days> days; exceeds stale_days threshold (<threshold>); no milestone assigned` | `close` |
 | `wontfix` | Issue has a `wontfix` label (case-insensitive) | `labeled <matchedLabel>; explicit wontfix signal` | `close` |
 | `invalid` | Issue has an `invalid` label (case-insensitive) | `labeled <matchedLabel>; explicit invalid signal` | `close` |
+| `merged-closing-pr` | Optional `closing_prs[]` includes `state: "MERGED"` and non-empty `mergedAt` | `merged closing PR detected: PR #<n> merged at <mergedAt>` | `close` |
+| `duplicate-of-closed` | Optional `closed_issues[]` includes an exact or high-overlap title match | `duplicate of closed issue #<n>: title similarity <score>` | `merge-into:#<closed-issue>` |
 
 `stale_days` comes from `backlog/triage-config.yml` unless `--since N` is passed, in which case the CLI override wins.
 
@@ -44,10 +46,45 @@ Each candidate includes a non-empty `evidence` object.
 
 For `invalid`, only `matchedLabel` and `labels` change accordingly.
 
+### `merged-closing-pr`
+
+```json
+{
+  "source": "closing_prs",
+  "pr": {
+    "number": 88,
+    "state": "MERGED",
+    "mergedAt": "2026-04-18T01:15:00.000Z",
+    "url": "https://github.com/owner/name/pull/88"
+  },
+  "updatedAt": "2026-04-18T01:00:00.000Z",
+  "milestone": null
+}
+```
+
+### `duplicate-of-closed`
+
+```json
+{
+  "target": {
+    "number": 44,
+    "title": "OAuth token refresh worker",
+    "state": "closed",
+    "closedAt": "2026-06-01T00:00:00.000Z",
+    "url": "https://github.com/owner/name/issues/44"
+  },
+  "score": 1,
+  "overlap": ["oauth", "refresh", "token", "worker"],
+  "exactTitle": true,
+  "titles": {
+    "open": "OAuth token refresh worker",
+    "closed": "OAuth token refresh worker"
+  }
+}
+```
+
 ## Deferred follow-ups
 
-- `PR already merged`: collector v2 includes `closing_prs`, but stale analysis still needs a conservative rule before suggesting closure.
-- `Duplicate of closed`: `--with-closed-issues` can include bounded closed-issue context, but stale analysis still needs a tested title/body matching rule before suggesting merge-or-close actions.
 - `Referenced code removed`: deferred because the current snapshot has no code-removal evidence and no follow-up implementation is defined yet.
 
-The first two signals are tracked in #190.
+Missing optional v2 fields (`closing_prs`, `closed_issues`) degrade to no candidates rather than errors.

--- a/skills/backlog-triage/scripts/triage-report.js
+++ b/skills/backlog-triage/scripts/triage-report.js
@@ -9,10 +9,10 @@ const DEFAULT_REPORT_DIR = path.join("backlog", "triage");
 const OPTIONAL_RELATIONSHIPS_MARKER =
   "_(comment and closing-PR relationship signals run only when snapshot v2 fields are present)_";
 const DEFERRED_OBSOLETE_MARKER =
-  "_(closing-PR-already-merged and duplicate-of-closed signals deferred — collector fields exist; stale rules tracked in #190)_";
+  "_(merged closing-PR and duplicate-of-closed signals run only when snapshot v2 fields are present)_";
 
 function usage() {
-  return "Usage: triage-report.js --snapshot PATH [--relate PATH] [--stale PATH] [--out PATH] [--json]";
+  return "Usage: triage-report.js --snapshot PATH [--relate PATH] [--stale PATH] [--active-sprint PATH] [--out PATH] [--json]";
 }
 
 function parseArgs(args) {
@@ -20,6 +20,7 @@ function parseArgs(args) {
     snapshotPath: undefined,
     relatePath: undefined,
     stalePath: undefined,
+    activeSprintPath: undefined,
     outPath: undefined,
     json: false,
   };
@@ -60,6 +61,19 @@ function parseArgs(args) {
     }
     if (arg.startsWith("--out=")) {
       options.outPath = arg.slice("--out=".length);
+      continue;
+    }
+    if (arg === "--active-sprint") {
+      const nextValue = args[index + 1];
+      if (!nextValue) {
+        return { ...options, error: `Missing value for --active-sprint. ${usage()}` };
+      }
+      options.activeSprintPath = nextValue;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--active-sprint=")) {
+      options.activeSprintPath = arg.slice("--active-sprint=".length);
       continue;
     }
 
@@ -185,6 +199,37 @@ function groupBy(items, keyFn) {
 
 function sortIssues(issues) {
   return [...issues].sort((left, right) => left.number - right.number);
+}
+
+function extractMarkdownSection(content, heading) {
+  const source = String(content || "");
+  const escapedHeading = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(`^##\\s+${escapedHeading}\\s*$`, "m");
+  const match = source.match(pattern);
+  if (!match || match.index === undefined) return "";
+
+  const start = match.index + match[0].length;
+  const rest = source.slice(start);
+  const nextHeading = rest.search(/^##\s+/m);
+  return (nextHeading === -1 ? rest : rest.slice(0, nextHeading)).trim();
+}
+
+function collectActiveSprintIssueNumbers(content) {
+  const protectedNumbers = new Set();
+  const sections = [
+    extractMarkdownSection(content, "Plan"),
+    extractMarkdownSection(content, "Running Context"),
+  ];
+
+  for (const section of sections) {
+    const pattern = /(^|[^A-Za-z0-9_])#(\d+)\b/g;
+    let match;
+    while ((match = pattern.exec(section)) !== null) {
+      protectedNumbers.add(Number(match[2]));
+    }
+  }
+
+  return protectedNumbers;
 }
 
 function sortGroupEntries(groups, orderHint) {
@@ -324,6 +369,17 @@ function formatStaleEvidence(candidate) {
   } else if (ev.updatedAt) {
     parts.push(`updated ${String(ev.updatedAt).slice(0, 10)}`);
   }
+  if (ev.pr && typeof ev.pr === "object") {
+    const prLabel = ev.pr.number ? `PR #${ev.pr.number}` : "merged PR";
+    const mergedAt = ev.pr.mergedAt ? ` merged ${String(ev.pr.mergedAt).slice(0, 10)}` : "";
+    parts.push(`${prLabel}${mergedAt}`);
+  }
+  if (ev.target && typeof ev.target === "object" && Number.isInteger(ev.target.number)) {
+    parts.push(`target=#${ev.target.number}`);
+  }
+  if (typeof ev.score === "number") {
+    parts.push(`score=${ev.score.toFixed(2)}`);
+  }
   if ("milestone" in ev) {
     parts.push(ev.milestone ? `milestone=${ev.milestone}` : "no milestone");
   }
@@ -374,12 +430,13 @@ function staleCandidateToAction(candidate) {
   return null;
 }
 
-function buildObsoleteActions(stale) {
+function buildObsoleteActions(stale, { protectedIssueNumbers = new Set() } = {}) {
   if (!stale) return [];
   return dedupeActions(
     stale.candidates
       .map(staleCandidateToAction)
       .filter(Boolean)
+      .filter((action) => !protectedIssueNumbers.has(action.issueNumber))
   );
 }
 
@@ -434,6 +491,7 @@ function buildRelationshipCounts(relate) {
   if (!relate) return counts;
 
   for (const edge of relate.edges) {
+    if (edge.kind === "merged-pr-link") continue;
     counts.set(edge.from, (counts.get(edge.from) || 0) + 1);
     if (edge.to !== edge.from) {
       counts.set(edge.to, (counts.get(edge.to) || 0) + 1);
@@ -626,9 +684,10 @@ function buildFrontmatter(snapshot, snapshotPath) {
   ].join("\n");
 }
 
-function buildReportModel({ snapshot, snapshotPath, relate, stale }) {
+function buildReportModel({ snapshot, snapshotPath, relate, stale, activeSprintContent = "" }) {
   const issueIndex = buildIssueIndex(snapshot);
-  const obsoleteActions = buildObsoleteActions(stale);
+  const protectedIssueNumbers = collectActiveSprintIssueNumbers(activeSprintContent);
+  const obsoleteActions = buildObsoleteActions(stale, { protectedIssueNumbers });
   const priorityActions = buildPriorityActions(snapshot, relate, obsoleteActions);
   const milestoneActions = buildMilestoneActions(snapshot, relate, obsoleteActions, priorityActions);
   const allActions = [...obsoleteActions, ...priorityActions, ...milestoneActions];
@@ -695,11 +754,15 @@ function loadInputs(options) {
   const stale = options.stalePath
     ? readJsonFile(options.stalePath, { label: "stale JSON", validate: validateStaleResult })
     : null;
+  const activeSprintContent = options.activeSprintPath
+    ? fs.readFileSync(path.resolve(options.activeSprintPath), "utf-8")
+    : "";
 
   return {
     snapshot,
     relate,
     stale,
+    activeSprintContent,
   };
 }
 
@@ -721,6 +784,7 @@ function main() {
       snapshotPath: options.snapshotPath,
       relate: inputs.relate,
       stale: inputs.stale,
+      activeSprintContent: inputs.activeSprintContent,
     });
     markdown = renderReport(reportModel);
   } catch (error) {
@@ -750,7 +814,10 @@ module.exports = {
   readJsonFile,
   validateRelateResult,
   validateStaleResult,
+  extractMarkdownSection,
+  collectActiveSprintIssueNumbers,
   buildObsoleteActions,
+  buildRelationshipCounts,
   buildPriorityActions,
   buildMilestoneActions,
   formatStaleEvidence,

--- a/skills/backlog-triage/scripts/triage-report.test.js
+++ b/skills/backlog-triage/scripts/triage-report.test.js
@@ -14,6 +14,8 @@ const {
   writeReportFile,
   formatStaleEvidence,
   staleCandidateToAction,
+  buildRelationshipCounts,
+  collectActiveSprintIssueNumbers,
 } = require("./triage-report.js");
 
 function makeSnapshot() {
@@ -145,6 +147,7 @@ describe("parseArgs", () => {
         snapshotPath: "snapshot.json",
         relatePath: "relate.json",
         stalePath: "stale.json",
+        activeSprintPath: undefined,
         outPath: "report.md",
         json: true,
       }
@@ -234,6 +237,52 @@ describe("renderer helpers", () => {
     });
     assert.equal(action.verb, "close");
     assert.match(action.evidence, /label=wontfix/);
+
+    const mergedPr = formatStaleEvidence({
+      evidence: {
+        pr: { number: 88, mergedAt: "2026-04-18T01:15:00.000Z" },
+        milestone: null,
+      },
+    });
+    assert.match(mergedPr, /PR #88 merged 2026-04-18/);
+
+    const duplicate = formatStaleEvidence({
+      evidence: {
+        target: { number: 50 },
+        score: 1,
+      },
+    });
+    assert.match(duplicate, /target=#50/);
+    assert.match(duplicate, /score=1.00/);
+  });
+
+  it("collects protected issue refs only from active sprint Plan and Running Context", () => {
+    const content = [
+      "## Plan",
+      "- [ ] #101 Active task",
+      "",
+      "## Running Context",
+      "- Keep #102 open while executing.",
+      "",
+      "## Progress",
+      "- Mention #103 historically only.",
+      "",
+    ].join("\n");
+
+    assert.deepEqual([...collectActiveSprintIssueNumbers(content)].sort((left, right) => left - right), [101, 102]);
+  });
+
+  it("does not count merged-pr-link as a planning relationship", () => {
+    const counts = buildRelationshipCounts({
+      edges: [
+        { from: 101, to: 101, kind: "merged-pr-link" },
+        { from: 102, to: 103, kind: "mentions" },
+      ],
+    });
+
+    assert.equal(counts.has(101), false);
+    assert.equal(counts.get(102), 1);
+    assert.equal(counts.get(103), 1);
   });
 
   it("renders no-input placeholders for omitted relate/stale inputs", () => {
@@ -278,6 +327,86 @@ describe("renderer helpers", () => {
     const markdown = renderReport(model);
     assert.match(markdown, /#107 the important part is here because the keyword /);
     assert.doesNotMatch(markdown, /#107 feat\(foo\):/);
+  });
+
+  it("suppresses obsolete close proposals for issues protected by active sprint state", () => {
+    const snapshot = makeSnapshot();
+    const stale = {
+      candidates: [
+        {
+          number: 104,
+          title: "Legacy sprint cleanup chore",
+          reason: "inactive/stale: no activity for 107 days; exceeds stale_days threshold (60); no milestone assigned",
+          suggested_action: "close",
+          evidence: { daysSinceUpdate: 107, thresholdDays: 60, milestone: null },
+        },
+        {
+          number: 105,
+          title: "Audit token rotation docs cleanup",
+          reason: "labeled wontfix; explicit wontfix signal",
+          suggested_action: "close",
+          evidence: { matchedLabel: "wontfix", milestone: null },
+        },
+      ],
+    };
+
+    const model = buildReportModel({
+      snapshot,
+      snapshotPath: "fixtures/snapshot.json",
+      relate: null,
+      stale,
+      activeSprintContent: ["## Plan", "- [ ] #104 Keep this active", "", "## Running Context", "- #105 is under review"].join("\n"),
+    });
+
+    const obsolete = model.sections.find((section) => section.key === "obsolete").markdown;
+    assert.doesNotMatch(obsolete, /triage:close #104/);
+    assert.doesNotMatch(obsolete, /triage:close #105/);
+  });
+
+  it("merged-pr-link alone does not create priority or milestone proposals", () => {
+    const snapshot = {
+      generated: "2026-04-18T01:30:00.000Z",
+      repo: "sungjunlee/dev-backlog",
+      issues: [
+        {
+          number: 201,
+          title: "Single merged issue",
+          body: "",
+          labels: ["type:feature", "priority:medium"],
+          createdAt: "2026-04-10T01:30:00.000Z",
+          updatedAt: "2026-04-17T01:30:00.000Z",
+          milestone: null,
+          buckets: {
+            label: { type: "feature", priority: "medium", status: "todo" },
+            theme: "uncategorized",
+            age: "7-30d",
+            activity: "recent",
+            milestone: "unassigned",
+          },
+        },
+      ],
+    };
+    const relate = {
+      edges: [
+        {
+          from: 201,
+          to: 201,
+          kind: "merged-pr-link",
+          confidence: 1,
+          evidence: { pr: { number: 88, mergedAt: "2026-04-18T01:15:00.000Z" } },
+        },
+      ],
+    };
+
+    const model = buildReportModel({
+      snapshot,
+      snapshotPath: "fixtures/snapshot.json",
+      relate,
+      stale: null,
+    });
+
+    assert.equal(model.anchors.some((anchor) => anchor.section === "priority"), false);
+    assert.equal(model.anchors.some((anchor) => anchor.section === "milestone"), false);
   });
 });
 
@@ -368,13 +497,14 @@ describe("triage-report integration chain", () => {
     }
 
     assert.match(markdown, /^---\ngenerated: 2026-04-18\nrepo: sungjunlee\/dev-backlog\nsnapshot: .*fixture-snapshot\.json\nopen_issues: 6\n---/m);
+    assert.match(markdown, /<!-- triage:close #101 reason="merged closing PR detected: PR #88 merged at 2026-04-18T01:15:00.000Z" -->/);
     assert.match(markdown, /<!-- triage:close #104 reason="inactive\/stale: no activity for 107 days; exceeds stale_days threshold \(60\); no milestone assigned" -->/);
     assert.match(markdown, /<!-- triage:close #105 reason="labeled wontfix; explicit wontfix signal" -->/);
     assert.match(markdown, /<!-- triage:close #106 reason="labeled invalid; explicit invalid signal" -->/);
     assert.match(markdown, /#101 OAuth token refresh flow comment-mentions #103 Audit token rotation docs/);
     assert.match(markdown, /#101 OAuth token refresh flow merged-pr-link PR #88; mergedAt 2026-04-18T01:15:00.000Z/);
     assert.match(markdown, /comment and closing-PR relationship signals run only when snapshot v2 fields are present/);
-    assert.match(markdown, /closing-PR-already-merged and duplicate-of-closed signals deferred/);
+    assert.match(markdown, /merged closing-PR and duplicate-of-closed signals run only when snapshot v2 fields are present/);
 
     // Classification groups must match Done Criteria: theme / label / age.
     const classificationBlock = markdown.split(/^##\s+Classification/m)[1].split(/^##\s/m)[0];
@@ -400,7 +530,7 @@ describe("triage-report integration chain", () => {
 
     // Obsolete Candidates must carry a compact evidence line per item.
     const obsoleteBlock = markdown.split(/^##\s+Obsolete Candidates/m)[1].split(/^##\s/m)[0];
-    for (const issueNumber of [104, 105, 106]) {
+    for (const issueNumber of [101, 104, 105, 106]) {
       const anchorRegex = new RegExp(`<!-- triage:close #${issueNumber} [^>]*-->[\\s\\S]*?- \\[ \\] [^\\n]+\\n\\s+- _evidence: [^\\n]+_`);
       assert.match(obsoleteBlock, anchorRegex, `expected evidence line for obsolete #${issueNumber}`);
     }

--- a/skills/backlog-triage/scripts/triage-stale.js
+++ b/skills/backlog-triage/scripts/triage-stale.js
@@ -12,6 +12,8 @@ const SIGNALS = Object.freeze({
   INACTIVE: "inactive",
   WONTFIX: "wontfix",
   INVALID: "invalid",
+  MERGED_CLOSING_PR: "merged-closing-pr",
+  DUPLICATE_OF_CLOSED: "duplicate-of-closed",
 });
 
 function usage() {
@@ -174,7 +176,10 @@ function pickAction(signal, context = {}) {
     case SIGNALS.INACTIVE:
     case SIGNALS.WONTFIX:
     case SIGNALS.INVALID:
+    case SIGNALS.MERGED_CLOSING_PR:
       return "close";
+    case SIGNALS.DUPLICATE_OF_CLOSED:
+      return context.targetIssueNumber ? `merge-into:#${context.targetIssueNumber}` : "revisit";
     default:
       return context.targetIssueNumber ? `merge-into:#${context.targetIssueNumber}` : "revisit";
   }
@@ -242,6 +247,115 @@ function scanWontfixInvalid(issue) {
   return candidates;
 }
 
+function scanMergedClosingPr(issue) {
+  const closingPrs = Array.isArray(issue.closing_prs) ? issue.closing_prs : [];
+  const candidates = [];
+
+  for (const pr of closingPrs) {
+    const state = typeof pr?.state === "string" ? pr.state.toUpperCase() : "";
+    if (state !== "MERGED" || typeof pr?.mergedAt !== "string" || !pr.mergedAt) continue;
+
+    const prNumber = Number.isInteger(pr?.number) ? pr.number : null;
+    const prLabel = prNumber ? `PR #${prNumber}` : "a merged closing PR";
+    candidates.push(
+      buildCandidate(
+        issue,
+        SIGNALS.MERGED_CLOSING_PR,
+        `merged closing PR detected: ${prLabel} merged at ${pr.mergedAt}`,
+        {
+          source: "closing_prs",
+          pr: {
+            number: prNumber,
+            state: pr.state,
+            mergedAt: pr.mergedAt,
+            url: typeof pr?.url === "string" ? pr.url : null,
+          },
+          updatedAt: issue.updatedAt,
+          milestone: issue.milestone ?? null,
+        }
+      )
+    );
+  }
+
+  return candidates;
+}
+
+function tokenizeTitle(title) {
+  return new Set(
+    String(title || "")
+      .toLowerCase()
+      .match(/[a-z0-9]+/g)?.filter((token) => token.length > 1) || []
+  );
+}
+
+function jaccardSimilarity(left, right) {
+  const leftTokens = [...left];
+  const rightTokens = [...right];
+  const union = new Set([...leftTokens, ...rightTokens]);
+  if (union.size === 0) return { score: 0, overlap: [] };
+
+  const overlap = leftTokens.filter((token) => right.has(token));
+  return {
+    score: overlap.length / union.size,
+    overlap,
+  };
+}
+
+function closedIssueMatches(openIssue, closedIssue, threshold = 0.8) {
+  if (!Number.isInteger(closedIssue?.number) || typeof closedIssue?.title !== "string") {
+    return null;
+  }
+
+  const openTitle = String(openIssue.title || "").trim().toLowerCase();
+  const closedTitle = String(closedIssue.title || "").trim().toLowerCase();
+  const similarity = jaccardSimilarity(tokenizeTitle(openIssue.title), tokenizeTitle(closedIssue.title));
+  const exactTitle = openTitle.length > 0 && openTitle === closedTitle;
+  if (!exactTitle && similarity.score < threshold) return null;
+
+  return {
+    score: Number(similarity.score.toFixed(4)),
+    overlap: similarity.overlap.sort(),
+    exactTitle,
+  };
+}
+
+function scanDuplicateOfClosed(issue, closedIssues, { threshold = 0.8 } = {}) {
+  if (!Array.isArray(closedIssues) || closedIssues.length === 0) return [];
+
+  const candidates = [];
+  for (const closedIssue of closedIssues) {
+    const match = closedIssueMatches(issue, closedIssue, threshold);
+    if (!match) continue;
+
+    candidates.push(
+      buildCandidate(
+        issue,
+        SIGNALS.DUPLICATE_OF_CLOSED,
+        `duplicate of closed issue #${closedIssue.number}: title similarity ${match.score.toFixed(2)}`,
+        {
+          target: {
+            number: closedIssue.number,
+            title: closedIssue.title,
+            state: closedIssue.state || "closed",
+            closedAt: typeof closedIssue.closedAt === "string" ? closedIssue.closedAt : null,
+            url: typeof closedIssue.url === "string" ? closedIssue.url : null,
+          },
+          score: match.score,
+          overlap: match.overlap,
+          exactTitle: match.exactTitle,
+          titles: {
+            open: issue.title,
+            closed: closedIssue.title,
+          },
+        },
+        { targetIssueNumber: closedIssue.number }
+      )
+    );
+  }
+
+  return candidates;
+}
+
 function resolveThresholdDays({ since, backlogDir = DEFAULT_BACKLOG_DIR, config } = {}) {
   if (since !== undefined) return since;
   const resolvedConfig = config || readTriageConfig(backlogDir);
@@ -255,10 +369,13 @@ function analyzeSnapshot(snapshot, { since, backlogDir = DEFAULT_BACKLOG_DIR, co
   const candidates = [];
 
   for (const issue of snapshot.issues) {
+    candidates.push(...scanMergedClosingPr(issue));
+    candidates.push(...scanWontfixInvalid(issue));
+
     const inactiveCandidate = scanInactive(issue, thresholdDays, snapshot.generated);
     if (inactiveCandidate) candidates.push(inactiveCandidate);
 
-    candidates.push(...scanWontfixInvalid(issue));
+    candidates.push(...scanDuplicateOfClosed(issue, snapshot.closed_issues));
   }
 
   return {
@@ -331,6 +448,8 @@ module.exports = {
   pickAction,
   scanInactive,
   scanWontfixInvalid,
+  scanMergedClosingPr,
+  scanDuplicateOfClosed,
   resolveThresholdDays,
   analyzeSnapshot,
   formatCandidate,

--- a/skills/backlog-triage/scripts/triage-stale.test.js
+++ b/skills/backlog-triage/scripts/triage-stale.test.js
@@ -11,6 +11,8 @@ const {
   pickAction,
   scanInactive,
   scanWontfixInvalid,
+  scanMergedClosingPr,
+  scanDuplicateOfClosed,
   resolveThresholdDays,
   analyzeSnapshot,
 } = require("./triage-stale.js");
@@ -66,9 +68,11 @@ describe("pickAction", () => {
     assert.equal(pickAction(SIGNALS.INACTIVE), "close");
     assert.equal(pickAction(SIGNALS.WONTFIX), "close");
     assert.equal(pickAction(SIGNALS.INVALID), "close");
+    assert.equal(pickAction(SIGNALS.MERGED_CLOSING_PR), "close");
   });
 
   it("keeps revisit and merge-into actions available for future signals", () => {
+    assert.equal(pickAction(SIGNALS.DUPLICATE_OF_CLOSED, { targetIssueNumber: 42 }), "merge-into:#42");
     assert.equal(pickAction("future-signal", { targetIssueNumber: 42 }), "merge-into:#42");
     assert.equal(pickAction("future-signal"), "revisit");
   });
@@ -138,6 +142,72 @@ describe("scanWontfixInvalid", () => {
 
 });
 
+describe("scanMergedClosingPr", () => {
+  it("flags open issues with merged closing PR metadata", () => {
+    const [candidate] = scanMergedClosingPr({
+      number: 700,
+      title: "Close after merged PR",
+      updatedAt: "2026-07-01T00:00:00.000Z",
+      milestone: null,
+      closing_prs: [
+        {
+          number: 91,
+          state: "MERGED",
+          mergedAt: "2026-07-02T00:00:00.000Z",
+          url: "https://github.com/org/repo/pull/91",
+        },
+      ],
+    });
+
+    assert.equal(candidate.number, 700);
+    assert.equal(candidate.suggested_action, "close");
+    assert.match(candidate.reason, /merged closing PR/i);
+    assert.equal(candidate.evidence.pr.number, 91);
+  });
+
+  it("ignores absent or unmerged closing PR fields", () => {
+    assert.deepEqual(scanMergedClosingPr({ number: 701, title: "No optional field" }), []);
+    assert.deepEqual(
+      scanMergedClosingPr({
+        number: 702,
+        title: "Open PR",
+        closing_prs: [{ number: 92, state: "OPEN", mergedAt: null }],
+      }),
+      []
+    );
+  });
+});
+
+describe("scanDuplicateOfClosed", () => {
+  it("flags high-confidence duplicates of closed issues", () => {
+    const [candidate] = scanDuplicateOfClosed(
+      { number: 710, title: "OAuth token refresh worker" },
+      [
+        {
+          number: 44,
+          title: "OAuth token refresh worker",
+          state: "closed",
+          closedAt: "2026-06-01T00:00:00.000Z",
+        },
+      ]
+    );
+
+    assert.equal(candidate.suggested_action, "merge-into:#44");
+    assert.match(candidate.reason, /duplicate of closed issue #44/i);
+    assert.equal(candidate.evidence.target.number, 44);
+    assert.equal(candidate.evidence.exactTitle, true);
+  });
+
+  it("does not flag low-overlap closed issues", () => {
+    const candidates = scanDuplicateOfClosed(
+      { number: 711, title: "OAuth token refresh worker" },
+      [{ number: 45, title: "Documentation table formatting", state: "closed" }]
+    );
+
+    assert.deepEqual(candidates, []);
+  });
+});
+
 describe("resolveThresholdDays and analyzeSnapshot", () => {
   let tempBacklogDir;
 
@@ -183,5 +253,30 @@ describe("resolveThresholdDays and analyzeSnapshot", () => {
     assert.ok(numbers.includes(504));
     assert.ok(!inactiveCandidates.some((candidate) => candidate.number === 501));
     assert.ok(!numbers.includes(502));
+  });
+
+  it("includes optional merged-PR and duplicate-of-closed stale signals when snapshot fields are present", () => {
+    const snapshot = loadFixtureSnapshot();
+    snapshot.issues.push({
+      number: 700,
+      title: "Close after merged PR",
+      labels: [],
+      updatedAt: "2026-07-15T00:00:00.000Z",
+      milestone: null,
+      closing_prs: [{ number: 91, state: "MERGED", mergedAt: "2026-07-16T00:00:00.000Z" }],
+    });
+    snapshot.issues.push({
+      number: 701,
+      title: "OAuth token refresh worker",
+      labels: [],
+      updatedAt: "2026-07-15T00:00:00.000Z",
+      milestone: null,
+    });
+    snapshot.closed_issues = [{ number: 44, title: "OAuth token refresh worker", state: "closed" }];
+
+    const result = analyzeSnapshot(snapshot, { config: { stale_days: 60 } });
+
+    assert.ok(result.candidates.some((candidate) => candidate.number === 700 && candidate.suggested_action === "close"));
+    assert.ok(result.candidates.some((candidate) => candidate.number === 701 && candidate.suggested_action === "merge-into:#44"));
   });
 });

--- a/skills/dev-backlog/SKILL.md
+++ b/skills/dev-backlog/SKILL.md
@@ -48,7 +48,7 @@ backlog/
 
 ### sprints/ Rules
 
-- **One active sprint at a time.** The file with `status: active` is the current sprint.
+- **One active sprint at a time.** Exactly one `status: active` sprint is valid; scripts warn/refuse ambiguous active sprint state instead of picking one arbitrarily.
 - **Naming: `YYYY-MM-<topic>.md`** — date prefix for timeline, topic for content.
   - Task-focused: `2026-03-auth-system.md`, `2026-04-payment-integration.md`
   - Time-focused: `2026-03-W13-misc.md`, `2026-03-tech-debt.md`
@@ -228,15 +228,15 @@ Full process details: `references/process.md` (Orient, Create, Plan, Work, Compl
 
 All scripts live in `${CLAUDE_SKILL_DIR}/scripts/` (the skill's own directory, not the target project). Run from the target project root.
 
-- `scripts/lib.sh` — Shared bash functions: `find_active_sprint`, `count_checkboxes`, `extract_section`
+- `scripts/lib.sh` — Shared bash functions: `find_active_sprint`, `find_active_sprints`, `count_checkboxes`, `extract_section`
 - `scripts/lib.js` — Shared Node functions: `slugify`, `escapeYaml`, `readConfig`, `estimateSize`
 - `scripts/init.sh [project-name]` — Bootstrap `backlog/` directory with config.yml
-- `scripts/next.sh` — Show next actionable batch from active sprint (zero LLM cost)
+- `scripts/next.sh` — Show next actionable batch from the single active sprint (zero LLM cost)
 - `scripts/status.sh` — Project status from sprint file + GitHub
 - `scripts/sync-pull.js [PREFIX] [--update] [--dry-run] [--json] [--limit N]` — Pull open GitHub issues to local backlog/tasks/. By default it fetches all open issues; `--limit N` caps the fetch size. PREFIX defaults to config.yml's `task_prefix`. `--update` refreshes frontmatter while preserving local AC checkboxes. `--json` emits a machine-readable summary.
-- `scripts/sprint-init.js "auth-system" [--milestone "Name"] [--dry-run] [--json]` — Generate sprint file skeleton. `--json` emits the target sprint file path plus metadata.
+- `scripts/sprint-init.js "auth-system" [--milestone "Name"] [--dry-run] [--json]` — Generate sprint file skeleton; refuses to create a second active sprint. `--json` emits the target sprint file path plus metadata.
 - `scripts/progress-sync.js [--month YYYY-MM] [--dry-run] [--json] [--relay-manifest PATH] [--finalize]` — Sync the monthly GitHub Progress issue. `--finalize` adds the month-end block and closes the target month's issue idempotently.
-- `scripts/sprint-close.sh [backlog-dir] [--dry-run] [--close-milestone]` — Close active sprint: set completed, move tasks, remind about context promotion
+- `scripts/sprint-close.sh [backlog-dir] [--dry-run] [--close-milestone]` — Close the single active sprint: set completed, move tasks, remind about context promotion
 - `scripts/context-hook.sh [backlog-dir]` — One-line sprint summary for Claude Code PreToolUse hook (always exits 0)
 - `scripts/objectives-check.js [--sprints-dir PATH] [--charter PATH] [--json]` — Verify every `objectives:` ID in sprint files still exists in `spec/charter.md` (or legacy root `CHARTER.md`) with an actionable (non-deferred) status. Graceful no-op when both are absent.
 - `scripts/component-lint.js [--sprints-dir PATH] [--capabilities PATH] [--json]` — Verify every `component:` value in sprint files resolves to one declared capability in `spec/capabilities.md`. Comma-separated multi-component values fail because `component:` is the primary routing handle; put secondary touches in sprint prose. Graceful no-op when `spec/capabilities.md` is absent.

--- a/skills/dev-backlog/scripts/context-hook.sh
+++ b/skills/dev-backlog/scripts/context-hook.sh
@@ -27,8 +27,17 @@ if [ ! -d "$SPRINTS_DIR" ]; then
   exit 0
 fi
 
-ACTIVE=$(find_active_sprint "$SPRINTS_DIR")
-if [ -z "$ACTIVE" ]; then
+if ACTIVE=$(find_active_sprint "$SPRINTS_DIR" 2>/dev/null); then
+  ACTIVE_STATUS=0
+else
+  ACTIVE_STATUS=$?
+fi
+if [ "$ACTIVE_STATUS" -eq 2 ]; then
+  echo "[Sprint warning] Multiple active sprints found; resolve backlog/sprints/ before editing."
+  exit 0
+fi
+
+if [ "$ACTIVE_STATUS" -ne 0 ]; then
   exit 0
 fi
 

--- a/skills/dev-backlog/scripts/lib.sh
+++ b/skills/dev-backlog/scripts/lib.sh
@@ -9,12 +9,41 @@ RE_CB_DONE='^\- \[x\] #'
 RE_CB_INFLIGHT='^\- \[~\] #'
 RE_CB_TODO='^\- \[ \] #'
 
-# Find the active sprint file (status: active in frontmatter).
+# List active sprint files (status: active in frontmatter).
+# Usage: find_active_sprints "$SPRINTS_DIR"
+find_active_sprints() {
+  local sprints_dir="$1"
+  find "$sprints_dir" -maxdepth 1 -name "*.md" ! -name "_context.md" \
+    -exec grep -l "^status: active" {} + 2>/dev/null | sort
+}
+
+# Find the active sprint file.
+# Return codes:
+#   0: exactly one active sprint, printed to stdout
+#   1: no active sprint
+#   2: multiple active sprints, printed to stderr
 # Usage: ACTIVE=$(find_active_sprint "$SPRINTS_DIR")
 find_active_sprint() {
   local sprints_dir="$1"
-  find "$sprints_dir" -maxdepth 1 -name "*.md" ! -name "_context.md" \
-    -exec grep -l "^status: active" {} + 2>/dev/null | head -1
+  local active
+  local count
+
+  active=$(find_active_sprints "$sprints_dir")
+  count=$(printf "%s\n" "$active" | grep -c . || true)
+
+  if [ "$count" -eq 0 ]; then
+    return 1
+  fi
+
+  if [ "$count" -gt 1 ]; then
+    {
+      echo "Multiple active sprint files found:"
+      printf "%s\n" "$active" | sed 's/^/  /'
+    } >&2
+    return 2
+  fi
+
+  printf "%s\n" "$active"
 }
 
 # Count checkbox states in a sprint file (single awk pass).

--- a/skills/dev-backlog/scripts/next.sh
+++ b/skills/dev-backlog/scripts/next.sh
@@ -17,9 +17,18 @@ if [ ! -d "$SPRINTS_DIR" ]; then
   exit 1
 fi
 
-ACTIVE=$(find_active_sprint "$SPRINTS_DIR")
+ACTIVE=$(find_active_sprint "$SPRINTS_DIR" 2>/dev/null)
+ACTIVE_STATUS=$?
 
-if [ -z "$ACTIVE" ]; then
+if [ "$ACTIVE_STATUS" -eq 2 ]; then
+  echo "Multiple active sprints found. Resolve backlog/sprints/ before choosing next work."
+  find_active_sprints "$SPRINTS_DIR" | while IFS= read -r sprint; do
+    echo "  - $(basename "$sprint")"
+  done
+  exit 1
+fi
+
+if [ "$ACTIVE_STATUS" -ne 0 ]; then
   echo "No active sprint found."
   echo "Check GitHub: gh issue list --state open"
   exit 0

--- a/skills/dev-backlog/scripts/smoke-test.sh
+++ b/skills/dev-backlog/scripts/smoke-test.sh
@@ -160,6 +160,37 @@ assert_contains "find: returns active file" "$OUT" "active.md"
 assert_not_contains "find: excludes _context.md" "$OUT" "_context.md"
 assert_not_contains "find: excludes completed" "$OUT" "completed.md"
 
+rm "$TEST_DIR/sprints/active.md"
+set +e
+OUT=$(find_active_sprint "$TEST_DIR/sprints")
+STATUS=$?
+set -e
+assert_equals "find: no active exit code" "$STATUS" "1"
+assert_equals "find: no active output" "$OUT" ""
+
+cat > "$TEST_DIR/sprints/active-a.md" << 'EOF'
+---
+status: active
+---
+EOF
+
+cat > "$TEST_DIR/sprints/active-b.md" << 'EOF'
+---
+status: active
+---
+EOF
+
+ERR="$TEST_DIR/find-active-error.txt"
+set +e
+OUT=$(find_active_sprint "$TEST_DIR/sprints" 2>"$ERR")
+STATUS=$?
+set -e
+assert_equals "find: multiple active exit code" "$STATUS" "2"
+assert_equals "find: multiple active stdout empty" "$OUT" ""
+assert_contains "find: multiple active error heading" "$(cat "$ERR")" "Multiple active sprint files found"
+assert_contains "find: multiple active lists first" "$(cat "$ERR")" "active-a.md"
+assert_contains "find: multiple active lists second" "$(cat "$ERR")" "active-b.md"
+
 # ============================================================
 # next.sh integration tests
 # ============================================================
@@ -329,6 +360,44 @@ assert_contains "no-active: message" "$OUT" "No active sprint"
 
 OUT=$(bash "$SCRIPT_DIR/status.sh" "$TEST_DIR/backlog")
 assert_contains "status no-active: message" "$OUT" "no active sprint"
+
+# --- Multiple active sprints ---
+cat > "$TEST_DIR/backlog/sprints/2026-03-active-a.md" << 'EOF'
+---
+status: active
+---
+
+## Plan
+- [ ] #1 Task A
+EOF
+
+cat > "$TEST_DIR/backlog/sprints/2026-03-active-b.md" << 'EOF'
+---
+status: active
+---
+
+## Plan
+- [ ] #2 Task B
+EOF
+
+set +e
+OUT=$(bash "$SCRIPT_DIR/next.sh" "$TEST_DIR/backlog" 2>&1)
+STATUS=$?
+set -e
+assert_equals "next multiple-active: exit code" "$STATUS" "1"
+assert_contains "next multiple-active: message" "$OUT" "Multiple active sprints found"
+assert_contains "next multiple-active: lists first" "$OUT" "2026-03-active-a.md"
+assert_contains "next multiple-active: lists second" "$OUT" "2026-03-active-b.md"
+
+OUT=$(bash "$SCRIPT_DIR/status.sh" "$TEST_DIR/backlog" 2>&1)
+assert_contains "status multiple-active: warning" "$OUT" "Multiple active sprints found"
+assert_contains "status multiple-active: lists first" "$OUT" "2026-03-active-a.md"
+assert_contains "status multiple-active: lists second" "$OUT" "2026-03-active-b.md"
+
+OUT=$(bash "$SCRIPT_DIR/context-hook.sh" "$TEST_DIR/backlog" 2>&1)
+assert_contains "hook multiple-active: warning" "$OUT" "Multiple active sprints found"
+
+rm "$TEST_DIR/backlog/sprints/2026-03-active-a.md" "$TEST_DIR/backlog/sprints/2026-03-active-b.md"
 
 # --- status.sh: local files section ---
 mkdir -p "$TEST_DIR/backlog/tasks"
@@ -522,6 +591,25 @@ title: Unrelated
 status: To Do
 ---
 EOF
+
+cat > "$TEST_DIR/backlog/sprints/2026-03-other-active.md" << 'EOF'
+---
+status: active
+---
+
+## Plan
+- [x] #50 Other task
+EOF
+
+set +e
+OUT=$(bash "$SCRIPT_DIR/sprint-close.sh" "$TEST_DIR/backlog" 2>&1)
+STATUS=$?
+set -e
+assert_equals "close multiple-active: exit code" "$STATUS" "1"
+assert_contains "close multiple-active: refuses ambiguous close" "$OUT" "Refusing to close an ambiguous sprint"
+assert_contains "close multiple-active: lists first" "$OUT" "2026-03-auth.md"
+assert_contains "close multiple-active: lists second" "$OUT" "2026-03-other-active.md"
+rm "$TEST_DIR/backlog/sprints/2026-03-other-active.md"
 
 # --- dry-run test ---
 OUT=$(bash "$SCRIPT_DIR/sprint-close.sh" "$TEST_DIR/backlog" --dry-run 2>&1)

--- a/skills/dev-backlog/scripts/sprint-close.sh
+++ b/skills/dev-backlog/scripts/sprint-close.sh
@@ -33,8 +33,17 @@ if [ ! -d "$SPRINTS_DIR" ]; then
   exit 1
 fi
 
-ACTIVE=$(find_active_sprint "$SPRINTS_DIR")
-if [ -z "$ACTIVE" ]; then
+ACTIVE=$(find_active_sprint "$SPRINTS_DIR" 2>/dev/null)
+ACTIVE_STATUS=$?
+if [ "$ACTIVE_STATUS" -eq 2 ]; then
+  echo "Multiple active sprints found. Refusing to close an ambiguous sprint:"
+  find_active_sprints "$SPRINTS_DIR" | while IFS= read -r sprint; do
+    echo "  - $(basename "$sprint")"
+  done
+  exit 1
+fi
+
+if [ "$ACTIVE_STATUS" -ne 0 ]; then
   echo "No active sprint to close."
   exit 0
 fi

--- a/skills/dev-backlog/scripts/sprint-init.js
+++ b/skills/dev-backlog/scripts/sprint-init.js
@@ -77,7 +77,19 @@ ${issueLines.join("\n")}
 
 ## Progress
 [Timestamped log — update at end of each session/batch]
-`;
+  `;
+}
+
+function listActiveSprintFiles(sprintsDir) {
+  if (!fs.existsSync(sprintsDir)) return [];
+
+  return fs.readdirSync(sprintsDir)
+    .filter((file) => file.endsWith(".md") && file !== "_context.md")
+    .filter((file) => {
+      const content = fs.readFileSync(path.join(sprintsDir, file), "utf-8");
+      return /^status: active$/m.test(content);
+    })
+    .sort();
 }
 
 function createSprintResult({
@@ -150,9 +162,16 @@ function createSprintFile({
   const topicSlug = slugify(topic) || "sprint";
   const sprintFile = path.join(sprintsDir, `${datePrefix}-${topicSlug}.md`);
   const existingFile = fileExists(sprintFile);
+  const activeSprintFiles = listActiveSprintFiles(sprintsDir);
 
   if (existingFile && !dryRun) {
     throw new Error(`Sprint file already exists: ${sprintFile}`);
+  }
+
+  if (activeSprintFiles.length > 0 && !existingFile) {
+    throw new Error(
+      `Active sprint already exists: ${activeSprintFiles.join(", ")}. Close it before creating another active sprint.`
+    );
   }
 
   const due = existingFile ? "TBD" : getDue(milestone);
@@ -228,6 +247,7 @@ module.exports = {
   parseArgs,
   buildIssueLines,
   buildSprintContent,
+  listActiveSprintFiles,
   createSprintFile,
   printResult,
 };

--- a/skills/dev-backlog/scripts/sprint-init.test.js
+++ b/skills/dev-backlog/scripts/sprint-init.test.js
@@ -7,6 +7,7 @@ const {
   parseArgs,
   buildIssueLines,
   buildSprintContent,
+  listActiveSprintFiles,
   createSprintFile,
 } = require("./sprint-init.js");
 
@@ -112,6 +113,50 @@ describe("createSprintFile", () => {
     const written = fs.readFileSync(result.sprintFile, "utf-8");
     assert.equal(written, result.content);
     assert.match(written, /due: 2026-04-12\nobjectives: \[\]\ncomponent: ""\n---/);
+  });
+
+  it("lists active sprint files sorted and excludes _context.md", () => {
+    fs.writeFileSync(path.join(tmpDir, "2026-04-beta.md"), "---\nstatus: active\n---\n");
+    fs.writeFileSync(path.join(tmpDir, "2026-04-alpha.md"), "---\nstatus: active\n---\n");
+    fs.writeFileSync(path.join(tmpDir, "2026-04-done.md"), "---\nstatus: completed\n---\n");
+    fs.writeFileSync(path.join(tmpDir, "_context.md"), "status: active\n");
+
+    assert.deepEqual(listActiveSprintFiles(tmpDir), [
+      "2026-04-alpha.md",
+      "2026-04-beta.md",
+    ]);
+  });
+
+  it("refuses to create a new active sprint when another active sprint exists", () => {
+    fs.writeFileSync(path.join(tmpDir, "2026-04-current.md"), "---\nstatus: active\n---\n");
+
+    assert.throws(() => {
+      createSprintFile({
+        topic: "next-sprint",
+        milestone: "Sprint W14",
+        dryRun: false,
+        sprintsDir: tmpDir,
+        today: new Date("2026-04-05T09:00:00Z"),
+        getDue: () => "2026-04-12",
+        getIssues: () => [],
+      });
+    }, /Active sprint already exists: 2026-04-current\.md/);
+  });
+
+  it("also refuses dry-run creation when another active sprint exists", () => {
+    fs.writeFileSync(path.join(tmpDir, "2026-04-current.md"), "---\nstatus: active\n---\n");
+
+    assert.throws(() => {
+      createSprintFile({
+        topic: "next-sprint",
+        milestone: "Sprint W14",
+        dryRun: true,
+        sprintsDir: tmpDir,
+        today: new Date("2026-04-05T09:00:00Z"),
+        getDue: () => "2026-04-12",
+        getIssues: () => [],
+      });
+    }, /Active sprint already exists: 2026-04-current\.md/);
   });
 
   it("returns placeholder metadata on dry-run when milestone has no issues", () => {

--- a/skills/dev-backlog/scripts/status.sh
+++ b/skills/dev-backlog/scripts/status.sh
@@ -12,8 +12,14 @@ SPRINTS_DIR="$BACKLOG_DIR/sprints"
 # --- Active Sprint ---
 echo "=== Active Sprint ==="
 if [ -d "$SPRINTS_DIR" ]; then
-  ACTIVE=$(find_active_sprint "$SPRINTS_DIR")
-  if [ -n "$ACTIVE" ]; then
+  ACTIVE=$(find_active_sprint "$SPRINTS_DIR" 2>/dev/null)
+  ACTIVE_STATUS=$?
+  if [ "$ACTIVE_STATUS" -eq 2 ]; then
+    echo "!! Multiple active sprints found. Resolve before continuing:"
+    find_active_sprints "$SPRINTS_DIR" | while IFS= read -r sprint; do
+      echo "  - $(basename "$sprint")"
+    done
+  elif [ "$ACTIVE_STATUS" -eq 0 ]; then
     SPRINT_NAME=$(basename "$ACTIVE" .md)
     count_checkboxes "$ACTIVE"
     if [ "$CB_TOTAL" -gt 0 ]; then

--- a/skills/spec-charter/references/reassess.md
+++ b/skills/spec-charter/references/reassess.md
@@ -140,4 +140,4 @@ Archive older Learnings when they are useful history but no longer startup conte
 
 ## Reserved Names
 
-Naming policy lives in `docs/spec-system-design.md`. Summary: today the callable spec-series skills are `spec-charter` and `spec-grill`. The names `spec-reassess` and `spec-learn` are reserved/non-callable future split candidates. Mention them only when discussing naming policy or split triggers, not as commands the user can run.
+Naming policy lives in `docs/spec-system-design.md`. Summary: today the callable spec-series skills are `spec-charter`, `spec-system-map`, and `spec-grill`. The names `spec-reassess` and `spec-learn` are reserved/non-callable future split candidates. Mention them only when discussing naming policy or split triggers, not as commands the user can run.

--- a/spec/system-map.md
+++ b/spec/system-map.md
@@ -50,15 +50,21 @@ spec/
 - `spec/capabilities.md` remains compact enough to read at session start.
 - Completed sprint files are immutable history.
 
-## Candidate Capability Boundaries
+## Accepted Capability Contracts
 
-- `sprint-execution` - evidence: active sprint flow and completed-sprint invariant; owns sprint planning, in-flight state, and progress context; uncertainty: whether future relay learning writes should remain in this boundary.
-- `backlog-sync` - evidence: GitHub Issues -> task mirror flow and explicit sync invariant; owns issue-to-task mirroring and local AC preservation; uncertainty: whether richer triage snapshots should stay separate.
-- `triage-grooming` - evidence: advisory grooming flow and Decision Review use of spec evidence; owns issue classification, relationship, stale, alignment, and decision reports; uncertainty: whether closing-PR snapshot enrichment changes this contract.
-- `spec-charter` - evidence: canonical `spec/charter.md` invariant and proof-gated direction flow; owns project axis lifecycle; uncertainty: how concrete downstream routing recommendations should be generated.
-- `spec-system-map` - evidence: project-wide shape and boundary map flow; owns high-level system structure without module inventory; uncertainty: how much candidate boundary detail is useful before it becomes capability content.
-- `spec-grill` - evidence: capability contract flow and compact capability invariant; owns capability admission, predicate pressure tests, and report-first boundary review; uncertainty: how evidence grouping should influence candidate naming.
-- `task-progress-reporting` - evidence: progress helper scripts and GitHub Progress issue lifecycle; owns monthly progress issue updates and finalization; uncertainty: whether comment enrichment belongs here or in a separate integration boundary.
+Accepted capability contracts live in [`capabilities.md`](capabilities.md). Current boundaries are:
+
+- `sprint-execution` - sprint planning, in-flight state, progress context, and active/completed sprint invariants.
+- `backlog-sync` - GitHub issue mirroring, local task cache format, and AC preservation.
+- `triage-grooming` - advisory issue classification, relationships, stale signals, Alignment, Decision Review, and report/apply boundaries.
+- `spec-charter` - project axis lifecycle and proof-gated charter mutation.
+- `spec-system-map` - high-level system structure, runtime boundaries, flows, invariants, and durable pointers.
+- `spec-grill` - capability admission, predicate pressure tests, and compact `spec/capabilities.md` contracts.
+- `task-progress-reporting` - monthly GitHub Progress issue synchronization and finalization.
+
+## Open Boundary Questions
+
+No active unresolved boundary question is recorded in this map. New candidate boundaries should go through `spec-grill`; project-wide structure changes should go through `spec-system-map amend`.
 
 ## Where To Go Next
 


### PR DESCRIPTION
## Summary
- fail loud on ambiguous active sprint state across dev-backlog scripts and sprint creation
- add conservative backlog-triage stale signals for merged closing PRs and duplicate-of-closed issues
- refresh spec-series tracking docs and local sprint/task execution state

## Verification
- bash skills/dev-backlog/scripts/smoke-test.sh
- node --test skills/dev-backlog/scripts/*.test.js skills/backlog-triage/scripts/*.test.js skills/spec-charter/scripts/*.test.js skills/spec-grill/scripts/*.test.js
- node skills/dev-backlog/scripts/capabilities-doctor.js --strict
- node skills/dev-backlog/scripts/component-lint.js

Fixes #190
Fixes #193
Fixes #194