### PR TITLE
docs: add cold-adopter charter objective

### DIFF
--- a/spec/charter.md
+++ b/spec/charter.md
@@ -1,6 +1,6 @@
 ---
-last_amended: 2026-07-05
-revision: 6
+last_amended: 2026-07-07
+revision: 7
 ---
 
 # dev-backlog Charter
@@ -38,6 +38,7 @@ No server, no daemon, no hidden state, no silent sync.
 - O4 [validated] Open-issue drift (orphan work, neglected objectives, contradictions) is detectable without manual triage · src: user (proof: backlog-doctor PR #226 + sprint-close signal PR #229; live automatic catches 2026-07-03/04 — deferred-O5 objective reference at sprint open, unmoored `[~]` signals at close)
 - O5 [validated] Closing a sprint runs `backlog-doctor`; when doctor emits warnings or 3+ sprints have closed since the last dated reassess report (`backlog/triage/YYYY-MM-DD-reassess.md`), the close summary recommends `spec-charter reassess`. Report-only: unattended sessions may run reassess but never amend · src: user (proof: first full cycle 2026-07-04 — close signal → `backlog/triage/2026-07-04-reassess.md` → human-gated amend revision 5)
 - O6 [deferred]  `/goal` completion-condition auto-emission from `spec/charter.md` + active sprint — deferred to a follow-up spec
+- O7 [validated] A repo with no craftkit and no `spec/` files can complete a full sprint cycle from this bundle alone, with no dangling cross-repo spec pointers · src: user (proof: adoption-hardening milestone #12 closed 14/14 on 2026-07-07; PRD §8 candidate measured by V1 cold-adopter gates)
 
 ## Decisions          <!-- Tier 3 · History (immutable, append-only) -->
 | date       | decision                                                                              | rationale                                                                                        | supersedes |


### PR DESCRIPTION
## Summary
- add validated charter Objective O7 for cold-adopter portability
- bump charter amendment date/revision to record the human-gated spec-charter amendment
- point proof at adoption-hardening milestone #12 and PRD §8/V1 gates

## Verification
- `node skills/dev-backlog/scripts/objectives-check.js`
- `node skills/dev-backlog/scripts/backlog-doctor.js --json`
- `node --test skills/*/scripts/*.test.js` (431 pass / 0 fail / 1 skip)
- `bash skills/dev-backlog/scripts/smoke-test.sh` (141/141)
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * `spec/charter`의 메타데이터가 최신 상태로 갱신되었습니다.
  * 새로운 목표가 추가되어, 번들만으로도 전체 스프린트 사이클을 완료하고 외부 spec 참조가 남지 않도록 기준이 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->