### PR TITLE
Demote Backlog.md config compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ This keeps Codex focused on one execution file, not ten browser tabs and stale i
 | Task files stay thin | Sync cache only; decisions belong in the sprint file |
 | `_context.md` holds cross-sprint knowledge | Sprint files stay local to the sprint, project memory stays shared |
 | Sync is always explicit | No background process mutates your local state behind your back |
-| Builds on Backlog.md | `tasks/` follows the [Backlog.md](https://github.com/MrLesk/Backlog.md) format; `sprints/` and `gh` sync are the additions |
+| Task-file format is Backlog.md-compatible | `tasks/` follows the [Backlog.md](https://github.com/MrLesk/Backlog.md) task format; `sprints/` and `gh` sync are dev-backlog additions |
 
 ## Docs
 

--- a/skills/dev-backlog/references/file-format.md
+++ b/skills/dev-backlog/references/file-format.md
@@ -1,6 +1,6 @@
 # File Format Reference
 
-Task file specification following [Backlog.md](https://github.com/MrLesk/Backlog.md) format.
+Task files are compatible with the [Backlog.md](https://github.com/MrLesk/Backlog.md) task format.
 
 ## Frontmatter Fields
 
@@ -92,15 +92,12 @@ Only AC checkboxes get updated in task files during work. Everything else (notes
 
 ```yaml
 project_name: "my-project"
+task_prefix: "BACK"
 default_status: "To Do"
 statuses: ["To Do", "In Progress", "Done"]
-task_prefix: "BACK"
-labels: []
-milestones: []
-definition_of_done: []        # Default DoD items added to every new task
-date_format: yyyy-mm-dd hh:mm
-auto_commit: false
 ```
+
+dev-backlog reads `task_prefix`, `default_status`, and `statuses`; `project_name` is retained as metadata. Other Backlog.md config fields are not consumed by dev-backlog.
 
 ## Sub-tasks
 
@@ -113,6 +110,6 @@ Sub-tasks get their own files: `BACK-42.1 - Subtask-title.md`
 
 ## Backlog.md CLI Compatibility
 
-The `backlog/tasks/` and `backlog/completed/` directories follow Backlog.md standard — the CLI will recognize them.
+The `backlog/tasks/` and `backlog/completed/` directories use a Backlog.md-compatible task-file format, so the CLI will recognize them.
 
 The `backlog/sprints/` directory is a custom addition for sprint execution tracking. Backlog.md CLI ignores it (only scans `tasks/`, `completed/`, `drafts/`, `decisions/`, `docs/`). This is safe — sprints/ won't interfere with CLI operations.

--- a/skills/dev-backlog/scripts/init.sh
+++ b/skills/dev-backlog/scripts/init.sh
@@ -22,12 +22,9 @@ mkdir -p backlog/{sprints,tasks,completed}
 
 cat > backlog/config.yml << EOF
 project_name: "$PROJECT_NAME"
+task_prefix: "BACK"
 default_status: "To Do"
 statuses: ["To Do", "In Progress", "Done"]
-task_prefix: "BACK"
-labels: []
-milestones: []
-auto_commit: false
 EOF
 
 echo "Created backlog/ structure:"

--- a/spec/charter.md
+++ b/spec/charter.md
@@ -1,6 +1,6 @@
 ---
-last_amended: 2026-05-31
-revision: 2
+last_amended: 2026-07-03
+revision: 3
 ---
 
 # dev-backlog Charter
@@ -27,6 +27,7 @@ No server, no daemon, no hidden state, no silent sync.
 - Silent background sync — every pull and push is an explicit user action.
 - A knowledge base / wiki replacement — `spec/charter.md` is a yardstick, `_context.md` is rediscovery-prone HOW-knowledge, neither is a long-form doc store.
 - Per-vendor connectors (Jira, Linear, Notion) — out of scope, not the wedge.
+- Backlog.md convention-following — the task-file format stays Backlog.md-compatible, but new features are not constrained by Backlog.md conventions.
 
 ## Objectives         <!-- Tier 2 · Predicates (add/remove human-gated; status proof-gated) -->
 - O1 [validated] Claude Code, Codex, and humans read the same active sprint file as the single execution state · src: user
@@ -47,3 +48,4 @@ No server, no daemon, no hidden state, no silent sync.
 | 2026-05-29 | `backlog-charter` splits into `spec-charter` and `spec-grill`                         | Existing-repo onboarding needs a discoverable second step from project charter to capability contracts | 2026-05-22 |
 | 2026-05-29 | New charter files live at `spec/charter.md`; root `CHARTER.md` is legacy fallback     | Charter, system map, and capabilities should share one project spec home under `spec/`           | 2026-05-22 |
 | 2026-05-31 | `backlog-triage` adds spec-aware Decision Review as a prompt-driven report layer      | Final issue recommendations need semantic evidence from charter, capabilities, system map, and sprint context; mutations stay explicit | —          |
+| 2026-07-03 | Backlog.md demoted from design ancestor to format-compat surface                      | No script reads its config fields; compat is a task-file format guarantee, not a design constraint | —          |


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed as `b74b05c Demote Backlog.md config compatibility`.

Completion audit:
- [init.sh](/Users/sjlee/.relay/worktrees/8bf052f2/dev-backlog/skills/dev-backlog/scripts/init.sh:23) now emits only `project_name`, `task_prefix`, `default_status`, and `statuses`.
- [README.md](/Users/sjlee/.relay/worktrees/8bf052f2/dev-backlog/README.md:291) now frames Backlog.md as task-file format compatibility, not design ancestry.
- [file-format.md](/Users/sjlee/.relay/worktrees/8bf052f2/dev-
```

## Score Log

- Run: issue-209-20260703090706456-f1713a3a
- Executor: codex
- Branch: issue-209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 태스크 파일 형식과 설정 예시를 더 명확하게 정리해, 호환되는 항목과 CLI에서 인식되는 디렉터리 범위를 쉽게 이해할 수 있게 했습니다.
  * 프로젝트 기준 문서를 갱신해 Backlog.md 호환 방식에 대한 설명을 최신화했습니다.

* **Chores**
  * 초기 설정 템플릿의 생성 항목과 순서를 정리해, 더 간결한 기본 구성만 생성되도록 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->