### PR TITLE
Tighten skill documentation contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ Optional spec-series setup:
 
 For the detailed sprint contract, section semantics, and full script inventory, see [skills/dev-backlog/SKILL.md](skills/dev-backlog/SKILL.md).
 
+## Verification
+
+After editing this skill bundle, run the discovery smoke check from the repository root:
+
+```bash
+npx --yes skills add . -l
+```
+
+Expected: the CLI discovers `backlog-triage`, `dev-backlog`, `spec-charter`, `spec-grill`, and `spec-system-map`.
+
 Important if you use `dev-relay`: sprint files are not fully freeform markdown.
 These details are load-bearing for automation:
 

--- a/skills/backlog-triage/SKILL.md
+++ b/skills/backlog-triage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: backlog-triage
 argument-hint: "[collect|relate|stale|report|apply] [options]"
-description: Interactive backlog grooming for open GitHub Issues. Classifies, relates, flags stale/obsolete, and proposes priorities — produces a markdown triage report you review before applying. Advisory by default; mutations require explicit --apply. Use for backlog review, issue grooming, stale cleanup, priority re-ranking, 백로그 정리, 이슈 검토, 트리아지, 정리.
+description: Triage open GitHub Issues into an advisory report. Use for issue grooming, stale or obsolete detection, relationship mapping, priority and milestone proposals, accepted-action apply, 백로그 정리, 이슈 검토, 트리아지.
 compatibility: Requires gh CLI and git. Works on Claude Code and Codex.
 metadata:
   related-skills: "spec-charter, dev-backlog, relay, relay-plan"
@@ -133,10 +133,4 @@ Useful scripts:
 
 ## Smoke Check
 
-After editing this skill, run:
-
-```bash
-npx --yes skills add . -l
-```
-
-Expected: the CLI discovers `backlog-triage`, `dev-backlog`, `spec-charter`, `spec-grill`, and `spec-system-map`.
+After editing this skill bundle, run the repository-level skill discovery smoke check documented in `README.md`.

--- a/skills/dev-backlog/SKILL.md
+++ b/skills/dev-backlog/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dev-backlog
 argument-hint: "[orient|plan|work|next|sync] [issue-number]"
-description: Manage development work through GitHub Issues + local sprint files. Issues/Milestones are the source of truth; local sprint files handle execution — batching, ordering, context, and progress. Use for creating issues, planning sprints, checking what to work on, reviewing progress, syncing with GitHub, managing milestones, backlog, 다음 작업, 이슈 만들어, 스프린트 계획, 백로그.
+description: Manage GitHub-Issue-backed sprint execution. Use for issue mirrors, sprint planning or closing, next-work selection, progress sync, milestone-backed backlog work, 다음 작업, 이슈 만들어, 스프린트 계획, 백로그.
 compatibility: Requires gh CLI and git. Works on Claude Code and Codex.
 metadata:
   related-skills: "spec-charter, spec-grill, backlog-triage, relay, relay-plan, relay-dispatch, relay-review, relay-merge"
@@ -167,10 +167,4 @@ Useful scripts:
 
 ## Smoke Check
 
-After editing this skill, run:
-
-```bash
-npx --yes skills add . -l
-```
-
-Expected: the CLI discovers `backlog-triage`, `dev-backlog`, `spec-charter`, `spec-grill`, and `spec-system-map`.
+After editing this skill bundle, run the repository-level skill discovery smoke check documented in `README.md`.

--- a/skills/spec-charter/SKILL.md
+++ b/skills/spec-charter/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: spec-charter
 argument-hint: "[create|amend|reassess]"
-description: "Create, amend, and reassess spec/charter.md as the project-wide spec axis. Use to establish or evolve project direction, Objectives, Non-Goals, Decisions, stale spec findings, project charter, 기준, 헌장, 방향성, spec axis."
+description: "Manage spec/charter.md as the project charter. Use to create, amend, or reassess project direction, Objectives, Non-Goals, Decisions, stale spec-axis findings, 기준, 헌장, 방향성."
 compatibility: Requires git. Works on Claude Code and Codex.
 metadata:
   related-skills: "spec-system-map, spec-grill, dev-backlog, backlog-triage"
@@ -11,7 +11,7 @@ metadata:
 
 Create and amend `spec/charter.md`, the opt-in project reference axis used to measure backlog work, sprint plans, and drift. This skill is rerunnable.
 
-`spec/charter.md` is the first layer, not the whole large-repo spec. On existing/brownfield repos, finish create mode by recommending `spec-system-map` for `spec/system-map.md` and `spec-grill` for `spec/capabilities.md` from real repo signals.
+`spec/charter.md` is the first layer, not the whole large-repo spec. On existing/brownfield repos, finish create mode by recommending the next spec-axis action from real repo signals.
 
 ## Execution Contract
 
@@ -35,7 +35,7 @@ Resolve helper scripts from the installed `spec-charter` skill directory, not fr
 
 End every mode with a short summary:
 
-- `create`: created files, unresolved assumptions, and a concrete next natural-language action. On brownfield repos, recommend creating `spec/system-map.md` before asking `spec-grill` to review capability boundaries.
+- `create`: created files, unresolved assumptions, and a concrete next natural-language action. On brownfield repos, create `spec/system-map.md` first when absent; recommend `spec-grill` only when capability candidates are evidence-backed.
 - `amend`: accepted changes, refused/parked changes, proof cited for status advances, and size-check result.
 - `reassess`: required report sections from the Reassess Mode dispatch contract, with one recommended next natural-language action.
 
@@ -66,7 +66,7 @@ Use create mode when neither `spec/charter.md` nor legacy root `CHARTER.md` exis
 1. Draft from repo signals: product/user-facing signals (`README.md`, open epics/issues, `CHANGELOG.md`) before development-harness signals (`CLAUDE.md`, `AGENTS.md`). Harness files may inform workflow conventions, local commands, and repo-specific guardrails, but they do not override README, charter, issues, code structure, or user interview answers for product/capability authority unless they explicitly describe product boundaries. When signals conflict, surface the conflict in the interview rather than picking silently.
 2. Interview the user to fill and sharpen Problem, Approach, Non-Goals, and initial Objectives. Follow the checklist in `references/create.md`: Problem framing options, the wedge test for Approach, Non-Goals elicitation, and Objective framing that cites `references/objectives.md`.
 3. Create `spec/` if needed, then write `spec/charter.md` from `templates/charter.md` with `revision: 1` and today's `last_amended`. The Decisions table may be left empty. Seed 3-5 rows only when prior design docs, ADRs, or notable merged PRs already record direction; whatever lands becomes immutable from revision 2.
-4. If the target repo is brownfield, recommend `spec-system-map` as the next step when `spec/system-map.md` is absent. After the map exists, recommend asking `spec-grill` to review candidate capability boundaries. Brownfield signals include existing source roots (`src/`, `app/`, `lib/`, `packages/`, `skills/`), commit history, tests/scripts/config, open issues, or multiple top-level feature/workflow surfaces.
+4. If the target repo is brownfield, use the create-mode completion contract to choose the next spec-axis action. Brownfield signals include existing source roots (`src/`, `app/`, `lib/`, `packages/`, `skills/`), commit history, tests/scripts/config, open issues, or multiple top-level feature/workflow surfaces.
 
 Objective conventions:
 
@@ -106,7 +106,7 @@ If reassess finds that `spec/system-map.md` is missing on a brownfield repo, rec
 
 Dispatch contract:
 
-1. Resolve helper scripts from the installed dev-backlog skill directory; if unavailable, report **Missing Evidence**.
+1. Resolve cross-skill helper scripts from the installed `dev-backlog` skill directory (`capabilities-doctor.js`, `component-lint.js`); if unavailable, report **Missing Evidence**.
 2. Start with bounded evidence: `capabilities-doctor.js --json`, `component-lint.js --json`, named charter, system-map, or capability sections, the active sprint, and at most the latest five completed sprint files.
 3. Emit these report sections: **Evidence**, **No Change**, **System Map Candidates**, **Grill Candidates**, **Amend Candidates**, **Learning Actions**, **Missing Evidence**, **Recommended Next Step**.
 4. Use `references/reassess.md` as the source of truth for evidence order, report shape, recommendation rules, Learning Actions, and stale-spec failure modes.

--- a/skills/spec-grill/SKILL.md
+++ b/skills/spec-grill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: spec-grill
 argument-hint: "[natural-language request]"
-description: "Create or refine spec/capabilities.md by grilling existing repo signals into capability contracts, Behaviors, and Hard Constraints. Use after spec-charter on existing repos, or when users ask for capability specs, component contracts, middle-layer specs, repo capability boundaries, 능력 명세, or grill."
+description: "Grill repo evidence into spec/capabilities.md capability contracts. Use after charter or system-map work, or for capability boundaries, component contracts, Behaviors, Hard Constraints, 능력 명세."
 compatibility: Requires git. Works on Claude Code and Codex.
 metadata:
   related-skills: "spec-charter, dev-backlog, backlog-triage"

--- a/skills/spec-system-map/SKILL.md
+++ b/skills/spec-system-map/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: spec-system-map
 argument-hint: "[create|amend]"
-description: "Create or amend spec/system-map.md as a high-level project system map. Use for architecture scope confusion, system shape, runtime boundaries, core flows, invariants, storage/external systems, or SYSTEM_MAP."
+description: "Manage spec/system-map.md as the high-level system map. Use for project shape, runtime boundaries, core flows, invariants, storage or external systems, architecture scope confusion."
 compatibility: Requires git. Works on Claude Code and Codex.
 metadata:
   related-skills: "spec-charter, spec-grill, dev-backlog"
@@ -43,6 +43,8 @@ The Repo Evidence Pass is an agent checklist, not a new script. Report evidence 
 3. Move low-level module details, endpoint lists, deployment commands, and temporary implementation notes out of the map.
 4. If a change is really a capability contract, route it to `spec-grill`. If it changes why/good-state, route it to `spec-charter amend`.
 
+Done when the map reflects only evidence-backed project-wide changes, low-level detail has been demoted or refused, charter/capability changes have been routed out, and the final response names evidence read and evidence missing.
+
 ## Quality Checks
 
 Before finishing, verify:
@@ -57,7 +59,7 @@ Before finishing, verify:
 
 ## Completion Output
 
-End create mode with:
+End create and amend mode with:
 
 - `Evidence Read`: concise bullets naming the concrete docs, entrypoints, configs, tests, storage/external surfaces, and history inspected.
 - `Evidence Missing`: concise bullets naming unavailable or ambiguous evidence that affects confidence.


### PR DESCRIPTION
## Summary

- Prune model-invoked skill descriptions to branch-level trigger surfaces.
- Add a checkable amend completion contract for `spec-system-map`.
- Move the skill-bundle discovery smoke check to `README.md` as the single source of truth.
- Tighten `spec-charter` brownfield follow-up and cross-skill helper wording.

## Verification

- `npx --yes skills add . -l`
- `git diff --check`

Fixes #202
Fixes #203
Fixes #204
Fixes #205


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * 저장소 루트에서 수행하는 검증 절차와 기대되는 발견 결과가 README에 추가되었습니다.
  * 여러 스킬 문서의 설명이 더 명확하게 정리되어, 각 기능의 적용 범위와 사용 시점이 분명해졌습니다.
* **개선**
  * 백로그 정리, 스펙 헌장, 시스템 맵 관련 안내가 최신 흐름에 맞게 업데이트되었습니다.
  * 검증 안내가 통일되어, 스킬 변경 후 확인 방법을 일관되게 따를 수 있게 되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->