### PR TITLE
fix(sprint-close): parse flags before backlog dir

### DIFF
--- a/skills/dev-backlog/scripts/smoke-test.sh
+++ b/skills/dev-backlog/scripts/smoke-test.sh
@@ -809,6 +809,42 @@ assert_contains "close dry-run: reassess verdict appears" "$OUT" "Reassess signa
 assert_contains "close dry-run: file unchanged" "$(grep '^status:' "$TEST_DIR/backlog/sprints/2026-03-auth.md")" "active"
 assert_equals "close dry-run: task not moved" "$(ls "$TEST_DIR/backlog/tasks/" | wc -l | tr -d ' ')" "3"
 
+# --- dry-run flag/order parsing tests ---
+set +e
+OUT=$(cd "$TEST_DIR" && bash "$SCRIPT_DIR/sprint-close.sh" --dry-run 2>&1)
+STATUS=$?
+set -e
+assert_equals "close dry-run flag-only: exit code" "$STATUS" "0"
+assert_contains "close dry-run flag-only: would set completed" "$OUT" "Would set status: completed"
+assert_contains "close dry-run flag-only: runs doctor" "$OUT" "=== Backlog Doctor (pre-close) ==="
+assert_contains "close dry-run flag-only: defaults to backlog" "$OUT" "backlog/sprints/2026-03-auth.md"
+assert_contains "close dry-run flag-only: file unchanged" "$(grep '^status:' "$TEST_DIR/backlog/sprints/2026-03-auth.md")" "active"
+
+set +e
+OUT=$(bash "$SCRIPT_DIR/sprint-close.sh" --dry-run "$TEST_DIR/backlog" 2>&1)
+STATUS=$?
+set -e
+assert_equals "close dry-run flag-first positional: exit code" "$STATUS" "0"
+assert_contains "close dry-run flag-first positional: would set completed" "$OUT" "Would set status: completed"
+assert_contains "close dry-run flag-first positional: runs doctor" "$OUT" "=== Backlog Doctor (pre-close) ==="
+assert_contains "close dry-run flag-first positional: file unchanged" "$(grep '^status:' "$TEST_DIR/backlog/sprints/2026-03-auth.md")" "active"
+
+set +e
+OUT=$(bash "$SCRIPT_DIR/sprint-close.sh" --bogus "$TEST_DIR/backlog" 2>&1)
+STATUS=$?
+set -e
+assert_equals "close unknown flag: exit code" "$STATUS" "1"
+assert_contains "close unknown flag: message" "$OUT" "Unknown argument: --bogus"
+assert_contains "close unknown flag: file unchanged" "$(grep '^status:' "$TEST_DIR/backlog/sprints/2026-03-auth.md")" "active"
+
+set +e
+OUT=$(bash "$SCRIPT_DIR/sprint-close.sh" "$TEST_DIR/backlog" "$TEST_DIR/other-backlog" --dry-run 2>&1)
+STATUS=$?
+set -e
+assert_equals "close extra positional: exit code" "$STATUS" "1"
+assert_contains "close extra positional: message" "$OUT" "Unexpected argument: $TEST_DIR/other-backlog"
+assert_contains "close extra positional: file unchanged" "$(grep '^status:' "$TEST_DIR/backlog/sprints/2026-03-auth.md")" "active"
+
 # --- actual close ---
 OUT=$(bash "$SCRIPT_DIR/sprint-close.sh" "$TEST_DIR/backlog" 2>&1)
 assert_contains "close: set completed" "$OUT" "status: completed"

--- a/skills/dev-backlog/scripts/sprint-close.sh
+++ b/skills/dev-backlog/scripts/sprint-close.sh
@@ -14,14 +14,27 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib.sh"
 
-BACKLOG_DIR="${1:-backlog}"
+BACKLOG_DIR="backlog"
 DRY_RUN=false
 CLOSE_MILESTONE=false
+BACKLOG_DIR_SET=false
 
 for arg in "$@"; do
   case "$arg" in
     --dry-run) DRY_RUN=true ;;
     --close-milestone) CLOSE_MILESTONE=true ;;
+    --*)
+      echo "Unknown argument: $arg"
+      exit 1
+      ;;
+    *)
+      if $BACKLOG_DIR_SET; then
+        echo "Unexpected argument: $arg"
+        exit 1
+      fi
+      BACKLOG_DIR="$arg"
+      BACKLOG_DIR_SET=true
+      ;;
   esac
 done
 


### PR DESCRIPTION
## Dispatch Summary

```text
Implemented and committed as `e6508f7 fix(sprint-close): parse flags before backlog dir` with `Fixes #247`.

Changed [sprint-close.sh](/Users/sjlee/.relay/worktrees/f405d17a/dev-backlog/skills/dev-backlog/scripts/sprint-close.sh:17) to parse flags position-independently, default to `backlog`, reject unknown `--*` flags, and reject extra positional args. Added smoke coverage in [smoke-test.sh](/Users/sjlee/.relay/worktrees/f405d17a/dev-backlog/skills/dev-backlog/scripts/smoke-test.sh:812) for fla
```

## Score Log

- Run: issue-247-20260705054603535-f8fa8f1d
- Executor: codex
- Branch: issue-247