### PR TITLE
chore: open tracker seam sprint

### DIFF
--- a/backlog/sprints/2026-07-tracker-seam.md
+++ b/backlog/sprints/2026-07-tracker-seam.md
@@ -1,0 +1,38 @@
+---
+milestone: 2026-07 tracker adapter foundation
+status: active
+started: 2026-07-11
+due: 2026-07-15
+objectives: [O8, O9]
+component: "tracker-task-truth"
+---
+
+# Tracker Seam and GitHub Compatibility
+
+## Goal
+Existing GitHub users retain compatible behavior while core sprint execution gains an explicit, capability-gated tracker seam and stable tracker-neutral task identity.
+
+## Plan
+
+### Batch 1 - Freeze the deep interface
+- [ ] #272 Inventory GitHub coupling and freeze the tracker contract (~1hr)
+
+### Batch 2 - Add explicit tracker resolution (after #272)
+- [ ] #273 Add configured tracker selection and the core adapter seam (~2hr)
+
+### Batch 3 - Generalize task identity (after #273)
+- [ ] #274 Add backward-compatible tracker-neutral task references (~2hr)
+
+### Batch 4 - Preserve GitHub behind the seam (after #273 and #274)
+- [ ] #275 Move existing GitHub behavior behind the tracker adapter (~3hr)
+
+## Running Context
+- #270 was accepted with narrowing and closed by spec amendment PR #271.
+- Runtime selection is persistent and fail-closed. Detection may suggest only during setup; it never changes an existing tracker selection.
+- The tracker module must be deep: required lifecycle and identity stay small; milestones, PR relationships, mirrors, progress issues, comments, and closing semantics remain capability-gated.
+- Existing GitHub markdown, CLI, JSON, and helper exports are compatibility surfaces. Additive normalized fields must not remove `issue_number` or rewrite historical sprints.
+- Sprint A is deliberately serial because #273-#275 share the tracker resolver, sprint parser, and GitHub call sites. Sprint B starts only after GitHub regression proof merges.
+
+## Progress
+- 2026-07-11: #270 accepted-with-narrowing recorded and spec PR #271 merged after three independent review rounds; Milestone 13 and issues #272-#278 created.
+- 2026-07-11: Sprint A opened with four serial execution waves; task mirrors refreshed from live GitHub state.

--- a/backlog/tasks/BACK-272 - design-inventory-github-coupling-and-freeze-tracker-contract.md
+++ b/backlog/tasks/BACK-272 - design-inventory-github-coupling-and-freeze-tracker-contract.md
@@ -41,4 +41,3 @@ Freeze the smallest deep tracker module interface, its capability model, and the
 - Changing existing runtime output.
 
 Parent: #270
-

--- a/backlog/tasks/BACK-272 - design-inventory-github-coupling-and-freeze-tracker-contract.md
+++ b/backlog/tasks/BACK-272 - design-inventory-github-coupling-and-freeze-tracker-contract.md
@@ -1,0 +1,44 @@
+---
+id: BACK-272
+title: 'design: inventory GitHub coupling and freeze tracker contract'
+status: To Do
+labels:
+  - enhancement
+priority: medium
+milestone: 2026-07 tracker adapter foundation
+created_date: '2026-07-11'
+---
+## Description
+## Context
+
+Issue #270 and PR #271 accepted one explicitly configured canonical tracker per repository, initially `github` and `local`. Runtime work must begin with an evidence-backed inventory because GitHub identity and `gh` calls are spread across sprint parsing, sync, progress, mirrors, closeout, and triage.
+
+## Goal
+
+Freeze the smallest deep tracker module interface, its capability model, and the backward-compatibility matrix before runtime extraction begins.
+
+## Suggested Direction
+
+- inventory every direct GitHub call and numeric issue-ID assumption by caller
+- separate required task lifecycle from optional forge capabilities
+- define normalized task identity (`tracker`, stable `id`, display `ref`, optional URL)
+- define configuration, availability, unsupported-capability, and no-fallback errors
+- record the compatibility matrix for existing CLI, markdown, JSON, and exported helper surfaces
+
+## Acceptance Criteria
+
+- [ ] A durable design reference inventories direct `gh` coupling and numeric `#N` assumptions with current owning callers.
+- [ ] The required tracker interface contains only list/read/create/update/close, stable identity/link data, availability probing, and capability reporting.
+- [ ] Optional milestones, PR relationships, mirrors, progress issues, comments, and close-keyword behavior are capability-gated rather than required.
+- [ ] The compatibility matrix names every existing GitHub CLI, markdown, JSON, and exported helper surface that must remain stable.
+- [ ] Runtime selection is explicitly persistent and fail-closed; detection is setup-only and never causes a silent adapter switch.
+- [ ] The design passes `git diff --check` and relevant spec/component validation.
+
+## Non-Goals
+
+- Implementing an adapter.
+- Adding GitLab, Gitea, or Forgejo.
+- Changing existing runtime output.
+
+Parent: #270
+

--- a/backlog/tasks/BACK-273 - feat-add-configured-tracker-selection-and-core-adapter-seam.md
+++ b/backlog/tasks/BACK-273 - feat-add-configured-tracker-selection-and-core-adapter-seam.md
@@ -34,4 +34,3 @@ Add explicit tracker configuration, fail-closed resolution, capability reporting
 - Adding setup automation.
 
 Depends on #272. Parent: #270.
-

--- a/backlog/tasks/BACK-273 - feat-add-configured-tracker-selection-and-core-adapter-seam.md
+++ b/backlog/tasks/BACK-273 - feat-add-configured-tracker-selection-and-core-adapter-seam.md
@@ -1,0 +1,37 @@
+---
+id: BACK-273
+title: 'feat: add configured tracker selection and core adapter seam'
+status: To Do
+labels:
+  - enhancement
+priority: medium
+milestone: 2026-07 tracker adapter foundation
+created_date: '2026-07-11'
+---
+## Description
+## Context
+
+#272 freezes the tracker contract and compatibility matrix. The first runtime slice must add a real seam with two eventual adapters without changing existing GitHub behavior.
+
+## Goal
+
+Add explicit tracker configuration, fail-closed resolution, capability reporting, and a small adapter interface that core callers can consume.
+
+## Acceptance Criteria
+
+- [ ] `backlog/config.yml` supports exactly one explicit tracker value: `github` or `local`.
+- [ ] Existing configurations without the new key retain GitHub behavior through a documented compatibility default; runtime never selects based on transient auth failure.
+- [ ] One tracker resolver returns the selected adapter or an actionable configuration/availability error.
+- [ ] The adapter interface matches #272 and exposes provider capabilities without optional forge semantics in the required method set.
+- [ ] A GitHub adapter and local adapter slot both satisfy the interface contract, even if later issues complete their implementations.
+- [ ] Unit tests cover valid selection, invalid selection, missing configuration compatibility, unavailable provider, and no silent fallback.
+- [ ] Existing exported helper contracts remain available or have explicit compatibility shims.
+
+## Non-Goals
+
+- Moving every GitHub caller in this issue.
+- Implementing local task persistence.
+- Adding setup automation.
+
+Depends on #272. Parent: #270.
+

--- a/backlog/tasks/BACK-274 - feat-add-backward-compatible-tracker-neutral-task-references.md
+++ b/backlog/tasks/BACK-274 - feat-add-backward-compatible-tracker-neutral-task-references.md
@@ -33,4 +33,3 @@ Introduce tracker-neutral task references and additive JSON identity while prese
 - Implementing tracker persistence.
 
 Depends on #272 and coordinates with #273. Parent: #270.
-

--- a/backlog/tasks/BACK-274 - feat-add-backward-compatible-tracker-neutral-task-references.md
+++ b/backlog/tasks/BACK-274 - feat-add-backward-compatible-tracker-neutral-task-references.md
@@ -1,0 +1,36 @@
+---
+id: BACK-274
+title: 'feat: add backward-compatible tracker-neutral task references'
+status: To Do
+labels:
+  - enhancement
+priority: medium
+milestone: 2026-07 tracker adapter foundation
+created_date: '2026-07-11'
+---
+## Description
+## Context
+
+Sprint plan parsing, progress matching, mirrors, and JSON currently assume numeric GitHub references such as `#42` and `issue_number`. Local canonical tasks need stable `BACK-42`-style references without breaking existing consumers.
+
+## Goal
+
+Introduce tracker-neutral task references and additive JSON identity while preserving every existing GitHub markdown and JSON contract.
+
+## Acceptance Criteria
+
+- [ ] The sprint parser accepts legacy GitHub `#N` references and local canonical `{PREFIX}-N` references without ambiguous partial matches.
+- [ ] Machine state adds normalized tracker/task identity fields while retaining `issue_number` unchanged for GitHub entries.
+- [ ] Existing GitHub sprint markdown renders byte-for-byte compatible plan references unless a caller opts into normalized fields.
+- [ ] Progress age matching, exact task-file lookup, next-batch grouping, mirror rendering, and closeout use one normalized task-ref implementation.
+- [ ] Tests cover `#1` vs `#11`, `BACK-1` vs `BACK-11`, decimal subtask IDs where supported, invalid refs, and mixed legacy fixtures.
+- [ ] The actor integration contract documents additive fields, compatibility aliases, and local reference grammar.
+
+## Non-Goals
+
+- Rewriting historical sprint files.
+- Removing `issue_number`.
+- Implementing tracker persistence.
+
+Depends on #272 and coordinates with #273. Parent: #270.
+

--- a/backlog/tasks/BACK-275 - refactor-move-existing-github-behavior-behind-the-tracker-adapter.md
+++ b/backlog/tasks/BACK-275 - refactor-move-existing-github-behavior-behind-the-tracker-adapter.md
@@ -1,0 +1,37 @@
+---
+id: BACK-275
+title: 'refactor: move existing GitHub behavior behind the tracker adapter'
+status: To Do
+labels:
+  - enhancement
+priority: medium
+milestone: 2026-07 tracker adapter foundation
+created_date: '2026-07-11'
+---
+## Description
+## Context
+
+After #273 and #274 establish the seam and identity contract, existing GitHub behavior must move behind the adapter with no intended user-visible change.
+
+## Goal
+
+Make the GitHub adapter the sole owner of canonical GitHub task operations and provider capabilities while preserving current commands, output, and mutation safety.
+
+## Acceptance Criteria
+
+- [ ] Core task lifecycle callers no longer invoke `gh` directly; GitHub task calls live behind the adapter seam.
+- [ ] `sync-pull`, sprint planning from milestones, status/orientation, task creation/update/close, and closeout retain current behavior and messages.
+- [ ] Optional milestone, PR relationship, sprint mirror, progress issue, and comment behavior is exposed only through declared GitHub capabilities or explicitly GitHub-scoped modules.
+- [ ] Existing public helper exports and dependency-injection test seams remain compatible.
+- [ ] Golden regression fixtures cover current GitHub command argv, markdown task files, sprint plan lines, and JSON output.
+- [ ] No human-authored GitHub content can be overwritten beyond existing marker-gated behavior.
+- [ ] Full Node tests, smoke tests, and GitHub-mocked CLI tests pass.
+
+## Non-Goals
+
+- Local task persistence.
+- Tracker-neutral triage beyond consuming the core list/read surface.
+- New GitHub features.
+
+Depends on #273 and #274. Parent: #270.
+

--- a/backlog/tasks/BACK-275 - refactor-move-existing-github-behavior-behind-the-tracker-adapter.md
+++ b/backlog/tasks/BACK-275 - refactor-move-existing-github-behavior-behind-the-tracker-adapter.md
@@ -34,4 +34,3 @@ Make the GitHub adapter the sole owner of canonical GitHub task operations and p
 - New GitHub features.
 
 Depends on #273 and #274. Parent: #270.
-

--- a/backlog/tasks/BACK-276 - feat-add-offline-local-canonical-task-adapter.md
+++ b/backlog/tasks/BACK-276 - feat-add-offline-local-canonical-task-adapter.md
@@ -1,0 +1,37 @@
+---
+id: BACK-276
+title: 'feat: add offline local canonical task adapter'
+status: To Do
+labels:
+  - enhancement
+priority: medium
+milestone: 2026-07 tracker adapter foundation
+created_date: '2026-07-11'
+---
+## Description
+## Context
+
+The accepted direction requires local Backlog.md-compatible task files to act as canonical task truth, not as fake GitHub mirrors. This starts only after the core seam and task-reference contract are stable.
+
+## Goal
+
+Implement an offline local adapter that completes canonical task lifecycle and the core sprint cycle without `gh`, a network, or provider-only semantics.
+
+## Acceptance Criteria
+
+- [ ] Local list/read/create/update/close operations work against Backlog.md-compatible `backlog/tasks/` and `backlog/completed/` files.
+- [ ] ID allocation is deterministic, collision-safe, prefix-aware, and preserves existing decimal subtask compatibility.
+- [ ] Create and update preserve human-authored descriptions and AC checkbox state; close archives the exact task atomically.
+- [ ] Local plan/work/complete uses normalized task refs and does not invoke `gh` or require GitHub authentication.
+- [ ] Unsupported milestone, PR relationship, mirror, progress issue, comment, and close-keyword operations return actionable capability errors.
+- [ ] Offline integration tests run with `gh` absent from `PATH` and prove create → plan → read/work state → complete/archive.
+- [ ] Concurrent or duplicate ID allocation fails safely rather than overwriting a task.
+
+## Non-Goals
+
+- Bidirectional local/GitHub synchronization.
+- Reimplementing Backlog.md CLI.
+- GitLab/Gitea/Forgejo adapters.
+
+Depends on #273 and #274; begins after GitHub regression proof in #275. Parent: #270.
+

--- a/backlog/tasks/BACK-276 - feat-add-offline-local-canonical-task-adapter.md
+++ b/backlog/tasks/BACK-276 - feat-add-offline-local-canonical-task-adapter.md
@@ -34,4 +34,3 @@ Implement an offline local adapter that completes canonical task lifecycle and t
 - GitLab/Gitea/Forgejo adapters.
 
 Depends on #273 and #274; begins after GitHub regression proof in #275. Parent: #270.
-

--- a/backlog/tasks/BACK-277 - feat-add-idempotent-tracker-aware-setup-dev-backlog.md
+++ b/backlog/tasks/BACK-277 - feat-add-idempotent-tracker-aware-setup-dev-backlog.md
@@ -34,4 +34,3 @@ Add idempotent `setup-dev-backlog` behavior that initializes or repairs the mini
 - Runtime auto-detection on every command.
 
 Depends on #273 and #276. Parent: #270.
-

--- a/backlog/tasks/BACK-277 - feat-add-idempotent-tracker-aware-setup-dev-backlog.md
+++ b/backlog/tasks/BACK-277 - feat-add-idempotent-tracker-aware-setup-dev-backlog.md
@@ -1,0 +1,37 @@
+---
+id: BACK-277
+title: 'feat: add idempotent tracker-aware setup-dev-backlog'
+status: To Do
+labels:
+  - enhancement
+priority: medium
+milestone: 2026-07 tracker adapter foundation
+created_date: '2026-07-11'
+---
+## Description
+## Context
+
+Tracker selection must be explicit and persistent. Detection may propose a safe initial value during setup but runtime must never change the configured tracker because a remote, CLI, or credential is temporarily unavailable.
+
+## Goal
+
+Add idempotent `setup-dev-backlog` behavior that initializes or repairs the minimum backlog structure and records one deliberate tracker choice without overwriting user state.
+
+## Acceptance Criteria
+
+- [ ] Setup accepts an explicit `--tracker github|local` selection and persists it in `backlog/config.yml`.
+- [ ] Without an explicit selection, setup may recommend GitHub only when a usable GitHub remote and authenticated `gh` are detected; otherwise it recommends local and reports the evidence.
+- [ ] Non-interactive mode requires an explicit tracker or a documented deterministic default and never switches an existing selection.
+- [ ] Re-running setup is byte-idempotent when configuration and directories are already valid.
+- [ ] Existing config keys, task files, sprint files, and user-authored content are preserved.
+- [ ] Invalid configuration and unavailable selected providers produce actionable repair instructions.
+- [ ] Tests cover fresh GitHub, fresh local, rerun, partial structure, invalid tracker, missing `gh`, unauthenticated `gh`, and changed remote.
+
+## Non-Goals
+
+- Rewriting AGENTS.md or CLAUDE.md.
+- Installing provider CLIs.
+- Runtime auto-detection on every command.
+
+Depends on #273 and #276. Parent: #270.
+

--- a/backlog/tasks/BACK-278 - test-prove-github-and-local-core-sprint-cycles-end-to-end.md
+++ b/backlog/tasks/BACK-278 - test-prove-github-and-local-core-sprint-cycles-end-to-end.md
@@ -1,0 +1,38 @@
+---
+id: BACK-278
+title: 'test: prove github and local core sprint cycles end to end'
+status: To Do
+labels:
+  - enhancement
+priority: medium
+milestone: 2026-07 tracker adapter foundation
+created_date: '2026-07-11'
+---
+## Description
+## Context
+
+O8 is not satisfied by adapters merely existing. The release needs executable proof that the same core sprint cycle works in GitHub and local modes, that legacy GitHub users do not migrate, and that unsupported features degrade explicitly.
+
+## Goal
+
+Ship a deterministic dual-mode acceptance harness, upgrade documentation, and final contract alignment for the tracker foundation milestone.
+
+## Acceptance Criteria
+
+- [ ] One acceptance matrix runs the core create → plan → orient/read → work-state → complete cycle in both `github` and `local` fixtures.
+- [ ] The GitHub fixture proves legacy config, `#N`, `issue_number`, command argv, task mirrors, milestones, sprint mirror, and progress behavior remain compatible.
+- [ ] The local fixture runs offline with `gh` absent and proves canonical task creation, normalized sprint refs, state reads, and archive-on-close.
+- [ ] Unsupported local capabilities have deterministic non-zero/error JSON and user-facing remediation text.
+- [ ] README, SKILL.md, file-format, process, integration contract, and script inventory consistently document tracker selection and mode-specific behavior without duplicating implementation detail.
+- [ ] Upgrade notes state that existing repositories remain GitHub-backed until explicitly changed and that no automatic multi-tracker migration exists.
+- [ ] Full Node tests, smoke tests, spec validators, skill discovery, and `git diff --check` pass.
+- [ ] O2/O9 and O8 status changes are proposed only with matching merged/runtime proof; no objective is declared validated early.
+
+## Non-Goals
+
+- Tracker-neutral `shape` publication.
+- GitLab/Gitea/Forgejo.
+- Generic provider parity beyond declared capabilities.
+
+Depends on #275, #276, and #277. Parent: #270.
+

--- a/backlog/tasks/BACK-278 - test-prove-github-and-local-core-sprint-cycles-end-to-end.md
+++ b/backlog/tasks/BACK-278 - test-prove-github-and-local-core-sprint-cycles-end-to-end.md
@@ -35,4 +35,3 @@ Ship a deterministic dual-mode acceptance harness, upgrade documentation, and fi
 - Generic provider parity beyond declared capabilities.
 
 Depends on #275, #276, and #277. Parent: #270.
-


### PR DESCRIPTION
## Summary

- mirror implementation issues #272-#278 into local task files
- open the single active Sprint A for #272-#275
- route the sprint to O8/O9 and `tracker-task-truth`
- record serial batch dependencies and the accepted compatibility constraints

## Validation

- `objectives-check.js --json`
- `component-lint.js --json`
- `backlog-doctor.js --json`
- `status.sh --json`
- `next.sh --json`
- `git diff --check`

This PR establishes execution state only. It does not implement tracker runtime behavior.
