### PR TITLE
Generalize dev-backlog integration contract

### DIFF
--- a/skills/dev-backlog/references/integration-contract.md
+++ b/skills/dev-backlog/references/integration-contract.md
@@ -1,6 +1,21 @@
-# Integration Contract: dev-relay ↔ dev-backlog
+# Integration Contract: dev-backlog Actor Consumption
 
-This document defines the exact interface that dev-relay depends on when reading and writing dev-backlog files. Changes to these patterns must be coordinated across both projects.
+Decision note (2026-07): this actor-agnostic contract stays in `skills/dev-backlog/references/integration-contract.md` because `dev-relay` already consumes this path; re-scoping it in place preserves compatibility and avoids a split reference.
+
+This document defines the exact file interface that any long-running actor can depend on when reading and writing dev-backlog files. Actors include humans, relay executors, external loops, analyzers, and future automation. `dev-relay` is one named consumer profile of the general contract, not the definition of the audience.
+
+Changes to checkbox, annotation, path, or section patterns parsed by `dev-relay` must be coordinated with `dev-relay` before landing.
+
+## Read Surface
+
+Any actor consuming dev-backlog state should treat these files as the stable read surface:
+
+- `backlog/sprints/*.md` with `status: active` is the active execution hub: frontmatter identifies lifecycle and routing state; `## Goal`, `## Plan`, `## Running Context`, and `## Progress` identify the current objective, work queue, reusable discoveries, and execution trace.
+- `backlog/sprints/_context.md` is cross-sprint project memory. Its sections provide durable context for future sessions and analyzers.
+- `backlog/tasks/` and `backlog/completed/` are GitHub issue mirrors. Task files carry issue bodies and local Acceptance Criteria checkboxes; sprint files remain the execution log.
+- `spec/capabilities.md`, when present, is an optional capability-level learning target addressed by active sprint frontmatter `component:`.
+
+The sections below define the path, heading, checkbox, and annotation grammar. Consumers may read more prose, but they must not require additional headings or rewritten formats to orient from files alone.
 
 ## File Paths
 
@@ -15,7 +30,7 @@ This document defines the exact interface that dev-relay depends on when reading
 
 ## Sprint File Sections
 
-dev-relay reads and writes specific `## ` sections in the active sprint file.
+Every actor reads the same `## ` sections in the active sprint file. Writes are limited by [Write Rules](#write-rules). The `dev-relay` columns are retained as the current named consumer profile and remain normative for `dev-relay`.
 
 | Section | dev-relay reads | dev-relay writes | Purpose |
 |---------|:-:|:-:|---------|
@@ -31,6 +46,18 @@ dev-relay reads and writes specific `## ` sections in the active sprint file.
 ```
 
 Extraction: read lines between the matched `## ` heading and the next `## ` heading (or EOF). See `lib.sh:extract_section()` for the canonical implementation.
+
+## Write Rules
+
+These rules are observable from files alone and apply to any actor mutating sprint state under this integration contract:
+
+- An actor may append new bullets to `## Progress` and `## Running Context`.
+- An actor may update a `## Plan` line only to perform a permitted checkbox transition and add or update a trace pointer.
+- `[ ]` → `[~]` is allowed when the actor starts active work, dispatches the task, or records external in-flight ownership. The resulting `[~]` line must carry a pointer defined in [Trace Grammar](#trace-grammar).
+- `[~]` → `[x]` is allowed only when the line's pointer resolves to evidence: a merged PR annotation, or a verified completion recorded as a `## Progress` entry. The actor must append a `## Progress` entry naming the issue, pointer, and verification/merge evidence.
+- Actors must preserve existing Plan item text except for checkbox state and additive trace annotations.
+- Actors must not change sprint frontmatter `status:` under this contract. Sprint lifecycle workflows own `status: active` and `status: completed`.
+- Actors must not delete Plan items, rewrite Plan items into a different task, remove trace pointers, or rewrite historical `## Progress` / `## Running Context` entries.
 
 ## Sprint Frontmatter: Component Routing
 
@@ -81,6 +108,24 @@ Captures the GitHub issue number from any checkbox state.
 
 Appended when dispatching: `→ PR #87 (reviewing)`. Updated on merge: `→ PR #87 (merged)`.
 
+## Trace Grammar
+
+Every `[~]` Plan line must carry at least one pointer that lets a later reader find the live work:
+
+- PR pointer: `→ PR #N (state)`, using the existing PR annotation format.
+- Branch pointer: `[branch:<git-ref>]`, where `<git-ref>` is a Git branch name with no whitespace or `]`.
+- Run pointer: `[run:<run-id>]`, using the existing run-id annotation format.
+
+A `[~]` line with none of those pointers is **unmoored**. Historical unmoored lines should be read conservatively as in-flight but unattributable; the upcoming `backlog-doctor` consumer will flag them for repair.
+
+Non-human `## Progress` entries must include an actor tag:
+
+```
+- YYYY-MM-DD HH:MM: [actor:<actor-id>] #N action summary → pointer [run:<run-id>]
+```
+
+`<actor-id>` matches `[A-Za-z0-9][A-Za-z0-9._/-]{0,79}`. The actor tag is a strictly additive bracketed annotation compatible with the existing `[run:...]` grammar. When both tags are present, place `[actor:...]` before trailing `[run:...]` so the existing run-id extraction remains valid.
+
 ## Task File Structure
 
 ```yaml
@@ -110,7 +155,7 @@ Task-file AC is the issue mirror and local progress surface. It is not the relay
 
 ## Cross-Sprint Context (`_context.md`) Sections
 
-dev-relay reads `_context.md` for project-level knowledge. The following `## ` headings are expected:
+Actors read `_context.md` for project-level knowledge. The following `## ` headings are expected:
 
 | Section | dev-relay reads | Purpose |
 |---------|:-:|---------|
@@ -118,11 +163,13 @@ dev-relay reads `_context.md` for project-level knowledge. The following `## ` h
 | `## Conventions` | Yes | Recurring patterns (e.g., "All new endpoints need rate limiting middleware") |
 | `## Known Gotchas` | Yes | Non-obvious pitfalls (e.g., "Safari doesn't send cookies on first redirect") |
 
-relay-plan uses these sections as context when building scoring rubrics. relay-dispatch may include relevant conventions in the executor prompt. Sections may be empty or absent — treated as empty.
+`dev-relay` profile: `relay-plan` uses these sections as context when building scoring rubrics. `relay-dispatch` may include relevant conventions in the executor prompt. Sections may be empty or absent — treated as empty.
+
+The following sections define the `dev-relay` consumer profile. They specialize the general read, write, and trace rules above without narrowing the contract for other actors.
 
 ## Relay-Merge Sprint Update Format
 
-When relay-merge completes a task, it updates the active sprint file in these specific formats:
+When `relay-merge` completes a task, it updates the active sprint file in these specific formats:
 
 **Plan section** — mark checkbox done with PR annotation:
 ```
@@ -141,7 +188,7 @@ When relay-merge completes a task, it updates the active sprint file in these sp
 
 ## Capability Learnings Append Contract
 
-When `spec/capabilities.md` exists and the active sprint has a primary `component:` value, relay-merge may append one capability-level Learning after a successful run. This is a narrow writer contract, not permission for working agents to edit the capability spec.
+When `spec/capabilities.md` exists and the active sprint has a primary `component:` value, `relay-merge` may append one capability-level Learning after a successful run. This is the `dev-relay` capability-learning writer profile, not permission for working agents or other actors to edit the capability spec.
 
 Inputs:
 
@@ -188,11 +235,11 @@ Regex for extraction:
 /\[run:([^\]]+)\]$/
 ```
 
-This is optional — items without `[run:...]` are valid. relay-merge appends it when a manifest exists.
+This is optional — items without `[run:...]` are valid when another trace pointer is present. `relay-merge` appends it when a manifest exists.
 
 ## Progress Reporting Boundary
 
-Monthly progress reporting is owned by `dev-backlog`, not `dev-relay`.
+Monthly progress reporting is owned by `dev-backlog`, not `dev-relay`. This profile defines how `dev-relay` may enrich the dev-backlog-owned reporting flow.
 
 - Canonical engine: `skills/dev-backlog/scripts/progress-sync.js`
 - Backlog-only mode: `node skills/dev-backlog/scripts/progress-sync.js --month YYYY-MM`
@@ -228,10 +275,10 @@ This allows comment upserts to stay idempotent and prevents duplicate machine co
 
 ## Graceful Degradation
 
-- **No sprint file**: dev-relay skips sprint tracking entirely. Tasks still work standalone.
+- **No sprint file**: actors skip sprint tracking entirely. Tasks still work standalone.
 - **No `_context.md`**: ignored silently.
 - **Missing section in sprint**: treated as empty.
-- **No task file for an issue**: dev-relay reads directly from GitHub via `gh`.
+- **No task file for an issue**: actors that can access GitHub may read directly via `gh`; `dev-relay` does this today.
 - **No relay manifest path**: progress reporting stays backlog-only.
 
 ## Cross-Project Smoke Test
@@ -260,7 +307,9 @@ These patterns are also validated by `scripts/smoke-test.sh` (checkbox counting 
 
 ## Versioning
 
-This contract is unversioned. Breaking changes require:
+This contract is unversioned, but its checkbox and annotation grammar is compatibility-sensitive. Any change to grammar parsed by `dev-relay` regexes must be coordinated with `dev-relay` before landing; prefer strictly additive grammar that preserves existing matches.
+
+Breaking changes require:
 1. Update this document
 2. Update regex patterns in both dev-backlog (lib.sh, lib.js) and dev-relay
 3. Run smoke tests in both projects


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed as `ac1c97c Generalize dev-backlog integration contract`.

Changed [integration-contract.md](/Users/sjlee/.relay/worktrees/69af0bb5/dev-backlog/skills/dev-backlog/references/integration-contract.md:1) to make the contract actor-agnostic while keeping dev-relay as a named consumer profile. Key artifacts:

- Header decision note: lines 3-7
- Actor read surface: lines 9-18
- Write rules and forbidden mutations: lines 50-60
- Trace grammar, unmoored definition, actor tag fo
```

## Score Log

- Run: issue-212-20260703125820308-36828a54
- Executor: codex
- Branch: issue-212