### PR TITLE
Clarify skill execution contracts

### DIFF
--- a/skills/backlog-triage/SKILL.md
+++ b/skills/backlog-triage/SKILL.md
@@ -9,222 +9,134 @@ metadata:
 
 # Backlog Triage
 
-Open-issue grooming as a two-phase loop:
+Real job: inspect open GitHub Issues, produce an advisory triage report, and apply only human-accepted issue mutations through stable anchor comments.
+
+Sibling skill to `dev-backlog`, not a replacement. `dev-backlog` owns sprint execution, progress, milestones, and AC mirrors. `backlog-triage` owns open-issue classification, relationships, stale signals, priority/milestone proposals, and optional accepted GitHub mutations.
+
+## Phase Model
 
 ```
-Phase 1 — Report (advisory)          Phase 2 — Apply (explicit)
-  collect → relate → stale              review report → --apply
-      ↓                                       ↓
-  single markdown report                gh mutations via anchors
+Phase 1 — Report (default, read-only)     Phase 2 — Apply (explicit mutation)
+  collect -> analyze -> render              review report -> --apply
+       |                                          |
+  one snapshot + markdown report             gh mutations + JSONL audit log
 ```
 
-Sibling skill to dev-backlog, not a replacement. dev-backlog is the execution hub (sprints, progress, milestones). backlog-triage is advisory: it inspects the open issue set and proposes changes. You decide; it applies only what you've approved.
+| Phase | Step | Completion boundary |
+| --- | --- | --- |
+| Report | Collect | One `gh` fetch writes a snapshot JSON; downstream steps use `--snapshot PATH` and do not re-fetch. |
+| Report | Analyze | Classification, relationships, stale/obsolete signals, Alignment, and Decision Review are computed from the same snapshot/spec evidence. |
+| Report | Render | One markdown report is written with anchored proposals and a consolidated Apply Checklist. |
+| Apply | Review | A human accepts proposals by flipping paired checkboxes from `[ ]` to `[x]`; unchecked anchors remain inert. |
+| Apply | Dry-run | `triage-apply.js <report.md>` prints intended `gh` mutations without writing. |
+| Apply | Mutate | `triage-apply.js <report.md> --apply` executes only accepted actions; `--yes` is required for non-interactive apply. |
+| Apply | Re-run | Re-running apply is idempotent and logs `already-applied` for completed actions. |
 
----
+Report mode is always safe to rerun. Apply mode is opt-in and must preserve an audit log beside the report.
 
-## Two-Phase Model
+## Report Evidence
 
-### Phase 1 — Report (default, no mutations)
-
-1. **Collect** open issues → snapshot JSON (one `gh` fetch per run)
-2. **Analyze** — classification, relationships, stale/obsolete signals, Alignment Check, and spec-aware Decision Review
-3. **Render** — one markdown report with anchored proposals
-
-Every script in this phase is read-only. Running any number of times is safe. The snapshot is the canonical artifact; all downstream analysis consumes it via `--snapshot PATH` (no re-fetch).
-
-Alignment Check is prompt-driven, not a `triage-*.js` script: read `spec/charter.md` first, fall back to legacy root `CHARTER.md`, then map open issues to Objectives using `../spec-charter/references/alignment.md` and emit an `## Alignment` report section. When both files are absent, skip this step entirely.
-
-Decision Review is also prompt-driven and report-only: read `spec/charter.md` with legacy root `CHARTER.md` fallback, optionally read `spec/capabilities.md` and `spec/system-map.md`, then classify open issues into `Do Now`, `Shape First`, `Defer`, or `Drop / Close` using `references/decision-review.md`. Missing spec artifacts are graceful no-ops.
-
-### Phase 2 — Apply (opt-in, explicit)
-
-Humans review the report and mark accepted proposals (flip `[ ]` → `[x]`). Then:
-
-```bash
-# Run from the target project root; scripts live under ${CLAUDE_SKILL_DIR}/scripts/.
-node "${CLAUDE_SKILL_DIR}/scripts/triage-apply.js" backlog/triage/YYYY-MM-DD-report.md               # dry-run
-node "${CLAUDE_SKILL_DIR}/scripts/triage-apply.js" backlog/triage/YYYY-MM-DD-report.md --apply       # with confirmation
-node "${CLAUDE_SKILL_DIR}/scripts/triage-apply.js" backlog/triage/YYYY-MM-DD-report.md --apply --yes # CI-safe
-
-# Live integration coverage (opt-in only; disposable sandbox repo + write token required)
-GH_TOKEN="$(gh auth token)" TRIAGE_APPLY_INTEGRATION=1 \
-  node --test "${CLAUDE_SKILL_DIR}/scripts/triage-apply.integration.test.js"
-```
-
-Default is **dry-run**. `--apply` requires confirmation unless `--yes`. Idempotent: re-running after a partial apply emits `already-applied` log entries for actions already executed.
-The integration test is intentionally separate from the default `node --test` path. It mutates the dedicated sandbox repo `sungjunlee/triage-apply-sandbox`, so it only runs when `TRIAGE_APPLY_INTEGRATION=1` and `GH_TOKEN` are both present.
-
----
-
-## Directory Layout
-
-```
-backlog/
-├── triage/
-│   ├── .cache/                       # Snapshots (downstream scripts read from here)
-│   │   └── 2026-04-18T01-30-00Z.json
-│   ├── 2026-04-18-report.md          # Triage report (human entry point)
-│   └── 2026-04-18-apply.log          # JSONL audit trail of apply run
-└── triage-config.yml                 # Thresholds, theme keywords, weights
-```
-
-The triage report is a **derived artifact**. GitHub Issues remain the source of truth. Regenerating from the snapshot must reproduce the same proposals.
-
----
+- Snapshot JSON is the canonical input artifact for a triage run.
+- Alignment is prompt-driven: read `spec/charter.md`, fall back to legacy root `CHARTER.md`, then use `../spec-charter/references/alignment.md`. When both charter files are absent, skip the mapping work and render `## Alignment` as skipped because no charter evidence exists.
+- Decision Review is prompt-driven and report-only: read the resolved charter, optional `spec/capabilities.md`, optional `spec/system-map.md`, active sprint context, and triage signals; use `references/decision-review.md`.
+- Spec-axis boundaries live in `../spec-charter/references/spec-axis.md`; triage may propose charter/capability/system-map follow-ups but must not mutate those specs.
 
 ## Anchor-Comment Apply Contract
 
-Every actionable proposal in the report carries a stable anchor comment paired with a visible checkbox:
+Every actionable proposal pairs a stable machine anchor with a visible checkbox:
 
 ```markdown
 <!-- triage:close #42 reason="merged PR #87 already exists" -->
-- [ ] close #42 — merged PR #87 already exists
+- [ ] close #42 - merged PR #87 already exists
 ```
 
-- The **anchor comment** is the machine contract.
-- The **checkbox** is the human confirmation surface.
-- An action is accepted when **both** the anchor exists AND its paired checkbox is `[x]`.
+Rules:
 
-This mirrors dev-backlog's `<!-- AC:BEGIN --><!-- AC:END -->` convention and survives markdown reformatting, so a human editing the report cannot silently break the parse.
+- The anchor comment is the machine contract.
+- The paired checkbox is the human confirmation surface.
+- An action is accepted only when the anchor exists and its paired checkbox is `[x]`.
+- Unknown verbs parse without crashing and are skipped by consumers that do not implement them.
+- Duplicate proposal surfaces are deduped by `(verb, issueNumber, normalizedArgs)`.
 
-See `references/apply.md` for the full anchor grammar, parse rules, and audit-log schema.
-
----
+See `references/apply.md` for anchor grammar, parse rules, dedupe behavior, idempotency, and audit-log schema.
 
 ## Report Shape
 
-```markdown
----
-generated: 2026-04-18
-repo: owner/name
-snapshot: backlog/triage/.cache/2026-04-18T01-30-00Z.json
-open_issues: 12
----
+The report is a derived artifact under `backlog/triage/`. GitHub Issues remain the source of truth.
 
-# Backlog Triage — 2026-04-18
+Required sections:
 
-## Classification
-By theme / label / age — grouped tables.
+- `## Classification` — issue buckets by theme, label, age, activity, and milestone state.
+- `## Relationships` — mentions, blocks, depends-on, duplicate candidates, and merged closing PR links.
+- `## Obsolete Candidates` — anchored close/revisit proposals with evidence.
+- `## Priority Proposals` — anchored priority proposals with rationale.
+- `## Milestone Suggestions` — anchored milestone proposals grouped into candidate sprint clusters.
+- `## Alignment` — objective coverage, orphan work, neglected objectives, contradictions, and proposed charter changes; when no charter exists, record that alignment was skipped.
+- `## Decision Review` — `Do Now`, `Shape First`, `Defer`, and `Drop / Close`.
+- `## Apply Checklist` — consolidated review surface for every anchored action.
 
-## Relationships
-Edges list (mentions, blocks, depends-on, duplicate candidates).
+Full section examples and rubric details live in `references/classification.md`, `references/relationships.md`, `references/stale.md`, `references/decision-review.md`, and `references/apply.md`.
 
-## Obsolete Candidates
-anchor + checkbox + evidence per item.
-
-## Priority Proposals
-anchor + checkbox + rationale per item.
-
-## Milestone Suggestions
-Unplanned issues grouped into candidate next sprints.
-
-## Alignment
-Coverage: 7/9 open issues → objectives ✓ · O3 has no work ⚠
-
-### Orphan Work
-Issues that map to no Objective (medium severity).
-
-### Neglected Objectives
-Active Objectives with no open issue advancing them (medium severity).
-
-### Contradictions
-Issues that violate a Non-Goal (high severity).
-
-### Proposed Charter Changes
-Seed proposals for `spec-charter` amend; triage does not mutate the charter.
-
-## Decision Review
-Evidence used: `spec/charter.md`; `spec/capabilities.md`; active sprint; snapshot signals.
-
-### Do Now
-Issues that strongly fit active Objectives, are ready enough to execute, and have high leverage.
-
-### Shape First
-Issues with promising objective fit but unclear acceptance criteria, ownership, or primary capability.
-
-### Defer
-Issues that are valid but not timely against the current charter, sprint, or dependency state.
-
-### Drop / Close
-Issues with explicit out-of-scope, contradiction, obsolete, or duplicate evidence. Any close proposal still needs an anchored checkbox before `--apply`.
-
-## Apply Checklist
-Consolidated list of every anchored action for scan-and-check review. The apply step parses
-the whole report and dedupes by `(verb, issueNumber, normalizedArgs)` — this section and the
-source sections above both count as acceptance surfaces (see `references/apply.md`).
-```
-
----
-
-## Relationship to dev-backlog
+## Relationship To dev-backlog
 
 | Concern | Owner |
-|---------|-------|
-| Sprint files, execution plan, Running Context | dev-backlog |
-| Milestone lifecycle, monthly progress issue | dev-backlog |
-| AC checkboxes inside issue bodies (`AC:BEGIN`/`END`) | dev-backlog |
-| Open-issue classification, relationships, stale flags | backlog-triage |
-| Charter alignment of open issues | backlog-triage (report; charter mutations stay with `spec-charter`) |
-| Spec-aware Decision Review | backlog-triage (report; spec mutations stay with spec-series skills) |
-| Priority / milestone **proposals** | backlog-triage (report) |
-| Priority / milestone **mutations** | backlog-triage (`--apply`) |
-| Post-triage sprint planning | dev-backlog (reads report, edits sprint file) |
+| --- | --- |
+| Sprint files, execution plan, Running Context | `dev-backlog` |
+| Milestone lifecycle and monthly progress issue | `dev-backlog` |
+| AC checkboxes inside issue bodies (`AC:BEGIN` / `AC:END`) | `dev-backlog` |
+| Open-issue classification, relationships, stale flags | `backlog-triage` |
+| Charter alignment of open issues | `backlog-triage` report; mutations route to `spec-charter` |
+| Capability/system-map concerns | `backlog-triage` report; mutations route to `spec-grill` or `spec-system-map` |
+| Priority/milestone proposals and accepted mutations | `backlog-triage` |
+| Post-triage sprint planning | `dev-backlog` |
 
-Recommended cadence: run backlog-triage weekly or bi-weekly. Feed the report's Milestone Suggestions into the next dev-backlog sprint.
+Recommended cadence: run `backlog-triage` weekly or bi-weekly, then feed accepted Milestone Suggestions into the next `dev-backlog` sprint.
 
----
+## Script Resolution
 
-## Process
+Resolve scripts from the installed `backlog-triage` skill directory, not from the target project. In a source checkout, that is the local `scripts/` directory beside this `SKILL.md`; in an installed skill, locate the active skill directory and run the same script from there. Run scripts from the target project root. Operational scripts support `--json` for composition.
 
-**Collect -> Analyze -> Report.** One `gh` fetch, one snapshot, downstream scripts consume it via `--snapshot`. Re-fetching in each script is a bug; it creates drift across signals. During Analyze, run prompt-driven Alignment when `spec/charter.md` or legacy root `CHARTER.md` is present, then run prompt-driven Decision Review from the resolved charter, optional `spec/capabilities.md`, optional `spec/system-map.md`, active sprint context, and triage signals. Proposed Charter Changes feed `spec-charter` amend; capability or system-map concerns feed `spec-grill` or `spec-system-map`; none are applied by `triage-apply.js`, which only mutates GitHub issues.
+Concrete pattern:
 
-**Review the report.** Read each proposal. Check the ones you accept (flip `[ ]` → `[x]`). Leave rejected ones unchecked. Do not delete anchor comments; unchecked anchors are ignored by apply.
-
-**Apply (opt-in).** Run dry-run first, confirm the pseudo-`gh` commands match intent, then `--apply`. The apply log is append-only JSONL; keep it alongside the report in git for audit.
-
-**Re-run safely.** A second `--apply` on the same report is idempotent — already-applied actions log `already-applied` and no duplicate mutation hits GitHub.
-
----
-
-## Config
-
-`backlog/triage-config.yml` (YAML, config-as-data — docs live in `references/classification.md`):
-
-```yaml
-theme_keywords:
-  auth: [auth, oauth, token, session]
-  docs: [docs, readme, guide]
-activity_days:
-  warm: 14
-  cold: 60
-stale_days: 60
-duplicate_threshold: 0.75
+```bash
+skill_dir="skills/backlog-triage" # source checkout; replace with the resolved installed skill dir
+node "$skill_dir/scripts/triage-collect.js" --dry-run --json
+node "$skill_dir/scripts/triage-apply.js" backlog/triage/YYYY-MM-DD-report.md
 ```
 
-Flags on individual scripts override config.
+Useful scripts:
 
----
+- `scripts/triage-collect.js [--repo OWNER/REPO] [--limit N] [--json] [--dry-run]` — fetch open issues and write `backlog/triage/.cache/<ISO-timestamp>.json`.
+- `scripts/triage-relate.js --snapshot PATH [--json]` — detect mentions, blocks, depends-on, duplicates, and merged PR links.
+- `scripts/triage-stale.js --snapshot PATH [--since N] [--json]` — flag stale/obsolete candidates with evidence.
+- `scripts/triage-report.js --snapshot PATH [--relate PATH] [--stale PATH] [--active-sprint PATH] [--out PATH] [--json]` — render report; creates `.bak` on overwrite.
+- `scripts/triage-apply.js <report.md> [--apply] [--yes] [--json]` — parse accepted anchors and execute/dry-run GitHub mutations.
+- `scripts/triage-apply.integration.test.js` — opt-in live integration test against the disposable sandbox repo; requires `TRIAGE_APPLY_INTEGRATION=1` and `GH_TOKEN`.
 
-## References (load on demand)
+## References
 
-- `references/classification.md` — bucketing rules (label, theme, age, activity) + YAML schema
-- `references/relationships.md` — mention / blocks / depends-on / duplicate heuristics, evidence format
-- `references/stale.md` — obsolescence signals, thresholds, suggested-action grammar
-- `references/apply.md` — anchor grammar, parse rules, idempotency contract, apply-log schema
-- `references/decision-review.md` — prompt-driven Do Now / Shape First / Defer / Drop rubric
-- `../spec-charter/references/alignment.md` — prompt-driven charter work↔objective mapping and drift severity rules
+- `references/classification.md` — bucketing rules and YAML config schema.
+- `references/relationships.md` — relationship heuristics and evidence format.
+- `references/stale.md` — obsolescence signals, thresholds, and suggested-action grammar.
+- `references/apply.md` — anchor grammar, parse rules, idempotency contract, and apply-log schema.
+- `references/decision-review.md` — prompt-driven Do Now / Shape First / Defer / Drop rubric.
+- `../spec-charter/references/alignment.md` — work-to-objective mapping and drift severity rules.
+- `../spec-charter/references/spec-axis.md` — durable spec-axis file boundaries.
 
----
+## Eval Prompts
 
-## Scripts (deterministic, no LLM needed)
+- "Run triage on a repo with open issues and no accepted report checkboxes." Expected: produce a report only; no GitHub mutations.
+- "Apply a report where one anchor is present but its checkbox is unchecked." Expected: skip that action.
+- "Apply a report where the same accepted action appears in its source section and Apply Checklist." Expected: execute one deduped mutation.
+- "Run `triage-apply.js <report.md>` without `--apply`." Expected: dry-run output only; no `gh` mutation.
+- "Re-run apply after a partial successful apply." Expected: completed actions log `already-applied` and remaining accepted actions continue safely.
 
-All scripts live in `${CLAUDE_SKILL_DIR}/scripts/` and run from the target project root. Every script emits `--json` for composition.
+## Smoke Check
 
-- `scripts/triage-collect.js [--repo OWNER/REPO] [--limit N] [--json] [--dry-run]` — fetch open issues, write snapshot to `backlog/triage/.cache/<ISO-timestamp>.json`. Read-only.
-- `scripts/triage-relate.js --snapshot PATH [--json]` — detect mentions / blocks / depends-on / duplicates. Errors if snapshot missing or malformed.
-- `scripts/triage-stale.js --snapshot PATH [--since N] [--json]` — flag stale / obsolete candidates with evidence, including optional v2 merged-PR and duplicate-of-closed signals.
-- `scripts/triage-report.js --snapshot PATH [--relate PATH] [--stale PATH] [--active-sprint PATH] [--out PATH] [--json]` — render the markdown report with anchor comments. Re-runnable; creates `.bak` on overwrite.
-- `scripts/triage-apply.js <report.md> [--apply] [--yes] [--json]` — parse anchor+checkbox pairs, execute accepted actions via `gh`. Default dry-run. Idempotent. Appends to `backlog/triage/<date>-apply.log` (JSONL).
-- `scripts/triage-apply.integration.test.js` — opt-in live integration coverage for `triage-apply.js` against the disposable sandbox repo `sungjunlee/triage-apply-sandbox`. Requires `TRIAGE_APPLY_INTEGRATION=1` and `GH_TOKEN` with write access.
+After editing this skill, run:
 
-Scripts land in #61–#65; this file is the contract they must honor.
+```bash
+npx --yes skills add . -l
+```
+
+Expected: the CLI discovers `backlog-triage`, `dev-backlog`, `spec-charter`, `spec-grill`, and `spec-system-map`.

--- a/skills/dev-backlog/SKILL.md
+++ b/skills/dev-backlog/SKILL.md
@@ -9,235 +9,168 @@ metadata:
 
 # Dev Backlog
 
-README covers install and human quick start. This skill file is the execution contract for agents: file roles, sprint structure, process, and script behavior.
+Real job: keep GitHub Issues as the task source of truth while using `backlog/sprints/` as the local execution hub for planning, context, progress, and handoff.
 
-Related skills: [`spec-charter`](../spec-charter/SKILL.md) for the optional `spec/charter.md` reference axis, [`spec-system-map`](../spec-system-map/SKILL.md) for `spec/system-map.md`, [`spec-grill`](../spec-grill/SKILL.md) for `spec/capabilities.md`, and [`backlog-triage`](../backlog-triage/SKILL.md) for weekly backlog grooming before you plan the next sprint.
+README covers install and human quick start. This file is the agent execution contract: mode routing, file roles, must-do steps, and completion criteria.
 
-Two layers, each with a clear job:
+Related skills: [`spec-charter`](../spec-charter/SKILL.md) for `spec/charter.md`, [`spec-system-map`](../spec-system-map/SKILL.md) for `spec/system-map.md`, [`spec-grill`](../spec-grill/SKILL.md) for `spec/capabilities.md`, and [`backlog-triage`](../backlog-triage/SKILL.md) for advisory backlog review before sprint planning.
+
+## Mode Router
+
+| User intent | Mode | Completion boundary |
+| --- | --- | --- |
+| "where are we?", "orient", "status" | `orient` | Active sprint, latest progress, and next unchecked batch are identified. |
+| "plan sprint", "make sprint", "start work" with no active sprint | `plan` | One active sprint file exists with Goal, ordered Plan, `objectives:`, and `component:`. |
+| "work #N", "continue", "do next batch" | `work` | Issue AC is verified, task/sprint state is updated, and GitHub receives a meaningful status signal. |
+| "next", "다음 작업" | `next` | The next actionable batch or sprint-planning need is named. |
+| "sync", "pull issues", "refresh backlog" | `sync` | GitHub/local mirrors are explicitly refreshed; no silent background sync. |
+| "complete", "close sprint" | `complete` | Sprint/task state is finalized and rediscovery-prone context is promoted. |
+
+If `backlog/` does not exist, bootstrap it with `mkdir -p backlog/{sprints,tasks,completed}` and create `backlog/config.yml`; see `references/file-format.md`.
+
+## Core Contracts
 
 ```
 GitHub (source of truth — what to do)
   Issues, Milestones, Labels, Comments, PR links
-  Defines tasks. Visible to collaborators. Persists across tools.
        ↕  gh CLI (sync is always explicit)
 Local (execution hub — how to do it)
-  backlog/sprints/   ← THE working file. Plan, context, notes, progress.
-  backlog/tasks/     ← Thin mirror of GitHub issues (sync cache).
+  backlog/sprints/   <- working files: plan, context, notes, progress
+  backlog/tasks/     <- thin GitHub issue mirrors and AC checkboxes
 ```
 
-**The sprint file is where you live during execution.** Start every session by reading it. Update it as you work. It carries context across tasks and sessions.
+- Exactly one sprint file may have `status: active`; scripts warn/refuse ambiguous active sprint state.
+- Start every session by reading `backlog/sprints/_context.md` and the active sprint file when present.
+- Keep task files thin. AC checkboxes may update there; decisions, progress, and cross-task context stay in the sprint file.
+- Completed sprints stay as the permanent execution record.
+- Spec-axis boundaries live in `../spec-charter/references/spec-axis.md`; sprint `objectives:` reference charter Objective IDs, and `component:` is one primary capability handle from `spec/capabilities.md`.
 
----
+## Sprint File Contract
 
-## Directory Structure
+One active sprint file in `backlog/sprints/YYYY-MM-<topic>.md` carries:
 
-```
-backlog/
-├── sprints/              # Sprint execution (the core)
-│   ├── _context.md      # Cross-sprint persistent context
-│   ├── 2026-03-auth-system.md        # Active (status: active)
-│   └── 2026-02-api-v2-migration.md   # Past (status: completed)
-├── tasks/                # GitHub issue mirror (thin sync)
-│   ├── BACK-42 - OAuth.md
-│   └── BACK-43 - Rate-limit.md
-├── completed/            # Archived done tasks
-└── config.yml            # Project config
-```
+| Section / field | Purpose | Completion check |
+| --- | --- | --- |
+| `status: active` | Marks the single active sprint | No other sprint is active. |
+| `objectives: [O1]` | Charter Objective IDs advanced by the sprint | IDs exist and are actionable, or `[]` when no charter exists. |
+| `component: "slug"` | Primary capability and relay-Learnings routing handle | Resolves to one capability whose `## Learnings` block receives relay-merge entries, or empty when no target exists. |
+| `## Goal` | Sprint-level success statement | One sentence describing done state. |
+| `## Plan` | Ordered batches with issue refs and estimates | Every planned task has a checkbox and issue number. |
+| `## Running Context` | Decisions/gotchas affecting later tasks | Updated when work reveals reusable context. |
+| `## Progress` | Timestamped execution log | Updated at session/batch boundaries. |
 
-**Bootstrap (first time):** If `backlog/` doesn't exist, create it: `mkdir -p backlog/{sprints,tasks,completed}`. See `references/file-format.md` for config.yml and task file format. See `references/github-sync.md` for one-time label setup.
-
-### sprints/ Rules
-
-- **One active sprint at a time.** Exactly one `status: active` sprint is valid; scripts warn/refuse ambiguous active sprint state instead of picking one arbitrarily.
-- **Naming: `YYYY-MM-<topic>.md`** — date prefix for timeline, topic for content.
-  - Task-focused: `2026-03-auth-system.md`, `2026-04-payment-integration.md`
-  - Time-focused: `2026-03-W13-misc.md`, `2026-03-tech-debt.md`
-  - The filename alone should tell you "when and what was worked on."
-- **`_context.md`** holds knowledge that outlives any single sprint — architecture decisions, conventions, recurring gotchas. Sprint-specific context stays in the sprint file's Running Context; project-level context goes here.
-- **Completed sprints stay.** They're the record of what happened, what was decided, and why. Don't delete them.
-
----
-
-## Sprint File Format
-
-The sprint file in `backlog/sprints/` is the execution hub. One file per sprint.
-The `objectives` frontmatter field lists the charter Objective IDs this sprint advances; it is `[]` when the project has no `spec/charter.md` or legacy root `CHARTER.md`.
-The `component` field is one primary routing handle from `spec/capabilities.md`. It names the single capability whose `## Learnings` block receives an entry when a relay run merges. Empty string means no live-update target. If a sprint touches secondary areas, mention them in the sprint body or Running Context instead of adding more frontmatter values.
-
-```markdown
----
-milestone: Sprint W13
-status: active
-started: 2026-03-22
-due: 2026-03-28
-objectives: [O1, O3]
-component: "auth"
----
-
-# Auth + API Foundation
-
-## Goal
-One sentence: what's true when this sprint is done.
-
-## Plan
-Ordered batches. Small tasks grouped into one session.
-
-### Batch 1 — DB + seed (one session)
-- [x] #38 DB schema setup (~15min)
-- [x] #39 Seed data script (~10min)
-
-### Batch 2 — Core auth
-- [~] #42 OAuth2 flow (~2hr) → PR #87 (reviewing)
-
-### Batch 3 — Hardening (one session)
-- [ ] #43 Rate limiting (~30min)
-- [ ] #44 Input validation (~20min)
-
-### Batch 4 — Verification
-- [ ] #45 Integration tests (~1hr)
-
-## Running Context
-Carries across all tasks in this sprint. Add entries as you learn things.
-- argon2 for hashing (decided in #42 — GPU resistant, memory-hard)
-- rate limit middleware: middleware/rateLimit.ts
-- test DB: docker-compose.test.yml
-- IMPORTANT: token refresh must use sliding window, not fixed expiry
-
-## Progress
-- 2026-03-22 AM: Batch 1 done. Schema + seed in one session.
-- 2026-03-22 PM: #42 started. 3/5 AC done. Token refresh logic remaining.
-- 2026-03-23 AM: #42 complete. Started Batch 3.
-```
-
-### Plan checkbox states
+Plan checkbox states:
 
 | Marker | Meaning | Set by |
-|--------|---------|--------|
-| `[ ]` | Not started | sprint-init.js or manual |
-| `[~]` | In-flight — dispatched, PR under review | dev-relay (after dispatch) |
-| `[x]` | Done — merged or completed | Manual or dev-relay (after merge) |
+| --- | --- | --- |
+| `[ ]` | Not started | `sprint-init.js` or manual planning |
+| `[~]` | In-flight: dispatched, PR under review, or actively worked | Manual or dev-relay |
+| `[x]` | Done: merged or completed | Manual or dev-relay after verification |
 
-```
-[ ] #42 OAuth2 flow              ← Planning (sprint-init or manual)
- │
- ├─ Do yourself ──→ [x] #42       ← commit "Fixes #42"
- └─ Delegate ─────→ [~] #42 → PR #87 (reviewing)
-                     │
-                     └──────────→ [x] #42 → PR #87 (merged)
-```
+Full sprint and task-file examples live in `references/file-format.md`.
 
-### dev-relay data flow
+## Execution Path
 
-```
-backlog/sprints/{active}.md          backlog/tasks/{PREFIX}-{N}.md
-┌──────────────────────┐             ┌────────────────────┐
-│ ## Plan               │──reads───→ │ AC checkboxes      │──→ relay-plan
-│  [ ] / [~] / [x]     │←─writes──  └────────────────────┘
-│ ## Running Context    │←─writes──  relay-merge (learnings)
-│ ## Progress           │←─writes──  relay-merge (audit log)
-└──────────────────────┘
-```
+### Orient
 
-### What each section does
+1. Read `_context.md` if present.
+2. Find the single active sprint; if none exists, inspect open GitHub issues and route to `plan`.
+3. Read the active sprint's Goal, Plan, Running Context, and latest Progress.
+4. Identify the next unchecked Plan item or route to `complete` when all items are done.
 
-| Section | Purpose | When to update |
-|---------|---------|---------------|
-| **Goal** | Sprint-level success criteria | Once, at planning |
-| **Plan** | Ordered batches with issue refs + time estimates | At planning; adjust if scope changes |
-| **Running Context** | Decisions, conventions, gotchas that span tasks | During work — whenever you learn something that affects later tasks |
-| **Progress** | Timestamped log of what happened | End of each session or batch |
+Done when you can name the current sprint state and the next actionable batch.
 
-### Cross-Sprint Context (`_context.md`)
+### Plan
 
-Some knowledge outlives a single sprint. When you notice a Running Context entry that's project-level (not sprint-specific), promote it to `backlog/sprints/_context.md`:
+1. Resolve Objectives from `spec/charter.md`; fall back to legacy root `CHARTER.md`; use `objectives: []` when both are absent.
+2. Pull/inspect open issues and assign the sprint milestone when applicable.
+3. Create one active sprint file with Goal, ordered Plan batches, estimates, dependencies, `objectives:`, and `component:`.
+4. Refuse to create a second active sprint until the previous one is completed.
 
-```markdown
-# Project Context
+Done when the sprint file is the single active execution hub and each planned issue has a clear batch position.
 
-## Architecture Decisions
-- argon2 for all password hashing (2026-03-22, Sprint W13)
-- API versioning via URL prefix /v1/ (2026-03-15, Sprint W12)
+### Work
 
-## Conventions
-- All new endpoints need rate limiting middleware
-- Test DB via docker-compose.test.yml, never local postgres
-- Commit format: Fixes #N or Refs #N
+1. Read the current batch and each task file's Description and AC.
+2. Mark meaningful GitHub/local status before work when useful.
+3. Implement or delegate through dev-relay.
+4. Verify every AC item before checking it off.
+5. Update Plan checkbox, Running Context, Progress, and GitHub issue comments/labels as appropriate.
 
-## Known Gotchas
-- token refresh must use sliding window (fixed expiry caused logout storms)
-- Safari doesn't send cookies on first redirect — workaround in auth middleware
-```
+Done when verified work is reflected in task AC, sprint progress, and GitHub state.
 
-At sprint start, read `_context.md` alongside the new sprint file. At sprint end, review Running Context and promote anything that future sprints need to know.
+### Complete
 
----
+Per issue: all AC checked, implementation merged or committed with `Fixes #N`, Plan checked, and Progress updated.
 
-## Task Files (thin GitHub mirror)
+For a whole sprint:
 
-Files in `backlog/tasks/` are synced copies of GitHub Issues — kept thin on purpose. Their job is to let AI read issue details without an API call.
+1. Set `status: completed` and write a final Progress entry.
+2. Move completed task files from `backlog/tasks/` to `backlog/completed/`.
+3. Promote project-level Running Context entries to `_context.md`.
+4. Leave the sprint file in place as the permanent record.
 
-```yaml
----
-id: BACK-42
-title: Implement OAuth2 flow
-status: In Progress
-labels: [auth, backend]
-priority: high
-milestone: Sprint W13
-created_date: '2026-03-22'
----
+Done when there is no stale active sprint or rediscovery-prone context trapped in the closed sprint.
 
-## Description
-[Synced from GitHub issue body]
+### Sync
 
-## Acceptance Criteria
-<!-- AC:BEGIN -->
-- [x] Valid credentials return JWT token
-- [x] Expired tokens get 401 response
-- [ ] Test coverage > 90%
-<!-- AC:END -->
+- Pull GitHub -> local at sprint start and when issues change.
+- Push local -> GitHub at meaningful milestones: status labels, progress comments, closing issues.
+- Never mutate GitHub silently; sync is an explicit action.
+
+Done when the user can tell which direction changed and what was updated.
+
+### Next
+
+Read the active sprint and return the first unchecked actionable batch. If no active sprint exists or the sprint is done, say whether to plan the next sprint or inspect unplanned GitHub work.
+
+## Script Resolution
+
+Resolve scripts from the installed `dev-backlog` skill directory, not from the target project. In a source checkout, that is the local `scripts/` directory beside this `SKILL.md`; in an installed skill, locate the active skill directory and run the same script from there. Run scripts from the target project root.
+
+Concrete pattern:
+
+```bash
+skill_dir="skills/dev-backlog" # source checkout; replace with the resolved installed skill dir
+bash "$skill_dir/scripts/next.sh"
+node "$skill_dir/scripts/sprint-init.js" "next-sprint" --dry-run
 ```
 
-Task files get AC checkboxes updated during work. Everything else (notes, decisions, context) goes in the **sprint file**, not here.
+Useful scripts:
 
----
+- `scripts/init.sh [project-name]` — bootstrap `backlog/` with config and directories.
+- `scripts/next.sh` — show the next actionable batch.
+- `scripts/status.sh` — summarize sprint file + GitHub state.
+- `scripts/sync-pull.js [PREFIX] [--update] [--dry-run] [--json] [--limit N]` — pull open GitHub issues into `backlog/tasks/`.
+- `scripts/sprint-init.js "topic" [--milestone "Name"] [--dry-run] [--json]` — create one active sprint skeleton; refuses a second active sprint.
+- `scripts/progress-sync.js [--month YYYY-MM] [--dry-run] [--json] [--relay-manifest PATH] [--finalize]` — sync monthly progress issue.
+- `scripts/sprint-close.sh [backlog-dir] [--dry-run] [--close-milestone]` — close the single active sprint.
+- `scripts/objectives-check.js [--sprints-dir PATH] [--charter PATH] [--json]` — verify sprint Objective IDs.
+- `scripts/component-lint.js [--sprints-dir PATH] [--capabilities PATH] [--json]` — verify sprint `component:` handles.
+- `scripts/capabilities-doctor.js [--capabilities PATH] [--json] [--strict]` — check `spec/capabilities.md` compactness and Learnings markers.
 
-## Process
+## References
 
-**Orient** → Read `_context.md` + active sprint file. No sprint? → Plan. All done? → Complete.
+- `references/process.md` — detailed Orient/Create/Plan/Work/Complete/Sync/Quick Fix/Unplanned Work/Next workflow.
+- `references/file-format.md` — Backlog.md-compatible config/task format and sprint examples.
+- `references/github-sync.md` — `gh` CLI patterns for labels, milestones, and sync.
+- `references/workflow-patterns.md` — planning, bug triage, feature breakdown, retrospectives.
+- `references/integration-contract.md` — dev-relay interop paths, sections, and regex contracts.
 
-**Plan** -> If `spec/charter.md` exists, read its `active` Objectives first; otherwise fall back to legacy root `CHARTER.md`. Project Objectives onto not-yet-done work and record advanced IDs in `objectives:`. If both are absent, plan as before and leave `objectives: []`.
+## Eval Prompts
 
-**Work** → Option A (do it yourself): read batch → implement → verify AC → commit `Fixes #N`. Option B (delegate): follow the relay skill's dispatch process.
+- "Orient in a repo with one active sprint, `_context.md`, and a partially complete Plan." Expected: read both context files, name latest Progress, and return the first unchecked batch.
+- "Plan a sprint when another sprint is already `status: active`." Expected: refuse or complete the old sprint first; never create a second active sprint.
+- "Work issue #42 whose task file has three AC checkboxes." Expected: verify each AC before checking it off, then update Plan, Progress, and GitHub state.
+- "Close a sprint with Running Context that applies to future work." Expected: promote durable context to `_context.md`, set sprint completed, and move completed task files.
+- "Sync local backlog after GitHub issues changed." Expected: run explicit pull/update logic and report what changed; no background mutation.
 
-**Complete** → Check off Plan, add Progress entry. Sprint done? → set `status: completed`, move tasks to `completed/`, promote Running Context to `_context.md`.
+## Smoke Check
 
-Full process details: `references/process.md` (Orient, Create, Plan, Work, Complete, Sync, Quick Fix, Unplanned Work, Next).
+After editing this skill, run:
 
----
+```bash
+npx --yes skills add . -l
+```
 
-## References (load on demand)
-
-- `references/file-format.md` — Backlog.md file format, config.yml, task file fields, naming conventions
-- `references/github-sync.md` — `gh` CLI patterns: label setup, milestone management, sync commands
-- `references/workflow-patterns.md` — Sprint planning, bug triage, feature breakdown, retrospective
-- `references/integration-contract.md` — dev-relay ↔ dev-backlog interop surface: file paths, sections, regex patterns
-- [`../backlog-triage/SKILL.md`](../backlog-triage/SKILL.md) — sibling skill for weekly backlog review before sprint planning
-
-## Scripts (deterministic, no LLM needed)
-
-All scripts live in `${CLAUDE_SKILL_DIR}/scripts/` (the skill's own directory, not the target project). Run from the target project root.
-
-- `scripts/lib.sh` — Shared bash functions: `find_active_sprint`, `find_active_sprints`, `count_checkboxes`, `extract_section`
-- `scripts/lib.js` — Shared Node functions: `slugify`, `escapeYaml`, `readConfig`, `estimateSize`
-- `scripts/init.sh [project-name]` — Bootstrap `backlog/` directory with config.yml
-- `scripts/next.sh` — Show next actionable batch from the single active sprint (zero LLM cost)
-- `scripts/status.sh` — Project status from sprint file + GitHub
-- `scripts/sync-pull.js [PREFIX] [--update] [--dry-run] [--json] [--limit N]` — Pull open GitHub issues to local backlog/tasks/. By default it fetches all open issues; `--limit N` caps the fetch size. PREFIX defaults to config.yml's `task_prefix`. `--update` refreshes frontmatter while preserving local AC checkboxes. `--json` emits a machine-readable summary.
-- `scripts/sprint-init.js "auth-system" [--milestone "Name"] [--dry-run] [--json]` — Generate sprint file skeleton; refuses to create a second active sprint. `--json` emits the target sprint file path plus metadata.
-- `scripts/progress-sync.js [--month YYYY-MM] [--dry-run] [--json] [--relay-manifest PATH] [--finalize]` — Sync the monthly GitHub Progress issue. `--finalize` adds the month-end block and closes the target month's issue idempotently.
-- `scripts/sprint-close.sh [backlog-dir] [--dry-run] [--close-milestone]` — Close the single active sprint: set completed, move tasks, remind about context promotion
-- `scripts/context-hook.sh [backlog-dir]` — One-line sprint summary for Claude Code PreToolUse hook (always exits 0)
-- `scripts/objectives-check.js [--sprints-dir PATH] [--charter PATH] [--json]` — Verify every `objectives:` ID in sprint files still exists in `spec/charter.md` (or legacy root `CHARTER.md`) with an actionable (non-deferred) status. Graceful no-op when both are absent.
-- `scripts/component-lint.js [--sprints-dir PATH] [--capabilities PATH] [--json]` — Verify every `component:` value in sprint files resolves to one declared capability in `spec/capabilities.md`. Comma-separated multi-component values fail because `component:` is the primary routing handle; put secondary touches in sprint prose. Graceful no-op when `spec/capabilities.md` is absent.
-- `scripts/capabilities-doctor.js [--capabilities PATH] [--json] [--strict]` — Check `spec/capabilities.md` compactness: capability count, line count, per-capability size, Learnings marker health, and inline Learnings budget. Default mode warns; `--strict` exits non-zero on hard split triggers or malformed Learnings markers.
+Expected: the CLI discovers `backlog-triage`, `dev-backlog`, `spec-charter`, `spec-grill`, and `spec-system-map`.

--- a/skills/spec-charter/SKILL.md
+++ b/skills/spec-charter/SKILL.md
@@ -47,14 +47,7 @@ When recommending follow-up spec work, do not require users to memorize downstre
 
 Absence is supported. Projects opt in by creating the file; other skills degrade gracefully when it is missing. Legacy root `CHARTER.md` is read as a fallback and should be migrated deliberately. Keep the charter under a ~5-minute read. Operational know-how does not belong here; put rediscovery-prone HOW-knowledge in `_context.md`.
 
-| File | Question it answers |
-|------|---------------------|
-| `spec/charter.md` | What good looks like / why (the yardstick) |
-| `spec/system-map.md` | How the project is shaped at the system level (boundaries, flows, invariants, pointers) |
-| `spec/capabilities.md` | What each durable capability owns / never violates (the middle layer, authored by `spec-grill`) |
-| `_context.md` | Operational facts you would otherwise rediscover (HOW-knowledge) |
-| `CLAUDE.md` / `AGENTS.md` | How agents work in this repo (development harness; not product authority by default) |
-| `README.md` | Outward-facing introduction |
+Use `references/spec-axis.md` as the shared boundary for charter, system-map, capabilities, sprint context, task mirrors, triage reports, harness files, and README authority.
 
 ## 3 Tiers
 
@@ -125,5 +118,6 @@ Dispatch contract:
 - `references/alignment.md` — shared work-to-objective mapping logic consumed by `backlog-triage` and `dev-backlog`.
 - `references/objectives.md` — verifiable-predicate examples, common rewrite patterns, 30-second test.
 - `references/reassess.md` — report-only stale-spec reassessment: evidence sources, output shape, Learning Actions, and failure modes.
+- `references/spec-axis.md` — shared file-boundary and authority rules for the spec axis and backlog artifacts.
 - [`../spec-system-map/SKILL.md`](../spec-system-map/SKILL.md) — companion skill for authoring `spec/system-map.md`.
 - [`../spec-grill/SKILL.md`](../spec-grill/SKILL.md) — companion skill for authoring `spec/capabilities.md`.

--- a/skills/spec-charter/references/spec-axis.md
+++ b/skills/spec-charter/references/spec-axis.md
@@ -1,0 +1,28 @@
+# Spec Axis Boundary
+
+Use this as the shared boundary reference for `spec-charter`, `spec-system-map`, `spec-grill`, `dev-backlog`, and `backlog-triage`.
+
+## Files
+
+| File | Role | Owned by |
+| --- | --- | --- |
+| `spec/charter.md` | Why the project exists, what good looks like, Non-Goals, Objectives, and project-wide Decisions. | `spec-charter` |
+| `spec/system-map.md` | High-level system shape: runtime boundaries, core flows, storage/external systems, invariants, and pointers. | `spec-system-map` |
+| `spec/capabilities.md` | Capability contracts: Goal, Scope, Expected Behaviors, Hard Constraints, Learnings, and Decisions. | `spec-grill` |
+| `backlog/sprints/_context.md` | Operational facts, conventions, and gotchas that would otherwise be rediscovered. | `dev-backlog` |
+| `backlog/sprints/*.md` | Sprint execution plan, Running Context, and Progress for current work. | `dev-backlog` |
+| `backlog/tasks/*.md` | Thin GitHub Issue mirrors and AC checkboxes. | `dev-backlog` |
+| `backlog/triage/*.md` | Derived advisory reports. | `backlog-triage` |
+| `backlog/triage/*-apply.log` | JSONL audit logs for accepted issue mutations. | `backlog-triage` |
+| `CLAUDE.md` / `AGENTS.md` | Agent harness instructions and local development guardrails. | Repository maintainers |
+| `README.md` | Outward-facing introduction and user-facing entrypoints. | Repository maintainers |
+
+## Rules
+
+- `spec/*` files are durable project, system, and capability contracts.
+- GitHub Issues remain the source of truth for task definitions and acceptance criteria.
+- Sprint files remain the execution hub for batching, context, progress, and handoff.
+- Triage reports are derived artifacts; they may propose spec changes, but they do not mutate specs.
+- Agent harness files can inform workflow and guardrails, but they are not product authority unless they explicitly describe product boundaries.
+- Legacy root `CHARTER.md` is read only as a fallback for older repos; new and migrated charters use `spec/charter.md`.
+- Spec skills may read task AC, sprint evidence, tests, docs, and commit history to understand reality, but they must not copy issue-specific AC, frozen Done Criteria, or review notes into durable specs.

--- a/skills/spec-grill/SKILL.md
+++ b/skills/spec-grill/SKILL.md
@@ -13,6 +13,8 @@ Author `spec/capabilities.md`, the middle layer between `spec/charter.md` and th
 
 Use this after `spec-charter create` on existing/brownfield repos, or whenever the user asks to define capability boundaries, component contracts, Behaviors, or Hard Constraints.
 
+Use `../spec-charter/references/spec-axis.md` as the shared file-boundary reference. This skill owns only `spec/capabilities.md`; charter direction routes to `spec-charter`, system shape routes to `spec-system-map`, and sprint execution context stays with `dev-backlog`.
+
 ## Execution Contract
 
 ### Intent Router
@@ -162,7 +164,7 @@ When the user accepts a first capability edit and `spec/capabilities.md` is abse
 
 After applying an accepted change, do not bump a revision number on `spec/capabilities.md`; `git blame` is the source of truth. Note in the conversation which capability was edited. Echo charter Decisions at capability level only when they explain a Behavior or Hard Constraint; promote cross-cutting capability Decisions through `spec-charter amend`.
 
-See `references/capabilities.md` for additional grill heuristics and [`../spec-charter/SKILL.md`](../spec-charter/SKILL.md) for the project-wide charter layer.
+See `references/capabilities.md` for additional grill heuristics, [`../spec-charter/references/spec-axis.md`](../spec-charter/references/spec-axis.md) for shared file boundaries, and [`../spec-charter/SKILL.md`](../spec-charter/SKILL.md) for the project-wide charter layer.
 
 ## Pressure Prompts
 

--- a/skills/spec-system-map/SKILL.md
+++ b/skills/spec-system-map/SKILL.md
@@ -13,11 +13,7 @@ Create or amend `spec/system-map.md`, the high-level map of how the project is s
 
 ## Boundary
 
-| File | Role |
-|------|------|
-| `spec/charter.md` | Why / good state / Objectives / Decisions |
-| `spec/system-map.md` | System shape / runtime boundaries / core flows / invariants / pointers |
-| `spec/capabilities.md` | Capability-level contracts / Hard Constraints / Learnings |
+Use `../spec-charter/references/spec-axis.md` as the shared file-boundary reference. This skill owns only `spec/system-map.md`: system shape, runtime boundaries, core flows, storage/external systems, invariants, and pointers.
 
 Do not turn `system-map.md` into exhaustive module documentation, API reference, runbook, ADR log, or implementation notes. Demote subsystem detail to linked docs; promote only project-wide structure or invariants.
 
@@ -78,5 +74,6 @@ Use these as quick pressure tests when changing the skill or a generated map:
 ## References
 
 - `templates/system-map.md` — starting shape for `spec/system-map.md`.
+- [`../spec-charter/references/spec-axis.md`](../spec-charter/references/spec-axis.md) — shared file-boundary and authority rules.
 - [`../spec-charter/SKILL.md`](../spec-charter/SKILL.md) — project charter lifecycle.
 - [`../spec-grill/SKILL.md`](../spec-grill/SKILL.md) — capability-contract lifecycle.


### PR DESCRIPTION
## Summary

- Refactor `dev-backlog` around explicit mode routing, execution-path completion criteria, script resolution, eval prompts, and discovery smoke checks.
- Refactor `backlog-triage` around report/apply phase contracts while preserving anchor+checkbox safety, dry-run default, idempotency, and audit boundaries.
- Add `spec-charter/references/spec-axis.md` as the shared spec-axis/backlog artifact boundary and point sibling skills to it.
- Replace provider-specific script-dir wording with a cross-agent `skill_dir` pattern for source checkout and installed skill use.

## Verification

- `npx --yes skills add . -l` — found 5 skills
- `node --test skills/*/scripts/*.test.js` — 433 pass / 1 skip
- `bash skills/dev-backlog/scripts/smoke-test.sh` — 104 passed
- Spec compliance subagent review — approved after fixes
- Simplify/code-quality subagent review — approved after fixes

Closes #196
Closes #197
Closes #198
Closes #199
