### PR TITLE
feat(dev-backlog): add sprint-mirror explicit sync command

### DIFF
--- a/skills/dev-backlog/SKILL.md
+++ b/skills/dev-backlog/SKILL.md
@@ -159,6 +159,7 @@ Useful scripts:
 - `scripts/component-lint.js [--sprints-dir PATH] [--capabilities PATH] [--json]` — verify sprint `component:` handles.
 - `scripts/capabilities-doctor.js [--capabilities PATH] [--json] [--strict]` — check `spec/capabilities.md` compactness and Learnings markers.
 - `scripts/backlog-doctor.js [--json] [--stale-days N] [backlog-dir]` — aggregate backlog health checks; hard violations fail, soft execution signals warn.
+- `scripts/sprint-mirror.js [backlog-dir] [--dry-run] [--json]` — publish the active sprint to a read-only GitHub issue mirror; explicit sync only.
 
 ## References
 

--- a/skills/dev-backlog/scripts/sprint-mirror.js
+++ b/skills/dev-backlog/scripts/sprint-mirror.js
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+/**
+ * Publish the single active sprint to a machine-managed GitHub issue.
+ *
+ * Usage: node scripts/sprint-mirror.js [backlog-dir] [--dry-run] [--json]
+ *
+ * This is the option-(c) half of the SSOT decision (spec/charter.md,
+ * Decision row 2026-07-03): the local sprint file stays canonical and is
+ * committed at explicit boundaries; this script publishes a read-only
+ * GitHub issue mirror of it for shared visibility. Sync is always explicit
+ * — there is no daemon and nothing runs this automatically.
+ *
+ * sprint-state.js is the single owner of sprint markdown parsing. This
+ * script never reads sprint files itself — it shells out to sprint-state.js
+ * (`--mode status`) and renders its JSON. If sprint-state.js reports no
+ * active sprint, or fails because multiple sprints are active, this script
+ * refuses rather than guessing.
+ */
+
+const { execFileSync } = require("child_process");
+const path = require("path");
+const { GH_EXEC_DEFAULTS } = require("./lib.js");
+
+const MARKER_PREFIX = "<!-- dev-backlog:sprint-mirror sprint=";
+const MARKER_SUFFIX = " -->";
+const SPRINT_STATE_PATH = path.join(__dirname, "sprint-state.js");
+const DEFAULT_BACKLOG_DIR = "backlog";
+
+function usage() {
+  return "Usage: sprint-mirror.js [backlog-dir] [--dry-run] [--json]";
+}
+
+function makeMarker(slug) {
+  return `${MARKER_PREFIX}${slug}${MARKER_SUFFIX}`;
+}
+
+// --- Args ---
+
+function parseArgs(args) {
+  const options = { backlogDir: DEFAULT_BACKLOG_DIR, dryRun: false, json: false };
+  let backlogDirSet = false;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--help" || arg === "-h") return { ...options, help: true };
+    if (arg === "--dry-run") { options.dryRun = true; continue; }
+    if (arg === "--json") { options.json = true; continue; }
+    if (arg.startsWith("--")) {
+      return { ...options, error: `Unknown argument: ${arg}. ${usage()}` };
+    }
+    if (backlogDirSet) {
+      return { ...options, error: `Unexpected argument: ${arg}. ${usage()}` };
+    }
+    options.backlogDir = arg;
+    backlogDirSet = true;
+  }
+
+  return options;
+}
+
+// --- Resolve execution state via sprint-state.js ---
+
+function resolveSprintState({
+  backlogDir = DEFAULT_BACKLOG_DIR,
+  execFile = execFileSync,
+  sprintStatePath = SPRINT_STATE_PATH,
+} = {}) {
+  let out;
+  try {
+    out = execFile(
+      process.execPath,
+      [sprintStatePath, "--mode", "status", backlogDir],
+      { encoding: "utf-8", maxBuffer: 10 * 1024 * 1024 }
+    );
+  } catch (error) {
+    const detail = error.stderr ? String(error.stderr).trim() : error.message;
+    throw new Error(`sprint-state.js failed — refusing to guess active sprint:\n${detail}`);
+  }
+
+  let state;
+  try {
+    state = JSON.parse(out);
+  } catch (error) {
+    throw new Error(`sprint-state.js produced invalid JSON: ${error.message}`);
+  }
+
+  if (state.schema_version !== 1) {
+    throw new Error(`Unsupported sprint-state schema_version: ${state.schema_version}`);
+  }
+
+  if (!state.active_sprint) {
+    throw new Error("No active sprint found. sprint-mirror requires exactly one active sprint.");
+  }
+
+  return state;
+}
+
+// --- Rendering ---
+
+function formatPointer(item) {
+  if (item.pr) return ` — PR #${item.pr.number} (${item.pr.state})`;
+  if (item.run_id) return ` — run:${item.run_id}`;
+  if (item.branch) return ` — branch ${item.branch}`;
+  if (item.unmoored) return " — (unmoored)";
+  return "";
+}
+
+function formatPlanItem(item) {
+  const title = item.title ? ` ${item.title}` : "";
+  return `- [${item.checkbox_state}] #${item.issue_number}${title}${formatPointer(item)}`;
+}
+
+function renderPlanSection(planItems) {
+  if (!planItems || planItems.length === 0) {
+    return ["_No plan items._"];
+  }
+
+  const lines = [];
+  let currentBatch;
+  for (const item of planItems) {
+    if (item.batch_heading && item.batch_heading !== currentBatch) {
+      if (currentBatch !== undefined) lines.push("");
+      lines.push(item.batch_heading);
+      currentBatch = item.batch_heading;
+    }
+    lines.push(formatPlanItem(item));
+  }
+  return lines;
+}
+
+function renderProgressSection(latestProgress) {
+  if (!latestProgress || latestProgress.length === 0) {
+    return ["_No progress recorded yet._"];
+  }
+  return latestProgress.map((entry) => entry.line);
+}
+
+function renderMirrorBody({ state, slug, now = new Date() }) {
+  const marker = makeMarker(slug);
+  const lines = [marker, ""];
+
+  lines.push(
+    "> The local sprint file is canonical. This mirror is read-only — it is",
+    "> not edited by hand — and sync is always explicit; there is no daemon.",
+    ""
+  );
+
+  lines.push("## Goal", "");
+  lines.push(state.active_sprint.goal || "_No goal recorded._");
+  lines.push("");
+
+  lines.push("## Plan", "");
+  lines.push(...renderPlanSection(state.plan_items));
+  lines.push("");
+
+  lines.push("## Latest Progress", "");
+  lines.push(...renderProgressSection(state.latest_progress));
+  lines.push("");
+
+  lines.push(`Last explicit sync: ${now.toISOString()}`);
+
+  return lines.join("\n");
+}
+
+// --- GitHub I/O ---
+
+function findMirrorIssue(marker, execFile) {
+  const out = execFile(
+    "gh",
+    [
+      "issue", "list", "--state", "all",
+      "--search", "dev-backlog:sprint-mirror in:body",
+      "--json", "number,body", "--limit", "50",
+    ],
+    GH_EXEC_DEFAULTS
+  );
+  const issues = JSON.parse(out);
+  return issues.find((issue) => issue.body && issue.body.includes(marker)) || null;
+}
+
+function createMirrorIssue(title, body, execFile) {
+  const out = execFile(
+    "gh",
+    ["issue", "create", "--title", title, "--body", body],
+    GH_EXEC_DEFAULTS
+  );
+  const match = String(out).trim().match(/\/issues\/(\d+)\s*$/);
+  if (!match) {
+    throw new Error(`Failed to parse issue number from gh output: ${String(out).trim()}`);
+  }
+  return { number: Number(match[1]) };
+}
+
+function updateMirrorIssue(number, body, execFile) {
+  execFile("gh", ["issue", "edit", String(number), "--body", body], GH_EXEC_DEFAULTS);
+}
+
+// --- Core sync ---
+
+function sync({
+  backlogDir = DEFAULT_BACKLOG_DIR,
+  dryRun = false,
+  now = new Date(),
+  execFile = execFileSync,
+  sprintStatePath = SPRINT_STATE_PATH,
+} = {}) {
+  const state = resolveSprintState({ backlogDir, execFile, sprintStatePath });
+  const slug = path.basename(state.active_sprint.path, ".md");
+  const marker = makeMarker(slug);
+  const title = `Sprint mirror: ${slug}`;
+  const body = renderMirrorBody({ state, slug, now });
+
+  const existing = findMirrorIssue(marker, execFile);
+
+  if (dryRun) {
+    return {
+      action: "dry-run",
+      issue_number: existing ? existing.number : null,
+      sprint: slug,
+      marker,
+      body,
+    };
+  }
+
+  if (existing) {
+    updateMirrorIssue(existing.number, body, execFile);
+    return { action: "updated", issue_number: existing.number, sprint: slug, marker, body };
+  }
+
+  const created = createMirrorIssue(title, body, execFile);
+  return { action: "created", issue_number: created.number, sprint: slug, marker, body };
+}
+
+// --- Output ---
+
+function printResult(result) {
+  if (result.action === "dry-run") {
+    const verb = result.issue_number ? "update" : "create";
+    const ref = result.issue_number ? ` #${result.issue_number}` : "";
+    console.log(`[dry-run] Would ${verb}${ref} mirror for sprint ${result.sprint} (${result.marker})`);
+    console.log("");
+    console.log(result.body);
+    return;
+  }
+
+  if (result.action === "created") {
+    console.log(`Created sprint mirror issue #${result.issue_number} for ${result.sprint}.`);
+  } else {
+    console.log(`Updated sprint mirror issue #${result.issue_number} for ${result.sprint}.`);
+  }
+}
+
+// --- CLI ---
+
+function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+  if (parsed.error) {
+    console.error(parsed.error);
+    process.exit(1);
+  }
+  if (parsed.help) {
+    console.log(usage());
+    return;
+  }
+
+  try {
+    const result = sync({ backlogDir: parsed.backlogDir, dryRun: parsed.dryRun });
+
+    if (parsed.json) {
+      console.log(JSON.stringify({
+        action: result.action,
+        issue_number: result.issue_number,
+        sprint: result.sprint,
+        marker: result.marker,
+      }, null, 2));
+      return;
+    }
+
+    printResult(result);
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  usage,
+  makeMarker,
+  parseArgs,
+  resolveSprintState,
+  formatPointer,
+  formatPlanItem,
+  renderPlanSection,
+  renderProgressSection,
+  renderMirrorBody,
+  findMirrorIssue,
+  createMirrorIssue,
+  updateMirrorIssue,
+  sync,
+  printResult,
+};

--- a/skills/dev-backlog/scripts/sprint-mirror.test.js
+++ b/skills/dev-backlog/scripts/sprint-mirror.test.js
@@ -1,0 +1,361 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  makeMarker,
+  parseArgs,
+  resolveSprintState,
+  formatPointer,
+  formatPlanItem,
+  renderPlanSection,
+  renderProgressSection,
+  renderMirrorBody,
+  findMirrorIssue,
+  sync,
+} = require("./sprint-mirror.js");
+
+// --- Test fixtures ---
+
+function planItem(overrides = {}) {
+  return {
+    line: "- [ ] #1 Do the thing",
+    checkbox_state: " ",
+    state: "todo",
+    issue_number: 1,
+    title: "Do the thing",
+    batch_heading: null,
+    pr: null,
+    run_id: null,
+    branch: null,
+    unmoored: false,
+    ...overrides,
+  };
+}
+
+function sprintState(overrides = {}) {
+  return {
+    schema_version: 1,
+    active_sprint: {
+      path: "backlog/sprints/2026-07-sample-sprint.md",
+      frontmatter: { status: "active" },
+      goal: "Ship the thing.",
+    },
+    plan_items: [planItem()],
+    next_batch: null,
+    latest_progress: [{ line: "- 2026-07-04: Started.", date: "2026-07-04" }],
+    in_flight: [],
+    ...overrides,
+  };
+}
+
+/**
+ * Build a fake execFile that dispatches on whether the call targets
+ * sprint-state.js (node subprocess) or gh (GitHub CLI), matching the two
+ * subprocess boundaries sprint-mirror.js shells out to.
+ */
+function makeExecFile({
+  state = sprintState(),
+  stateThrows = null,
+  issues = [],
+  createdIssueNumber = 99,
+} = {}) {
+  const calls = [];
+  const execFile = (cmd, args) => {
+    calls.push({ cmd, args });
+
+    const isSprintStateCall = args.some((a) => String(a).includes("sprint-state.js"));
+    if (isSprintStateCall) {
+      if (stateThrows) throw stateThrows;
+      return JSON.stringify(state);
+    }
+
+    const joined = args.join(" ");
+    if (joined.includes("issue list")) return JSON.stringify(issues);
+    if (joined.includes("issue create")) return `https://github.com/owner/repo/issues/${createdIssueNumber}\n`;
+    if (joined.includes("issue edit")) return "";
+    return "[]";
+  };
+  return { execFile, calls };
+}
+
+// --- parseArgs ---
+
+describe("parseArgs", () => {
+  it("defaults to backlog dir with no flags", () => {
+    const parsed = parseArgs([]);
+    assert.deepEqual(parsed, { backlogDir: "backlog", dryRun: false, json: false });
+  });
+
+  it("parses backlog-dir, --dry-run, and --json together", () => {
+    const parsed = parseArgs(["custom-dir", "--dry-run", "--json"]);
+    assert.equal(parsed.backlogDir, "custom-dir");
+    assert.equal(parsed.dryRun, true);
+    assert.equal(parsed.json, true);
+  });
+
+  it("rejects unknown flags", () => {
+    const parsed = parseArgs(["--bogus"]);
+    assert.match(parsed.error, /Unknown argument/);
+  });
+
+  it("rejects a second positional argument", () => {
+    const parsed = parseArgs(["dir-one", "dir-two"]);
+    assert.match(parsed.error, /Unexpected argument/);
+  });
+});
+
+// --- makeMarker ---
+
+describe("makeMarker", () => {
+  it("embeds the sprint slug", () => {
+    assert.equal(
+      makeMarker("2026-07-sample-sprint"),
+      "<!-- dev-backlog:sprint-mirror sprint=2026-07-sample-sprint -->"
+    );
+  });
+});
+
+// --- resolveSprintState ---
+
+describe("resolveSprintState", () => {
+  it("invokes sprint-state.js with --mode status and the backlog dir", () => {
+    const { execFile, calls } = makeExecFile();
+    resolveSprintState({ backlogDir: "backlog", execFile });
+
+    assert.equal(calls.length, 1);
+    assert.ok(calls[0].args.some((a) => String(a).includes("sprint-state.js")));
+    assert.deepEqual(calls[0].args.slice(1), ["--mode", "status", "backlog"]);
+  });
+
+  it("returns the parsed state when there is exactly one active sprint", () => {
+    const { execFile } = makeExecFile();
+    const state = resolveSprintState({ execFile });
+    assert.equal(state.active_sprint.path, "backlog/sprints/2026-07-sample-sprint.md");
+  });
+
+  it("refuses when there is no active sprint", () => {
+    const { execFile } = makeExecFile({ state: { schema_version: 1, active_sprint: null } });
+    assert.throws(() => resolveSprintState({ execFile }), /No active sprint/);
+  });
+
+  it("refuses loudly when sprint-state.js fails (ambiguous active sprints)", () => {
+    const failure = new Error("Multiple active sprint files found");
+    failure.stderr = "Multiple active sprint files found:\n  a.md\n  b.md";
+    const { execFile } = makeExecFile({ stateThrows: failure });
+
+    assert.throws(
+      () => resolveSprintState({ execFile }),
+      /refusing to guess active sprint/
+    );
+  });
+
+  it("rejects an unsupported schema_version", () => {
+    const { execFile } = makeExecFile({ state: { ...sprintState(), schema_version: 2 } });
+    assert.throws(() => resolveSprintState({ execFile }), /Unsupported sprint-state schema_version/);
+  });
+
+  it("rejects invalid JSON from sprint-state.js", () => {
+    const execFile = () => "not json";
+    assert.throws(() => resolveSprintState({ execFile }), /invalid JSON/);
+  });
+});
+
+// --- formatPointer / formatPlanItem ---
+
+describe("formatPointer", () => {
+  it("renders a PR annotation", () => {
+    const item = planItem({ pr: { number: 42, state: "merged" } });
+    assert.equal(formatPointer(item), " — PR #42 (merged)");
+  });
+
+  it("renders a run-id-only annotation", () => {
+    const item = planItem({ run_id: "run-abc" });
+    assert.equal(formatPointer(item), " — run:run-abc");
+  });
+
+  it("renders a branch annotation", () => {
+    const item = planItem({ branch: "issue-42" });
+    assert.equal(formatPointer(item), " — branch issue-42");
+  });
+
+  it("renders unmoored items distinctly", () => {
+    const item = planItem({ state: "in_flight", checkbox_state: "~", unmoored: true });
+    assert.equal(formatPointer(item), " — (unmoored)");
+  });
+
+  it("renders nothing for a plain todo item", () => {
+    assert.equal(formatPointer(planItem()), "");
+  });
+});
+
+describe("formatPlanItem", () => {
+  it("combines checkbox state, issue number, title, and pointer", () => {
+    const item = planItem({ pr: { number: 7, state: "open" } });
+    assert.equal(formatPlanItem(item), "- [ ] #1 Do the thing — PR #7 (open)");
+  });
+});
+
+// --- renderPlanSection / renderProgressSection / renderMirrorBody ---
+
+describe("renderPlanSection", () => {
+  it("renders all plan item shapes without crashing", () => {
+    const items = [
+      planItem({ issue_number: 1, title: "PR item", pr: { number: 7, state: "merged" } }),
+      planItem({ issue_number: 2, title: "Run item", checkbox_state: "~", state: "in_flight", run_id: "run-1" }),
+      planItem({ issue_number: 3, title: "Unmoored item", checkbox_state: "~", state: "in_flight", unmoored: true }),
+      planItem({ issue_number: 4, title: "Plain item" }),
+    ];
+    const lines = renderPlanSection(items);
+    assert.ok(lines.some((l) => l.includes("PR #7 (merged)")));
+    assert.ok(lines.some((l) => l.includes("run:run-1")));
+    assert.ok(lines.some((l) => l.includes("(unmoored)")));
+    assert.ok(lines.some((l) => l === "- [ ] #4 Plain item"));
+  });
+
+  it("groups items under batch headings with separating blank lines", () => {
+    const items = [
+      planItem({ issue_number: 1, batch_heading: "### Batch 1" }),
+      planItem({ issue_number: 2, batch_heading: "### Batch 2" }),
+    ];
+    const lines = renderPlanSection(items);
+    assert.deepEqual(lines, [
+      "### Batch 1",
+      "- [ ] #1 Do the thing",
+      "",
+      "### Batch 2",
+      "- [ ] #2 Do the thing",
+    ]);
+  });
+
+  it("renders a placeholder for an empty plan", () => {
+    assert.deepEqual(renderPlanSection([]), ["_No plan items._"]);
+  });
+});
+
+describe("renderProgressSection", () => {
+  it("renders progress lines", () => {
+    const lines = renderProgressSection([{ line: "- 2026-07-04: Did the thing.", date: "2026-07-04" }]);
+    assert.deepEqual(lines, ["- 2026-07-04: Did the thing."]);
+  });
+
+  it("renders a placeholder for an empty progress list", () => {
+    assert.deepEqual(renderProgressSection([]), ["_No progress recorded yet._"]);
+    assert.deepEqual(renderProgressSection(undefined), ["_No progress recorded yet._"]);
+  });
+});
+
+describe("renderMirrorBody", () => {
+  it("renders marker, blockquote, goal, plan, progress, and sync footer without crashing", () => {
+    const state = sprintState({
+      plan_items: [
+        planItem({ issue_number: 1, title: "PR item", pr: { number: 7, state: "merged" } }),
+        planItem({ issue_number: 2, title: "Run item", run_id: "run-1" }),
+        planItem({ issue_number: 3, title: "Unmoored", checkbox_state: "~", state: "in_flight", unmoored: true }),
+      ],
+      latest_progress: [],
+    });
+    const body = renderMirrorBody({ state, slug: "2026-07-sample-sprint", now: new Date("2026-07-04T12:00:00Z") });
+
+    assert.ok(body.startsWith("<!-- dev-backlog:sprint-mirror sprint=2026-07-sample-sprint -->"));
+    assert.match(body, /read-only/);
+    assert.match(body, /Ship the thing\./);
+    assert.match(body, /No progress recorded yet\./);
+    assert.match(body, /Last explicit sync: 2026-07-04T12:00:00\.000Z/);
+  });
+});
+
+// --- findMirrorIssue ---
+
+describe("findMirrorIssue", () => {
+  it("matches the exact marker string in the body", () => {
+    const marker = "<!-- dev-backlog:sprint-mirror sprint=2026-07-sample-sprint -->";
+    const execFile = () => JSON.stringify([
+      { number: 1, body: "unrelated body" },
+      { number: 2, body: `${marker}\nrest of body` },
+    ]);
+    const issue = findMirrorIssue(marker, execFile);
+    assert.equal(issue.number, 2);
+  });
+
+  it("returns null when no issue matches", () => {
+    const execFile = () => JSON.stringify([{ number: 1, body: "unrelated" }]);
+    assert.equal(findMirrorIssue("<!-- dev-backlog:sprint-mirror sprint=none -->", execFile), null);
+  });
+});
+
+// --- sync (integration) ---
+
+describe("sync", () => {
+  it("creates a new mirror issue when none exists", () => {
+    const { execFile, calls } = makeExecFile({ issues: [], createdIssueNumber: 55 });
+    const result = sync({ execFile });
+
+    assert.equal(result.action, "created");
+    assert.equal(result.issue_number, 55);
+    assert.equal(result.sprint, "2026-07-sample-sprint");
+    assert.ok(calls.some((c) => c.args.join(" ").includes("issue create")));
+    assert.ok(!calls.some((c) => c.args.join(" ").includes("issue edit")));
+  });
+
+  it("updates the existing mirror issue found by marker (idempotent identity)", () => {
+    const marker = "<!-- dev-backlog:sprint-mirror sprint=2026-07-sample-sprint -->";
+    const { execFile, calls } = makeExecFile({
+      issues: [{ number: 7, body: `${marker}\nold body` }],
+    });
+    const result = sync({ execFile });
+
+    assert.equal(result.action, "updated");
+    assert.equal(result.issue_number, 7);
+    assert.ok(calls.some((c) => c.args.join(" ").includes("issue edit 7")));
+    assert.ok(!calls.some((c) => c.args.join(" ").includes("issue create")));
+  });
+
+  it("is idempotent across repeated runs against the same mirror issue", () => {
+    const marker = "<!-- dev-backlog:sprint-mirror sprint=2026-07-sample-sprint -->";
+    const { execFile } = makeExecFile({
+      issues: [{ number: 7, body: `${marker}\nold body` }],
+    });
+    const first = sync({ execFile });
+    const second = sync({ execFile });
+
+    assert.equal(first.issue_number, 7);
+    assert.equal(second.issue_number, 7);
+    assert.equal(first.action, "updated");
+    assert.equal(second.action, "updated");
+  });
+
+  it("refuses when sprint-state reports no active sprint", () => {
+    const { execFile } = makeExecFile({ state: { schema_version: 1, active_sprint: null } });
+    assert.throws(() => sync({ execFile }), /No active sprint/);
+  });
+
+  it("refuses when sprint-state.js fails on ambiguous active sprints", () => {
+    const failure = new Error("Multiple active sprint files found");
+    failure.stderr = "Multiple active sprint files found";
+    const { execFile } = makeExecFile({ stateThrows: failure });
+    assert.throws(() => sync({ execFile }), /refusing to guess active sprint/);
+  });
+
+  it("--dry-run performs no mutating gh commands", () => {
+    const { execFile, calls } = makeExecFile({ issues: [] });
+    const result = sync({ execFile, dryRun: true });
+
+    assert.equal(result.action, "dry-run");
+    assert.equal(result.issue_number, null);
+    assert.ok(result.body.length > 0);
+    assert.ok(!calls.some((c) => c.args.join(" ").includes("issue create")));
+    assert.ok(!calls.some((c) => c.args.join(" ").includes("issue edit")));
+  });
+
+  it("--dry-run reports the target issue number when a mirror already exists", () => {
+    const marker = "<!-- dev-backlog:sprint-mirror sprint=2026-07-sample-sprint -->";
+    const { execFile, calls } = makeExecFile({
+      issues: [{ number: 7, body: `${marker}\nold body` }],
+    });
+    const result = sync({ execFile, dryRun: true });
+
+    assert.equal(result.action, "dry-run");
+    assert.equal(result.issue_number, 7);
+    assert.ok(!calls.some((c) => c.args.join(" ").includes("issue create")));
+    assert.ok(!calls.some((c) => c.args.join(" ").includes("issue edit")));
+  });
+});


### PR DESCRIPTION
Implements the option-(c) mirror from the SSOT decision (charter Decision row 2026-07-03; spike #215): marker-identity body upsert reusing `sprint-state.js` as the single parser. Read-only mirror, explicit sync, refuses ambiguous active sprint state.

Fixes #231

## Implementation
- `sprint-mirror.js` (+ 32 tests, mocked gh): resolve state via `sprint-state.js --mode status` (schema_version gate, fail-loud on no/ambiguous active), `<!-- dev-backlog:sprint-mirror sprint=<slug> -->` marker identity, find-by-marker → body upsert, `--dry-run`/`--json`.
- One-line SKILL.md Useful-scripts entry (179/250 lines).

## Orchestrator verification (independent of executor self-report)
- Code review: single-parser delegation, argv-array `execFileSync` only, injectable execFile for tests, fail-loud paths — all per contract.
- Re-ran on rebased head: smoke 119/119, node tests 320/320 (32 new), `--dry-run` against the live active sprint renders Goal/batched Plan with pointers/Latest Progress correctly and performs no mutating gh call.
- Bonus: the #214 recovery gate caught a real trace-grammar violation during verification (prose branch pointer in the sprint file, fixed on main as `[branch:issue-231]`) — the executor's renderer surfaced it as `(unmoored)`, which is the designed behavior.

Implementation delegated to a sonnet subagent (worktree isolation); reviewed and verified by the orchestrating session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rHYVnPZmoRPGxFMJ2a9NB