### PR TITLE
Add dev-backlog create issue route

### DIFF
--- a/skills/dev-backlog/SKILL.md
+++ b/skills/dev-backlog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dev-backlog
-argument-hint: "[orient|plan|work|next|sync] [issue-number]"
+argument-hint: "[orient|create|plan|work|next|sync|complete] [issue-number]"
 description: Manage GitHub-Issue-backed sprint execution. Use for issue mirrors, sprint planning or closing, next-work selection, progress sync, milestone-backed backlog work, 다음 작업, 이슈 만들어, 스프린트 계획, 백로그.
 compatibility: Requires gh CLI and git. Works on Claude Code and Codex.
 metadata:
@@ -20,6 +20,7 @@ Related skills: [`spec-charter`](../spec-charter/SKILL.md) for `spec/charter.md`
 | User intent | Mode | Completion boundary |
 | --- | --- | --- |
 | "where are we?", "orient", "status" | `orient` | Active sprint, latest progress, and next unchecked batch are identified. |
+| "create issue", "new issue", "이슈 만들어" | `create` | GitHub issue is created, mirrored locally, and added to the current sprint Plan when in scope. |
 | "plan sprint", "make sprint", "start work" with no active sprint | `plan` | One active sprint file exists with Goal, ordered Plan, `objectives:`, and `component:`. |
 | "work #N", "continue", "do next batch" | `work` | Issue AC is verified, task/sprint state is updated, and GitHub receives a meaningful status signal. |
 | "next", "다음 작업" | `next` | The next actionable batch or sprint-planning need is named. |
@@ -79,6 +80,12 @@ Full sprint and task-file examples live in `references/file-format.md`.
 4. Identify the next unchecked Plan item or route to `complete` when all items are done.
 
 Done when you can name the current sprint state and the next actionable batch.
+
+### Create
+
+Follow `references/process.md` → `## Create — New Issues`.
+
+Done when the new issue exists on GitHub, has a local task mirror, and is added to the active sprint Plan when in scope.
 
 ### Plan
 


### PR DESCRIPTION
## Dispatch Summary

```text
Committed `df02133 Add dev-backlog create issue route`.

Changed [SKILL.md](/Users/sjlee/.relay/worktrees/e312aee8/dev-backlog/skills/dev-backlog/SKILL.md:3):
- Added `create` and `complete` to `argument-hint`.
- Added a Mode Router row for `"create issue"`, `"new issue"`, `"이슈 만들어"`.
- Added a terse `### Create` execution path pointing to `references/process.md` `## Create — New Issues`.

Verification:
- `bash skills/dev-backlog/scripts/smoke-test.sh`: 104 passed, 0 failed.
- `node --test skill
```

## Score Log

- Run: issue-208-20260703090524030-d4bec2a2
- Executor: codex
- Branch: issue-208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 작업 안내 문서에 `create` 입력 모드가 추가되어, 새 이슈 생성 흐름을 더 쉽게 사용할 수 있게 되었습니다.
  * “이슈 만들어” 같은 표현이 새 이슈 생성 경로로 연결되도록 안내가 확장되었습니다.
  * 새 이슈 생성의 완료 기준이 명확해져, GitHub 이슈와 로컬 작업 항목이 함께 반영되었는지 확인하기 쉬워졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->