### PR TITLE
feat(dev-backlog): gate sprint-close reassess signal

### DIFF
--- a/skills/dev-backlog/SKILL.md
+++ b/skills/dev-backlog/SKILL.md
@@ -112,10 +112,13 @@ Per issue: all AC checked, implementation merged or committed with `Fixes #N`, P
 
 For a whole sprint:
 
-1. Set `status: completed` and write a final Progress entry.
-2. Move completed task files from `backlog/tasks/` to `backlog/completed/`.
-3. Promote project-level Running Context entries to `_context.md`.
-4. Leave the sprint file in place as the permanent record.
+1. Run `sprint-close.sh`; it runs `backlog-doctor.js` before the status flip and prints any reassess recommendation in the close summary.
+2. Set `status: completed` and write a final Progress entry.
+3. Move completed task files from `backlog/tasks/` to `backlog/completed/`.
+4. Promote project-level Running Context entries to `_context.md`.
+5. Leave the sprint file in place as the permanent record.
+
+The reassess signal is text-only: recommend `spec-charter reassess` when the doctor warns/fails or when Node counts 3+ completed sprints since the latest `backlog/triage/YYYY-MM-DD-reassess.md`. Counting uses each completed sprint's final `Sprint closed` Progress date, falling back to the filename month; dry-run/pre-close counts the closing sprint as today. Unattended sessions may run `reassess` because it is report-only, but must never run `amend`.
 
 Done when there is no stale active sprint or rediscovery-prone context trapped in the closed sprint.
 
@@ -151,7 +154,7 @@ Useful scripts:
 - `scripts/sync-pull.js [PREFIX] [--update] [--dry-run] [--json] [--limit N]` — pull open GitHub issues into `backlog/tasks/`.
 - `scripts/sprint-init.js "topic" [--milestone "Name"] [--dry-run] [--json]` — create one active sprint skeleton; refuses a second active sprint.
 - `scripts/progress-sync.js [--month YYYY-MM] [--dry-run] [--json] [--relay-manifest PATH] [--finalize]` — sync monthly progress issue.
-- `scripts/sprint-close.sh [backlog-dir] [--dry-run] [--close-milestone]` — close the single active sprint.
+- `scripts/sprint-close.sh [backlog-dir] [--dry-run] [--close-milestone]` — close the single active sprint and print the doctor/reassess signal summary.
 - `scripts/objectives-check.js [--sprints-dir PATH] [--charter PATH] [--json]` — verify sprint Objective IDs.
 - `scripts/component-lint.js [--sprints-dir PATH] [--capabilities PATH] [--json]` — verify sprint `component:` handles.
 - `scripts/capabilities-doctor.js [--capabilities PATH] [--json] [--strict]` — check `spec/capabilities.md` compactness and Learnings markers.

--- a/skills/dev-backlog/scripts/backlog-doctor.js
+++ b/skills/dev-backlog/scripts/backlog-doctor.js
@@ -28,12 +28,21 @@ const {
 const SCHEMA_VERSION = 1;
 const DEFAULT_BACKLOG_DIR = "backlog";
 const DEFAULT_STALE_DAYS = 7;
+const DEFAULT_REASSESS_THRESHOLD = 3;
 const CONTEXT_BLOAT_LINE_THRESHOLD = 200;
 const REQUIRED_ACTIVE_SECTIONS = ["Goal", "Plan", "Running Context", "Progress"];
+const REASSESS_REPORT_RE = /^(\d{4}-\d{2}-\d{2})-reassess\.md$/;
+const SPRINT_CLOSED_RE = /^-\s+(\d{4}-\d{2}-\d{2})(?:\s+[^:]+)?:\s+Sprint closed\b/;
+const SPRINT_FILENAME_MONTH_RE = /^(\d{4}-\d{2})-/;
+const REASSESS_ACCOUNTING_RULE = [
+  "Counts status: completed sprint files by their final 'Sprint closed' Progress date;",
+  "legacy completed sprints without that entry use the filename month as YYYY-MM-01.",
+  "A closing sprint passed by sprint-close counts on today's close date for dry-run/pre-close summaries.",
+].join(" ");
 
 function usage() {
   return [
-    "Usage: backlog-doctor.js [--json] [--stale-days N] [backlog-dir]",
+    "Usage: backlog-doctor.js [--json] [--stale-days N] [--close-summary] [--closing-sprint PATH] [--reassess-threshold N] [backlog-dir]",
     "",
     "Runs active-sprint, objectives, component, capabilities, sprint-shape,",
     "in-flight trace/staleness, and _context.md bloat checks.",
@@ -44,6 +53,9 @@ function parseArgs(args) {
   const options = {
     backlogDir: DEFAULT_BACKLOG_DIR,
     staleDays: DEFAULT_STALE_DAYS,
+    reassessThreshold: DEFAULT_REASSESS_THRESHOLD,
+    closeSummary: false,
+    closingSprintPath: null,
     json: false,
   };
   let backlogDirSet = false;
@@ -53,6 +65,39 @@ function parseArgs(args) {
     if (arg === "--help" || arg === "-h") return { ...options, help: true };
     if (arg === "--json") {
       options.json = true;
+      continue;
+    }
+    if (arg === "--close-summary") {
+      options.closeSummary = true;
+      continue;
+    }
+    if (arg === "--closing-sprint") {
+      const next = args[i + 1];
+      if (!next) return { ...options, error: `Missing value for --closing-sprint. ${usage()}` };
+      options.closingSprintPath = next;
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith("--closing-sprint=")) {
+      options.closingSprintPath = arg.slice("--closing-sprint=".length);
+      continue;
+    }
+    if (arg === "--reassess-threshold") {
+      const next = args[i + 1];
+      if (!next) return { ...options, error: `Missing value for --reassess-threshold. ${usage()}` };
+      const parsed = parseNonNegativeInteger(next, "--reassess-threshold");
+      if (parsed.error) return { ...options, error: parsed.error };
+      options.reassessThreshold = parsed.value;
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith("--reassess-threshold=")) {
+      const parsed = parseNonNegativeInteger(
+        arg.slice("--reassess-threshold=".length),
+        "--reassess-threshold",
+      );
+      if (parsed.error) return { ...options, error: parsed.error };
+      options.reassessThreshold = parsed.value;
       continue;
     }
     if (arg === "--stale-days") {
@@ -84,8 +129,12 @@ function parseArgs(args) {
 }
 
 function parseStaleDays(raw) {
+  return parseNonNegativeInteger(raw, "--stale-days");
+}
+
+function parseNonNegativeInteger(raw, flagName) {
   if (!/^\d+$/.test(raw)) {
-    return { error: `Invalid --stale-days value: ${raw}. Expected a non-negative integer.` };
+    return { error: `Invalid ${flagName} value: ${raw}. Expected a non-negative integer.` };
   }
   return { value: Number.parseInt(raw, 10) };
 }
@@ -158,8 +207,8 @@ function checkActiveSprint({ repoRoot, sprintsDir }) {
   }
 
   if (activeFiles.length === 0 && sprintFiles.length > 0) {
-    return verdict("active_sprint", "fail", {
-      summary: `No active sprint found among ${sprintFiles.length} sprint file(s).`,
+    return verdict("active_sprint", "warn", {
+      summary: `No active sprint found among ${sprintFiles.length} sprint file(s); this is normal between sprints.`,
       active_files: [],
       sprint_count: sprintFiles.length,
       active_path: null,
@@ -430,6 +479,188 @@ function checkContextBloat({ repoRoot, sprintsDir, threshold }) {
   });
 }
 
+function runCloseSummary({
+  repoRoot = process.cwd(),
+  backlogDir = DEFAULT_BACKLOG_DIR,
+  staleDays = DEFAULT_STALE_DAYS,
+  today = new Date(),
+  contextLineThreshold = CONTEXT_BLOAT_LINE_THRESHOLD,
+  reassessThreshold = DEFAULT_REASSESS_THRESHOLD,
+  closingSprintPath = null,
+} = {}) {
+  const report = runDoctor({
+    repoRoot,
+    backlogDir,
+    staleDays,
+    today,
+    contextLineThreshold,
+  });
+  return {
+    doctor_report: report,
+    reassess_signal: buildReassessSignal({
+      repoRoot,
+      backlogDir,
+      doctorReport: report,
+      closingSprintPath,
+      today,
+      threshold: reassessThreshold,
+    }),
+  };
+}
+
+function buildReassessSignal({
+  repoRoot = process.cwd(),
+  backlogDir = DEFAULT_BACKLOG_DIR,
+  doctorReport,
+  closingSprintPath = null,
+  today = new Date(),
+  threshold = DEFAULT_REASSESS_THRESHOLD,
+} = {}) {
+  if (!doctorReport) {
+    throw new Error("buildReassessSignal requires a doctorReport");
+  }
+
+  const root = path.resolve(repoRoot);
+  const backlogPath = resolvePath(root, backlogDir);
+  const sprintsDir = path.join(backlogPath, "sprints");
+  const triageDir = path.join(backlogPath, "triage");
+  const latestReassess = findLatestReassessReport({ repoRoot: root, triageDir });
+  const completedRecords = collectCompletedSprintRecords({ repoRoot: root, sprintsDir });
+  const records = maybeAddClosingSprintRecord({
+    repoRoot: root,
+    records: completedRecords,
+    closingSprintPath,
+    today,
+  });
+
+  const countedRecords = latestReassess
+    ? records.filter((record) => record.accounting_date >= latestReassess.date)
+    : records;
+
+  const doctorWarnCount = doctorReport.checks.filter((check) => check.status === "warn").length;
+  const doctorFailCount = doctorReport.checks.filter((check) => check.status === "fail").length;
+  const doctorSignal = doctorWarnCount > 0 || doctorFailCount > 0;
+  const sprintCountSignal = countedRecords.length >= threshold;
+  const reasons = [];
+
+  if (doctorSignal) {
+    reasons.push(
+      `doctor emitted ${doctorWarnCount} ${plural("warning", doctorWarnCount)} and ${doctorFailCount} ${plural("failure", doctorFailCount)}`,
+    );
+  }
+  if (sprintCountSignal) {
+    reasons.push(
+      `${countedRecords.length} ${plural("sprint", countedRecords.length)} closed since last reassess (threshold ${threshold})`,
+    );
+  }
+
+  const recommend = doctorSignal || sprintCountSignal;
+  const summary = recommend
+    ? `Signals: ${reasons.join("; ")} -> recommend: spec-charter reassess`
+    : `Signals: no reassess recommendation (doctor clean; ${countedRecords.length}/${threshold} sprint(s) closed since last reassess)`;
+
+  return {
+    recommend,
+    summary,
+    reasons,
+    doctor_warn_count: doctorWarnCount,
+    doctor_fail_count: doctorFailCount,
+    completed_sprints_since_reassess: countedRecords.length,
+    completed_sprint_paths: countedRecords.map((record) => record.display_path),
+    latest_reassess_date: latestReassess ? latestReassess.date : null,
+    latest_reassess_report: latestReassess ? latestReassess.display_path : null,
+    threshold,
+    accounting_rule: REASSESS_ACCOUNTING_RULE,
+  };
+}
+
+function findLatestReassessReport({ repoRoot, triageDir }) {
+  if (!fs.existsSync(triageDir)) return null;
+  const matches = fs.readdirSync(triageDir)
+    .map((file) => ({ file, match: file.match(REASSESS_REPORT_RE) }))
+    .filter((entry) => entry.match)
+    .map((entry) => ({
+      date: entry.match[1],
+      path: path.join(triageDir, entry.file),
+    }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+  const latest = matches[matches.length - 1];
+  if (!latest) return null;
+  return {
+    ...latest,
+    display_path: displayPath(repoRoot, latest.path),
+  };
+}
+
+function collectCompletedSprintRecords({ repoRoot, sprintsDir }) {
+  return listSprintFiles(sprintsDir)
+    .map((filePath) => {
+      const content = fs.readFileSync(filePath, "utf-8");
+      if (!/^status:\s*completed\s*$/m.test(content)) return null;
+      return sprintAccountingRecord({ repoRoot, filePath, content });
+    })
+    .filter(Boolean);
+}
+
+function maybeAddClosingSprintRecord({ repoRoot, records, closingSprintPath, today }) {
+  if (!closingSprintPath) return records;
+  const resolved = resolvePath(repoRoot, closingSprintPath);
+  if (!fs.existsSync(resolved)) return records;
+  if (records.some((record) => record.path === resolved)) return records;
+
+  return [
+    ...records,
+    {
+      path: resolved,
+      display_path: displayPath(repoRoot, resolved),
+      accounting_date: formatLocalDate(today),
+      accounting_source: "closing_sprint",
+    },
+  ];
+}
+
+function sprintAccountingRecord({ repoRoot, filePath, content }) {
+  const progressDate = finalSprintClosedProgressDate(content);
+  const fallbackDate = filenameMonthDate(filePath);
+  const accountingDate = progressDate || fallbackDate;
+  if (!accountingDate) return null;
+
+  return {
+    path: filePath,
+    display_path: displayPath(repoRoot, filePath),
+    accounting_date: accountingDate,
+    accounting_source: progressDate ? "progress" : "filename_month",
+  };
+}
+
+function finalSprintClosedProgressDate(content) {
+  const dates = content.split(/\r?\n/)
+    .map((line) => {
+      const match = line.match(SPRINT_CLOSED_RE);
+      return match ? match[1] : null;
+    })
+    .filter(Boolean);
+  return dates.length > 0 ? dates[dates.length - 1] : null;
+}
+
+function filenameMonthDate(filePath) {
+  const match = path.basename(filePath).match(SPRINT_FILENAME_MONTH_RE);
+  return match ? `${match[1]}-01` : null;
+}
+
+function formatLocalDate(date) {
+  return [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, "0"),
+    String(date.getDate()).padStart(2, "0"),
+  ].join("-");
+}
+
+function plural(noun, count) {
+  return count === 1 ? noun : `${noun}s`;
+}
+
 function countLines(content) {
   if (content === "") return 0;
   return content.split(/\r?\n/).length;
@@ -471,6 +702,16 @@ function formatHumanSummary(report) {
   return lines.join("\n");
 }
 
+function formatCloseSummary(result) {
+  return [
+    "=== Backlog Doctor (pre-close) ===",
+    formatHumanSummary(result.doctor_report),
+    "",
+    `Reassess signal: ${result.reassess_signal.summary}`,
+    `Accounting rule: ${result.reassess_signal.accounting_rule}`,
+  ].join("\n");
+}
+
 function displayPath(repoRoot, filePath) {
   const relative = path.relative(repoRoot, filePath);
   if (relative && !relative.startsWith("..") && !path.isAbsolute(relative)) return relative;
@@ -488,6 +729,17 @@ function main() {
     return;
   }
 
+  if (parsed.closeSummary) {
+    const result = runCloseSummary(parsed);
+    if (parsed.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(formatCloseSummary(result));
+    }
+    process.exitCode = exitCodeFor(result.doctor_report);
+    return;
+  }
+
   const report = runDoctor(parsed);
   if (parsed.json) {
     console.log(JSON.stringify(report, null, 2));
@@ -502,13 +754,22 @@ if (require.main === module) main();
 module.exports = {
   SCHEMA_VERSION,
   DEFAULT_STALE_DAYS,
+  DEFAULT_REASSESS_THRESHOLD,
   CONTEXT_BLOAT_LINE_THRESHOLD,
   REQUIRED_ACTIVE_SECTIONS,
+  REASSESS_ACCOUNTING_RULE,
   parseArgs,
   runDoctor,
+  runCloseSummary,
+  buildReassessSignal,
   exitCodeFor,
   formatHumanSummary,
+  formatCloseSummary,
   checkActiveSprint,
   checkSprintShape,
   findUnparseablePlanLines,
+  findLatestReassessReport,
+  collectCompletedSprintRecords,
+  finalSprintClosedProgressDate,
+  filenameMonthDate,
 };

--- a/skills/dev-backlog/scripts/backlog-doctor.test.js
+++ b/skills/dev-backlog/scripts/backlog-doctor.test.js
@@ -8,6 +8,7 @@ const {
   runDoctor,
   exitCodeFor,
   formatHumanSummary,
+  buildReassessSignal,
 } = require("./backlog-doctor.js");
 
 function write(filePath, content) {
@@ -72,6 +73,19 @@ function seedCleanRepo(repoRoot, sprintContent = sprint()) {
   write(path.join(repoRoot, "spec", "charter.md"), charter());
   write(path.join(repoRoot, "spec", "capabilities.md"), capabilities());
   write(path.join(repoRoot, "backlog", "sprints", "2026-07-test.md"), sprintContent);
+}
+
+function completedSprint({
+  closed = "2026-07-01",
+  objectives = "[O1]",
+  component = "sprint-execution",
+} = {}) {
+  return sprint({
+    status: "completed",
+    objectives,
+    component,
+    progress: `- ${closed}: Sprint closed. 1/1 tasks completed.`,
+  });
 }
 
 function check(report, name) {
@@ -146,14 +160,15 @@ describe("runDoctor", () => {
     assert.equal(exitCodeFor(report), 1);
   });
 
-  it("fails when existing sprint files contain no active sprint", () => {
+  it("warns when existing sprint files contain no active sprint because that is normal between sprints", () => {
     seedCleanRepo(repoRoot, sprint({ status: "completed" }));
 
     const report = runDoctor({ repoRoot });
 
-    assert.equal(check(report, "active_sprint").status, "fail");
-    assert.match(check(report, "active_sprint").detail.summary, /No active sprint/);
-    assert.equal(exitCodeFor(report), 1);
+    assert.equal(check(report, "active_sprint").status, "warn");
+    assert.match(check(report, "active_sprint").detail.summary, /between sprints/);
+    assert.equal(report.exit_hint, "warn");
+    assert.equal(exitCodeFor(report), 0);
   });
 
   it("fails on unknown objective IDs", () => {
@@ -249,5 +264,89 @@ describe("runDoctor", () => {
     assert.equal(check(report, "context_bloat").status, "warn");
     assert.equal(check(report, "context_bloat").detail.threshold_lines, 200);
     assert.equal(exitCodeFor(report), 0);
+  });
+});
+
+describe("buildReassessSignal", () => {
+  let repoRoot;
+
+  beforeEach(() => {
+    repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "backlog-doctor-signal-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it("recommends reassess when the closing sprint reaches three completed sprints with no reassess reports", () => {
+    seedCleanRepo(repoRoot);
+    write(path.join(repoRoot, "backlog", "sprints", "2026-06-one.md"), completedSprint());
+    write(path.join(repoRoot, "backlog", "sprints", "2026-06-two.md"), completedSprint());
+
+    const doctorReport = runDoctor({ repoRoot });
+    const signal = buildReassessSignal({
+      repoRoot,
+      backlogDir: "backlog",
+      doctorReport,
+      closingSprintPath: path.join(repoRoot, "backlog", "sprints", "2026-07-test.md"),
+      today: new Date("2026-07-03T00:00:00Z"),
+    });
+
+    assert.equal(doctorReport.exit_hint, "pass");
+    assert.equal(signal.recommend, true);
+    assert.equal(signal.completed_sprints_since_reassess, 3);
+    assert.equal(signal.latest_reassess_report, null);
+    assert.match(signal.summary, /recommend: spec-charter reassess/);
+  });
+
+  it("does not recommend reassess when a fresh reassess report leaves fewer than three closed sprints", () => {
+    seedCleanRepo(repoRoot);
+    write(path.join(repoRoot, "backlog", "sprints", "2026-06-one.md"), completedSprint({ closed: "2026-06-01" }));
+    write(path.join(repoRoot, "backlog", "sprints", "2026-06-two.md"), completedSprint({ closed: "2026-06-02" }));
+    write(path.join(repoRoot, "backlog", "triage", "2026-07-03-reassess.md"), "# Reassess\n");
+
+    const doctorReport = runDoctor({ repoRoot });
+    const signal = buildReassessSignal({
+      repoRoot,
+      backlogDir: "backlog",
+      doctorReport,
+      closingSprintPath: path.join(repoRoot, "backlog", "sprints", "2026-07-test.md"),
+      today: new Date("2026-07-03T00:00:00Z"),
+    });
+
+    assert.equal(doctorReport.exit_hint, "pass");
+    assert.equal(signal.recommend, false);
+    assert.equal(signal.completed_sprints_since_reassess, 1);
+    assert.equal(signal.latest_reassess_report, "backlog/triage/2026-07-03-reassess.md");
+    assert.match(signal.summary, /no reassess recommendation/);
+  });
+
+  it("recommends reassess when the doctor emits a warning even below the sprint-count threshold", () => {
+    seedCleanRepo(
+      repoRoot,
+      sprint({
+        plan: "- [~] #1 Needs a pointer",
+      }),
+    );
+    write(path.join(repoRoot, "backlog", "triage", "2026-07-03-reassess.md"), "# Reassess\n");
+
+    const doctorReport = runDoctor({
+      repoRoot,
+      today: new Date("2026-07-03T00:00:00Z"),
+    });
+    const signal = buildReassessSignal({
+      repoRoot,
+      backlogDir: "backlog",
+      doctorReport,
+      closingSprintPath: path.join(repoRoot, "backlog", "sprints", "2026-07-test.md"),
+      today: new Date("2026-07-03T00:00:00Z"),
+    });
+
+    assert.equal(doctorReport.exit_hint, "warn");
+    assert.equal(signal.recommend, true);
+    assert.equal(signal.doctor_warn_count, 1);
+    assert.equal(signal.completed_sprints_since_reassess, 1);
+    assert.match(signal.summary, /doctor emitted 1 warning/);
+    assert.match(signal.summary, /recommend: spec-charter reassess/);
   });
 });

--- a/skills/dev-backlog/scripts/smoke-test.sh
+++ b/skills/dev-backlog/scripts/smoke-test.sh
@@ -787,6 +787,9 @@ OUT=$(bash "$SCRIPT_DIR/sprint-close.sh" "$TEST_DIR/backlog" --dry-run 2>&1)
 assert_contains "close dry-run: would set completed" "$OUT" "Would set status: completed"
 assert_contains "close dry-run: would move task" "$OUT" "BACK-1"
 assert_contains "close dry-run: shows context entries" "$OUT" "argon2"
+assert_contains "close dry-run: runs doctor" "$OUT" "=== Backlog Doctor (pre-close) ==="
+assert_contains "close dry-run: doctor result appears" "$OUT" "[PASS] active_sprint"
+assert_contains "close dry-run: reassess verdict appears" "$OUT" "Reassess signal:"
 # Verify nothing actually changed
 assert_contains "close dry-run: file unchanged" "$(grep '^status:' "$TEST_DIR/backlog/sprints/2026-03-auth.md")" "active"
 assert_equals "close dry-run: task not moved" "$(ls "$TEST_DIR/backlog/tasks/" | wc -l | tr -d ' ')" "3"
@@ -796,6 +799,8 @@ OUT=$(bash "$SCRIPT_DIR/sprint-close.sh" "$TEST_DIR/backlog" 2>&1)
 assert_contains "close: set completed" "$OUT" "status: completed"
 assert_contains "close: moved tasks" "$OUT" "BACK-1"
 assert_contains "close: context reminder" "$OUT" "argon2"
+assert_contains "close: doctor result appears" "$OUT" "[PASS] active_sprint"
+assert_contains "close: reassess verdict appears" "$OUT" "Reassess signal:"
 
 # Verify sprint file updated
 assert_contains "close: frontmatter updated" "$(grep '^status:' "$TEST_DIR/backlog/sprints/2026-03-auth.md")" "completed"

--- a/skills/dev-backlog/scripts/sprint-close.sh
+++ b/skills/dev-backlog/scripts/sprint-close.sh
@@ -5,10 +5,11 @@ set -uo pipefail
 # Usage: bash scripts/sprint-close.sh [backlog-dir] [--dry-run] [--close-milestone]
 #
 # Steps:
-#   1. Set sprint status: completed + add Progress entry
-#   2. Move checked-off task files to backlog/completed/
-#   3. Show Running Context entries (remind to promote to _context.md)
-#   4. Optionally close GitHub milestone (--close-milestone)
+#   1. Run backlog-doctor pre-close and compute the text-only reassess signal
+#   2. Set sprint status: completed + add Progress entry
+#   3. Move checked-off task files to backlog/completed/
+#   4. Show Running Context entries (remind to promote to _context.md)
+#   5. Optionally close GitHub milestone (--close-milestone)
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib.sh"
@@ -57,8 +58,15 @@ if [ "$CB_TODO" -gt 0 ] || [ "$CB_IN_FLIGHT" -gt 0 ]; then
   echo "Warning: $CB_TODO todo, $CB_IN_FLIGHT in-flight items remaining"
 fi
 
-# --- Step 1: Set status: completed ---
+# --- Step 1: Run backlog-doctor and compute the close signal ---
+# The doctor runs before the status flip. Its Node close-summary mode receives
+# the closing sprint path and counts that sprint on today's date, so dry-run
+# output reports the same would-be reassess signal without mutating files.
 TODAY=$(date +%Y-%m-%d)
+DOCTOR_SUMMARY=$(node "$SCRIPT_DIR/backlog-doctor.js" --close-summary --closing-sprint "$ACTIVE" "$BACKLOG_DIR" 2>&1)
+DOCTOR_STATUS=$?
+
+# --- Step 2: Set status: completed ---
 if $DRY_RUN; then
   echo "[dry-run] Would set status: completed in $ACTIVE"
 else
@@ -69,7 +77,7 @@ else
   echo "Set status: completed in $ACTIVE"
 fi
 
-# --- Step 2: Move completed task files ---
+# --- Step 3: Move completed task files ---
 # Collect issue numbers from checked items
 DONE_ISSUES=$(grep "$RE_CB_DONE" "$ACTIVE" | sed "s/${RE_CB_DONE}\([0-9]*\).*/\1/" || true)
 
@@ -93,7 +101,7 @@ if [ -d "$TASKS_DIR" ] && [ -n "$DONE_ISSUES" ]; then
   done
 fi
 
-# --- Step 3: Show Running Context entries ---
+# --- Step 4: Show Running Context entries ---
 CONTEXT=$(extract_section "$ACTIVE" "Running Context")
 if [ -n "$CONTEXT" ]; then
   echo ""
@@ -103,7 +111,7 @@ if [ -n "$CONTEXT" ]; then
   echo "Promote project-level entries to: $SPRINTS_DIR/_context.md"
 fi
 
-# --- Step 4: Optionally close milestone ---
+# --- Step 5: Optionally close milestone ---
 if $CLOSE_MILESTONE; then
   MILESTONE=$(grep '^milestone:' "$ACTIVE" | sed 's/^milestone: *//')
   if [ -n "$MILESTONE" ]; then
@@ -121,5 +129,10 @@ if $CLOSE_MILESTONE; then
   fi
 fi
 
+echo ""
+printf "%s\n" "$DOCTOR_SUMMARY"
+if [ "$DOCTOR_STATUS" -ne 0 ]; then
+  echo "Doctor exit code: $DOCTOR_STATUS (close flow continues; see doctor failures above)."
+fi
 echo ""
 echo "Done."


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed: `c6acc66 feat(dev-backlog): gate sprint-close reassess signal`

What changed:
- `backlog-doctor` now treats zero active sprints as `[WARN] active_sprint` and exits `0` unless another check fails. Multiple active sprints still fail.
- `sprint-close.sh` now runs `backlog-doctor` pre-close and prints a text-only reassess signal summary in dry-run and real close flows.
- Signal logic lives in Node in `backlog-doctor.js`: doctor warn/fail OR 3+ completed sprints since lates
```

## Score Log

- Run: issue-216-20260703140629614-43632130
- Executor: codex
- Branch: issue-216