### PR TITLE
Single-source charter fallback policy

### DIFF
--- a/skills/spec-charter/SKILL.md
+++ b/skills/spec-charter/SKILL.md
@@ -45,7 +45,7 @@ When recommending follow-up spec work, do not require users to memorize downstre
 
 `spec/charter.md` lives in the target repo's project spec directory. It records what good looks like: the problem, approach, explicit non-goals, verifiable objectives, and immutable decision history the backlog is measured against.
 
-Absence is supported. Projects opt in by creating the file; other skills degrade gracefully when it is missing. Legacy root `CHARTER.md` is read as a fallback and should be migrated deliberately. Keep the charter under a ~5-minute read. Operational know-how does not belong here; put rediscovery-prone HOW-knowledge in `_context.md`.
+Absence is supported. Projects opt in by creating the file; other skills degrade gracefully when it is missing. See `references/spec-axis.md` for the legacy root `CHARTER.md` fallback policy. Keep the charter under a ~5-minute read. Operational know-how does not belong here; put rediscovery-prone HOW-knowledge in `_context.md`.
 
 Use `references/spec-axis.md` as the shared boundary for charter, system-map, capabilities, sprint context, task mirrors, triage reports, harness files, and README authority.
 
@@ -82,7 +82,7 @@ See `references/objectives.md` for worked examples, rewrite patterns, and a 30-s
 
 Use amend mode when `spec/charter.md` exists, legacy root `CHARTER.md` exists, or when invoked as `spec-charter amend`.
 
-First re-read `spec/charter.md`. If it is absent but root `CHARTER.md` exists, read that legacy file, state that the canonical path is now `spec/charter.md`, and recommend migrating before or during the accepted amendment. Direct hand-edits are allowed because it is the user's file; this skill is the disciplined path for applying the tier gates.
+First re-read `spec/charter.md`. If it is absent but root `CHARTER.md` exists, read that legacy file and follow `references/spec-axis.md` for fallback and migration handling. Direct hand-edits are allowed because it is the user's file; this skill is the disciplined path for applying the tier gates.
 
 Apply the 3-tier discipline:
 

--- a/skills/spec-charter/references/spec-axis.md
+++ b/skills/spec-charter/references/spec-axis.md
@@ -24,5 +24,5 @@ Use this as the shared boundary reference for `spec-charter`, `spec-system-map`,
 - Sprint files remain the execution hub for batching, context, progress, and handoff.
 - Triage reports are derived artifacts; they may propose spec changes, but they do not mutate specs.
 - Agent harness files can inform workflow and guardrails, but they are not product authority unless they explicitly describe product boundaries.
-- Legacy root `CHARTER.md` is read only as a fallback for older repos; new and migrated charters use `spec/charter.md`.
+- `spec/charter.md` is the canonical charter path. A legacy root `CHARTER.md` may be read only when `spec/charter.md` is absent, as a compatibility fallback for older repos; do not edit or create new root charters. Migrate from root `CHARTER.md` to `spec/charter.md` deliberately, as an explicit accepted change rather than a silent side effect.
 - Spec skills may read task AC, sprint evidence, tests, docs, and commit history to understand reality, but they must not copy issue-specific AC, frozen Done Criteria, or review notes into durable specs.


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed `d93edbc Single-source charter fallback policy`.

Completion audit:
- Full fallback policy now lives in [spec-axis.md](/Users/sjlee/.relay/worktrees/a80ef033/dev-backlog/skills/spec-charter/references/spec-axis.md:27).
- `SKILL.md` files retain behavior-only references: [dev-backlog](/Users/sjlee/.relay/worktrees/a80ef033/dev-backlog/skills/dev-backlog/SKILL.md:92), [backlog-triage](/Users/sjlee/.relay/worktrees/a80ef033/dev-backlog/skills/backlog-triage/SKILL.md:40), [
```

## Score Log

- Run: issue-210-20260703125556716-d72d883c
- Executor: codex
- Branch: issue-210