### PR TITLE
test(dev-backlog): pin fresh session recovery

### DIFF
--- a/skills/dev-backlog/SKILL.md
+++ b/skills/dev-backlog/SKILL.md
@@ -165,10 +165,11 @@ Useful scripts:
 - `references/workflow-patterns.md` — planning, bug triage, feature breakdown, retrospectives.
 - `references/integration-contract.md` — dev-relay interop paths, sections, and regex contracts.
 
-## Eval Prompts
+## Eval Prompts (fresh-session recovery)
 
 - "Orient in a repo with one active sprint, `_context.md`, and a partially complete Plan." Expected: read both context files, name latest Progress, and return the first unchecked batch.
 - "Plan a sprint when another sprint is already `status: active`." Expected: refuse or complete the old sprint first; never create a second active sprint.
 - "Work issue #42 whose task file has three AC checkboxes." Expected: verify each AC before checking it off, then update Plan, Progress, and GitHub state.
+- "Fresh session with only repo files available, no conversation history, and no GitHub access." Expected: use `status.sh --json` and `next.sh --json` to name the active sprint, next actionable batch, and every in-flight `[~]` item with its owner/pointer (PR, branch, or run-id); if `--json` is unavailable, read the sprint file directly.
 - "Close a sprint with Running Context that applies to future work." Expected: promote durable context to `_context.md`, set sprint completed, and move completed task files.
 - "Sync local backlog after GitHub issues changed." Expected: run explicit pull/update logic and report what changed; no background mutation.

--- a/skills/dev-backlog/scripts/smoke-test.sh
+++ b/skills/dev-backlog/scripts/smoke-test.sh
@@ -106,13 +106,14 @@ if (!next.active_sprint || next.active_sprint.path !== sprintPath) {
   process.exit(1);
 }
 const planItems = Array.isArray(status.plan_items) ? status.plan_items : [];
-const hasOpenWork = planItems.some((item) => item.state === "todo" || item.state === "in_flight");
+const hasTodo = planItems.some((item) => item.state === "todo");
+const hasInFlight = planItems.some((item) => item.state === "in_flight");
 const sprintComplete = planItems.length > 0 && planItems.every((item) => item.state === "done");
-if (hasOpenWork) {
+if (hasTodo) {
   if (!next.next_batch || !Array.isArray(next.next_batch.items) || next.next_batch.items.length === 0) {
     process.exit(1);
   }
-} else if (!sprintComplete) {
+} else if (!sprintComplete && !hasInFlight) {
   process.exit(1);
 }
 const inFlight = Array.isArray(status.in_flight) ? status.in_flight : null;
@@ -124,6 +125,55 @@ for (const item of inFlight) {
   const hasBranch = item.branch != null && item.branch !== "";
   const hasRun = item.run_id != null && item.run_id !== "";
   if (!hasPr && !hasBranch && !hasRun) process.exit(1);
+}
+'
+
+# Deterministic fixture: in-flight-only sprint keeps the pointer guarantee
+# observable even when the live repo has no [~] items.
+RECOVERY_FIXTURE_DIR="$TEST_DIR/recovery-backlog"
+mkdir -p "$RECOVERY_FIXTURE_DIR/sprints"
+cat > "$RECOVERY_FIXTURE_DIR/sprints/2026-01-recovery-fixture.md" << 'EOF'
+---
+milestone: recovery fixture
+status: active
+started: 2026-01-01
+due: TBD
+objectives: []
+component: ""
+---
+
+# Recovery Fixture
+
+## Goal
+Fixture sprint with only in-flight work.
+
+## Plan
+- [x] #1 Done item → PR #10 (merged)
+- [~] #2 In-flight item → PR #11 (reviewing) [run:issue-2-fixture]
+
+## Running Context
+- none
+
+## Progress
+- 2026-01-01: #2 dispatched.
+EOF
+FIXTURE_STATUS=$(node "$SCRIPT_DIR/sprint-state.js" --mode status "$RECOVERY_FIXTURE_DIR")
+FIXTURE_NEXT=$(node "$SCRIPT_DIR/sprint-state.js" --mode next "$RECOVERY_FIXTURE_DIR")
+FIXTURE_JSON=$(printf '{"status":%s,"next":%s}' "$FIXTURE_STATUS" "$FIXTURE_NEXT")
+assert_json_eval "recovery fixture: in-flight-only sprint orientable without next batch" "$FIXTURE_JSON" '
+const recovery = JSON.parse(require("fs").readFileSync(0, "utf8"));
+const { status, next } = recovery;
+if (!status.active_sprint || !status.active_sprint.path) process.exit(1);
+const planItems = Array.isArray(status.plan_items) ? status.plan_items : [];
+if (planItems.some((item) => item.state === "todo")) process.exit(1);
+const inFlight = Array.isArray(status.in_flight) ? status.in_flight : [];
+if (inFlight.length !== 1) process.exit(1);
+const item = inFlight[0];
+const hasPr = item.pr && item.pr.number != null;
+const hasRun = item.run_id != null && item.run_id !== "";
+if (!hasPr || !hasRun) process.exit(1);
+if (next.next_batch && Array.isArray(next.next_batch.items) && next.next_batch.items.length > 0) {
+  process.exit(1);
 }
 '
 

--- a/skills/dev-backlog/scripts/smoke-test.sh
+++ b/skills/dev-backlog/scripts/smoke-test.sh
@@ -79,11 +79,51 @@ for (const name of [
   "component_lint",
   "capabilities_doctor",
   "sprint_shape",
+  "in_flight_trace",
 ]) {
   if (!names.has(name)) process.exit(1);
 }
 if (j.schema_version !== 1 || !Array.isArray(j.checks) || j.exit_hint === "fail") {
   process.exit(1);
+}
+'
+
+# ============================================================
+# fresh-session recovery live-repo smoke test
+# ============================================================
+
+STATUS_JSON=$(cd "$REPO_ROOT" && bash "$SCRIPT_DIR/status.sh" --json)
+NEXT_JSON=$(cd "$REPO_ROOT" && bash "$SCRIPT_DIR/next.sh" --json)
+RECOVERY_JSON=$(printf '{"status":%s,"next":%s}' "$STATUS_JSON" "$NEXT_JSON")
+assert_json_eval "recovery live: files-only state is orientable" "$RECOVERY_JSON" '
+const recovery = JSON.parse(require("fs").readFileSync(0, "utf8"));
+const { status, next } = recovery;
+const sprintPath = status.active_sprint && status.active_sprint.path;
+if (status.schema_version !== 1 || next.schema_version !== 1 || !sprintPath) {
+  process.exit(1);
+}
+if (!next.active_sprint || next.active_sprint.path !== sprintPath) {
+  process.exit(1);
+}
+const planItems = Array.isArray(status.plan_items) ? status.plan_items : [];
+const hasOpenWork = planItems.some((item) => item.state === "todo" || item.state === "in_flight");
+const sprintComplete = planItems.length > 0 && planItems.every((item) => item.state === "done");
+if (hasOpenWork) {
+  if (!next.next_batch || !Array.isArray(next.next_batch.items) || next.next_batch.items.length === 0) {
+    process.exit(1);
+  }
+} else if (!sprintComplete) {
+  process.exit(1);
+}
+const inFlight = Array.isArray(status.in_flight) ? status.in_flight : null;
+if (!inFlight) process.exit(1);
+const inFlightPlanItems = planItems.filter((item) => item.state === "in_flight");
+if (inFlight.length !== inFlightPlanItems.length) process.exit(1);
+for (const item of inFlight) {
+  const hasPr = item.pr && item.pr.number != null;
+  const hasBranch = item.branch != null && item.branch !== "";
+  const hasRun = item.run_id != null && item.run_id !== "";
+  if (!hasPr && !hasBranch && !hasRun) process.exit(1);
 }
 '
 


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed `574702a test(dev-backlog): pin fresh session recovery`.

**Artifacts**
- Eval prompt added: [SKILL.md](/Users/sjlee/.relay/worktrees/83f9a4a6/dev-backlog/skills/dev-backlog/SKILL.md:173)
- Eval section remains within budget: [SKILL.md](/Users/sjlee/.relay/worktrees/83f9a4a6/dev-backlog/skills/dev-backlog/SKILL.md:168), `175` lines total
- Recovery smoke block added: [smoke-test.sh](/Users/sjlee/.relay/worktrees/83f9a4a6/dev-backlog/skills/dev-backlog/scripts/smoke-test
```

## Score Log

- Run: issue-214-20260703134948518-31b9d6f5
- Executor: codex
- Branch: issue-214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 신선한 세션에서 상태 조회와 다음 작업 추천이 정상 동작하는지 확인하는 검증이 추가되었습니다.
  * 진행 중인 항목이 JSON 응답에 올바르게 포함되는지, 완료/대기 상태에 따른 결과가 일관적인지 점검하도록 확대되었습니다.
  * 진단 결과에 추가 점검 항목이 포함되는지 확인하도록 검증이 강화되었습니다.

* **문서**
  * 평가 시나리오에 신선한 세션 복구 관련 안내가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->