### PR TITLE
Document sprint batch wave semantics

### DIFF
--- a/skills/dev-backlog/SKILL.md
+++ b/skills/dev-backlog/SKILL.md
@@ -91,7 +91,7 @@ Done when the new issue exists on GitHub, has a local task mirror, and is added 
 
 1. Resolve Objectives from `spec/charter.md`; fall back to legacy root `CHARTER.md`; omit the `objectives:` field entirely when both are absent (see `references/spec-fallback.md`).
 2. Pull/inspect open issues and assign the sprint milestone when applicable.
-3. Create one active sprint file with Goal, ordered Plan batches, estimates, dependencies, `objectives:`, and `component:`.
+3. Create one active sprint file with Goal, ordered Plan batches, estimates, dependencies, `objectives:`, and `component:`. Plan batches are execution waves: intra-batch items MUST be mutually parallel-safe (disjoint files, no ordering between them), dependent items MUST go in a later batch, and batch order is execution order.
 4. Refuse to create a second active sprint until the previous one is completed.
 
 Done when the sprint file is the single active execution hub and each planned issue has a clear batch position.

--- a/skills/dev-backlog/references/integration-contract.md
+++ b/skills/dev-backlog/references/integration-contract.md
@@ -71,6 +71,10 @@ Top-level schema:
 | `heading` | string or `null` | The first `### Batch...` heading containing unchecked `[ ]` work, or `null` for flat plans. |
 | `items` | array | The unchecked `plan_items` in that batch. For flat plans, all unchecked items. |
 
+### `next_batch` Batch Semantics
+
+Plan mode guarantees batch-as-wave semantics: items in one batch MUST be mutually parallel-safe (disjoint files, no ordering between them), dependent items MUST appear in a later batch, and batch order is execution order. A machine consumer, such as relay-fleet fan-out, MAY treat all `state:todo` items in `next_batch.items` as concurrently dispatchable under that guarantee.
+
 `latest_progress[]` entries are objects with:
 
 | Field | Type | Meaning |

--- a/skills/dev-backlog/references/workflow-patterns.md
+++ b/skills/dev-backlog/references/workflow-patterns.md
@@ -11,7 +11,7 @@ Common patterns for GitHub Issues + sprint file workflow.
 5. **Pull to local** — sync milestone issues to `backlog/tasks/`
 6. **Create sprint file** — run `./scripts/sprint-init.js "auth-system" --milestone "Sprint W13"` or write manually:
    - Set Goal (one sentence)
-   - Order issues into Batches (group small tasks for one session)
+   - Order issues into Batches (parallel-safe waves sized for one session)
    - Estimate time per task
    - Note dependencies
 
@@ -42,7 +42,7 @@ Two files at most, full picture. No need to query GitHub unless you suspect chan
 
 ## Working a Batch
 
-Small tasks grouped in one session:
+Each batch is one execution wave. Group by parallel-safety first, then session size: items in the same batch have disjoint files and no ordering dependency, while dependent work belongs in a later batch. Batch-heading prose suffixes such as `(after #211 and #212)` remain permitted as human documentation, not machine-readable grammar.
 
 1. Read sprint file → find the batch
 2. Start first task → update GitHub label → read task file AC → do the work

--- a/skills/dev-backlog/scripts/sprint-init.js
+++ b/skills/dev-backlog/scripts/sprint-init.js
@@ -88,7 +88,7 @@ ${specBlock}---
 [One sentence: what's true when this sprint is done]
 
 ## Plan
-[Order into batches. Group small tasks (~30min or less) for one session.]
+[Order into parallel-safe batches. Group small tasks (~30min or less) for one session only when they can run in the same wave.]
 
 ${issueLines.join("\n")}
 


### PR DESCRIPTION
## Dispatch Summary

```text
Committed `a10ef75` (`Document sprint batch wave semantics`). Worktree is clean.

**Completion Audit**
- [SKILL.md](/Users/sjlee/.relay/worktrees/cded554a/dev-backlog/skills/dev-backlog/SKILL.md:94): plan-mode now defines batches as execution waves with all three required clauses and `parallel-safe`.
- [integration-contract.md](/Users/sjlee/.relay/worktrees/cded554a/dev-backlog/skills/dev-backlog/references/integration-contract.md:74): `next_batch` machine-consumer semantics added, naming relay-
```

## Score Log

- Run: issue-267-20260708134842132-3a7801a4
- Executor: codex
- Branch: issue-267