### PR TITLE
Keep smoke checks out of skill runtime docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,15 +106,15 @@ Optional spec-series setup:
 
 For the detailed sprint contract, section semantics, and full script inventory, see [skills/dev-backlog/SKILL.md](skills/dev-backlog/SKILL.md).
 
-## Verification
+## Maintainer Verification
 
-After editing this skill bundle, run the discovery smoke check from the repository root:
+After editing this repository's skill bundle, run the discovery smoke check from the repository root:
 
 ```bash
 npx --yes skills add . -l
 ```
 
-Expected: the CLI discovers `backlog-triage`, `dev-backlog`, `spec-charter`, `spec-grill`, and `spec-system-map`.
+Expected: the CLI discovers `backlog-triage`, `dev-backlog`, `spec-charter`, `spec-grill`, and `spec-system-map`. This verifies bundle packaging and frontmatter discovery; those sibling skills are not runtime dependencies for every `dev-backlog` invocation.
 
 Important if you use `dev-relay`: sprint files are not fully freeform markdown.
 These details are load-bearing for automation:

--- a/skills/backlog-triage/SKILL.md
+++ b/skills/backlog-triage/SKILL.md
@@ -130,7 +130,3 @@ Useful scripts:
 - "Apply a report where the same accepted action appears in its source section and Apply Checklist." Expected: execute one deduped mutation.
 - "Run `triage-apply.js <report.md>` without `--apply`." Expected: dry-run output only; no `gh` mutation.
 - "Re-run apply after a partial successful apply." Expected: completed actions log `already-applied` and remaining accepted actions continue safely.
-
-## Smoke Check
-
-After editing this skill bundle, run the repository-level skill discovery smoke check documented in `README.md`.

--- a/skills/dev-backlog/SKILL.md
+++ b/skills/dev-backlog/SKILL.md
@@ -164,7 +164,3 @@ Useful scripts:
 - "Work issue #42 whose task file has three AC checkboxes." Expected: verify each AC before checking it off, then update Plan, Progress, and GitHub state.
 - "Close a sprint with Running Context that applies to future work." Expected: promote durable context to `_context.md`, set sprint completed, and move completed task files.
 - "Sync local backlog after GitHub issues changed." Expected: run explicit pull/update logic and report what changed; no background mutation.
-
-## Smoke Check
-
-After editing this skill bundle, run the repository-level skill discovery smoke check documented in `README.md`.


### PR DESCRIPTION
## Summary

- Remove maintainer-only smoke check pointers from runtime `SKILL.md` surfaces.
- Clarify README verification as bundle packaging/frontmatter discovery, not runtime dependency validation.
- Keep the sibling skill expected list only in maintainer documentation.

## Verification

- `git diff --check`
- `npx --yes skills add . -l`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 번들 검증 안내 문구를 더 구체적으로 다듬고, 확인 범위를 스킬 탐지와 번들 패키징 결과로 명확히 했습니다.
  * 일부 스킬 문서에서 중복된 스모크 체크 안내를 정리해 문서 구조를 간소화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->