### PR TITLE
feat: add configured tracker runtime seam

### DIFF
--- a/backlog/config.yml
+++ b/backlog/config.yml
@@ -1,4 +1,5 @@
 project_name: "dev-backlog"
+tracker: github
 default_status: "To Do"
 statuses: ["To Do", "In Progress", "Done"]
 task_prefix: "BACK"

--- a/docs/tracker-adapter-design.md
+++ b/docs/tracker-adapter-design.md
@@ -1,13 +1,31 @@
 # Tracker Adapter Design Contract
 
 Status: accepted target design for issue #272. Runtime evidence was inventoried
-at commit `019a6ec`; the adapter design described below is not yet implemented.
-GitHub is the compatibility baseline for issues #273-#275.
+at commit `019a6ec`. Issue #273 now implements only the configured runtime seam
+described below; GitHub caller wiring (#275) and local persistence (#276) remain
+future work. GitHub is the compatibility baseline for issues #273-#275.
 
-This document freezes the smallest tracker boundary that can support another
-canonical task store without weakening existing GitHub behavior. It does not
-configure a tracker, implement an adapter, persist local tasks, change setup,
-or alter any command, Markdown, JSON, helper export, sprint, or task mirror.
+This document froze the smallest tracker boundary that can support another
+canonical task store without weakening existing GitHub behavior. The #272
+freeze itself did not configure a tracker or implement an adapter; the #273
+state is recorded separately below. Neither issue persists local tasks, changes
+setup, or alters command, Markdown, JSON, sprint, or task-mirror behavior.
+
+## Runtime Seam State (#273)
+
+`backlog/config.yml` selects one `tracker`, initially `github` or `local`.
+Repositories without that key use `github` as a deterministic compatibility
+default. Selection reads only the supplied configuration value: it performs no
+CLI, authentication, remote, adapter, or filesystem detection.
+
+`skills/dev-backlog/scripts/tracker.js` owns selection, exact adapter-shape and
+identity validation, configured-only availability probing, and optional
+capability gates. An unavailable or throwing configured adapter fails with no
+probe or fallback to the other slot. The GitHub slot declares the accepted
+capabilities, but existing GitHub command transports and injection seams remain
+where they are until #275; no current caller has moved. The local slot reports
+one implementation-pending reason and fails all lifecycle calls consistently
+until #276 adds persistence. This seam does not make local task files canonical.
 
 ## Current Runtime Evidence
 

--- a/skills/dev-backlog/references/file-format.md
+++ b/skills/dev-backlog/references/file-format.md
@@ -103,12 +103,21 @@ Sprint files (`backlog/sprints/*.md`) carry `objectives:` and `component:` along
 
 ```yaml
 project_name: "my-project"
+tracker: github
 task_prefix: "BACK"
 default_status: "To Do"
 statuses: ["To Do", "In Progress", "Done"]
 ```
 
-dev-backlog reads `task_prefix`, `default_status`, and `statuses`; `project_name` is retained as metadata. Other Backlog.md config fields are not consumed by dev-backlog.
+`tracker` accepts only `github` or `local`. A missing key deterministically
+defaults to `github`; runtime availability never changes that selection or
+falls back to the other adapter. The `local` adapter is intentionally
+unavailable until #276 implements persistence, and existing GitHub callers are
+not moved behind the seam until #275.
+
+dev-backlog also reads `task_prefix`, `default_status`, and `statuses`;
+`project_name` is retained as metadata. Other Backlog.md config fields are not
+consumed by dev-backlog.
 
 ## Sub-tasks
 

--- a/skills/dev-backlog/scripts/lib.js
+++ b/skills/dev-backlog/scripts/lib.js
@@ -28,6 +28,7 @@ const GH_EXEC_DEFAULTS = {
 };
 
 const CONFIG_DEFAULTS = {
+  tracker: "github",
   task_prefix: "BACK",
   default_status: "To Do",
   statuses: ["To Do", "In Progress", "Done"],

--- a/skills/dev-backlog/scripts/lib.test.js
+++ b/skills/dev-backlog/scripts/lib.test.js
@@ -137,8 +137,19 @@ describe("readConfig", () => {
 
   it("returns defaults when config file is missing", () => {
     const config = readConfig(path.join(tmpDir, "nonexistent"));
+    assert.equal(config.tracker, "github");
     assert.equal(config.task_prefix, CONFIG_DEFAULTS.task_prefix);
     assert.equal(config.default_status, CONFIG_DEFAULTS.default_status);
+  });
+
+  it("reads an explicit tracker while preserving the github compatibility default", () => {
+    fs.writeFileSync(path.join(tmpDir, "config.yml"), "tracker: local\n");
+    assert.equal(readConfig(tmpDir).tracker, "local");
+
+    fs.writeFileSync(path.join(tmpDir, "config.yml"), 'task_prefix: "PROJ"\n');
+    const compatibilityConfig = readConfig(tmpDir);
+    assert.equal(compatibilityConfig.tracker, "github");
+    assert.equal(compatibilityConfig.task_prefix, "PROJ");
   });
 
   it("reads task_prefix from valid config", () => {

--- a/skills/dev-backlog/scripts/tracker.js
+++ b/skills/dev-backlog/scripts/tracker.js
@@ -1,0 +1,312 @@
+/**
+ * Configured tracker boundary.
+ *
+ * Selection is configuration-only. Availability can reject the configured
+ * adapter, but it can never choose a different one.
+ */
+
+const TRACKER_KEYS = Object.freeze(["github", "local"]);
+const REQUIRED_ADAPTER_OPERATIONS = Object.freeze([
+  "availability",
+  "capabilities",
+  "list",
+  "read",
+  "create",
+  "update",
+  "close",
+]);
+const CAPABILITY_NAMES = Object.freeze([
+  "milestones",
+  "pull-request-relationships",
+  "mirrors",
+  "progress-issues",
+  "comments",
+  "closing-semantics",
+]);
+
+const LOCAL_UNAVAILABLE_REASON =
+  "local tracker persistence is not implemented; issue #276 adds it";
+const GITHUB_LIFECYCLE_REASON =
+  "GitHub lifecycle transport remains on compatibility callers until issue #275";
+
+class TrackerConfigurationError extends Error {
+  constructor(value) {
+    const rendered = renderValue(value);
+    super(
+      `Invalid tracker configuration ${rendered}; expected one of: ${TRACKER_KEYS.join(", ")}.`
+    );
+    this.name = "TrackerConfigurationError";
+    this.value = value;
+  }
+}
+
+class TrackerContractError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "TrackerContractError";
+  }
+}
+
+class TrackerIdentityError extends TrackerContractError {
+  constructor(message) {
+    super(`Invalid tracker identity: ${message}.`);
+    this.name = "TrackerIdentityError";
+  }
+}
+
+class TrackerUnavailableError extends Error {
+  constructor(tracker, reason, options = {}) {
+    super(
+      `Configured tracker "${tracker}" is unavailable: ${reason}. ` +
+        "Restore that tracker or change backlog/config.yml explicitly; no fallback was attempted.",
+      options
+    );
+    this.name = "TrackerUnavailableError";
+    this.tracker = tracker;
+    this.reason = reason;
+  }
+}
+
+class UnsupportedTrackerCapabilityError extends Error {
+  constructor(tracker, capability) {
+    super(`Tracker "${tracker}" does not support capability "${capability}".`);
+    this.name = "UnsupportedTrackerCapabilityError";
+    this.tracker = tracker;
+    this.capability = capability;
+  }
+}
+
+function renderValue(value) {
+  if (typeof value === "string") return JSON.stringify(value);
+  if (value === undefined) return "undefined";
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function selectTracker(config = {}) {
+  const hasSelection =
+    config !== null &&
+    typeof config === "object" &&
+    Object.prototype.hasOwnProperty.call(config, "tracker");
+  if (!hasSelection) return "github";
+
+  const selection = config.tracker;
+  if (typeof selection !== "string" || !TRACKER_KEYS.includes(selection)) {
+    throw new TrackerConfigurationError(selection);
+  }
+  return selection;
+}
+
+function validateAdapter(tracker, adapter) {
+  if (adapter === null || typeof adapter !== "object" || Array.isArray(adapter)) {
+    throw new TrackerContractError(`Tracker "${tracker}" adapter must be an object.`);
+  }
+
+  const actual = Reflect.ownKeys(adapter);
+  const missing = REQUIRED_ADAPTER_OPERATIONS.filter((name) => !actual.includes(name));
+  const extra = actual.filter((name) => !REQUIRED_ADAPTER_OPERATIONS.includes(name));
+  const nonFunctions = REQUIRED_ADAPTER_OPERATIONS.filter(
+    (name) => actual.includes(name) && typeof adapter[name] !== "function"
+  );
+
+  if (missing.length || extra.length || nonFunctions.length) {
+    const details = [];
+    if (missing.length) details.push(`missing: ${missing.join(", ")}`);
+    if (extra.length) {
+      details.push(`not part of the required interface: ${extra.map(String).join(", ")}`);
+    }
+    if (nonFunctions.length) details.push(`not functions: ${nonFunctions.join(", ")}`);
+    throw new TrackerContractError(
+      `Tracker "${tracker}" adapter has an invalid operation shape (${details.join("; ")}).`
+    );
+  }
+
+  return adapter;
+}
+
+function availabilityFailure(tracker, reason, cause) {
+  return new TrackerUnavailableError(tracker, reason, cause ? { cause } : undefined);
+}
+
+function probeConfiguredAdapter(tracker, adapter) {
+  let report;
+  try {
+    report = adapter.availability();
+  } catch (error) {
+    const reason = error instanceof Error && error.message
+      ? `availability probe threw: ${error.message}`
+      : `availability probe threw: ${String(error)}`;
+    throw availabilityFailure(tracker, reason, error);
+  }
+
+  if (report === null || typeof report !== "object" || typeof report.available !== "boolean") {
+    throw availabilityFailure(
+      tracker,
+      "availability probe returned an unusable report (expected { available: boolean, reason? })"
+    );
+  }
+
+  if (!report.available) {
+    const reason = typeof report.reason === "string" && report.reason.trim()
+      ? report.reason.trim()
+      : "availability probe reported unavailable without an actionable reason";
+    throw availabilityFailure(tracker, reason);
+  }
+
+  return Object.freeze({ available: true });
+}
+
+function resolveTracker(config, { adapters = TRACKER_ADAPTERS } = {}) {
+  const tracker = selectTracker(config);
+  const adapter = adapters[tracker];
+  if (adapter === undefined) {
+    throw new TrackerContractError(`No adapter is registered for configured tracker "${tracker}".`);
+  }
+
+  validateAdapter(tracker, adapter);
+  const availability = probeConfiguredAdapter(tracker, adapter);
+  return Object.freeze({ tracker, adapter, availability });
+}
+
+function validateIdentity(identity) {
+  if (
+    identity === null ||
+    typeof identity !== "object" ||
+    Array.isArray(identity) ||
+    ![Object.prototype, null].includes(Object.getPrototypeOf(identity))
+  ) {
+    throw new TrackerIdentityError("expected an object with tracker, id, and ref");
+  }
+
+  const allowed = ["tracker", "id", "ref", "url"];
+  const keys = Reflect.ownKeys(identity);
+  const missing = ["tracker", "id", "ref"].filter(
+    (key) => !Object.prototype.hasOwnProperty.call(identity, key)
+  );
+  if (missing.length) {
+    throw new TrackerIdentityError(`missing field${missing.length === 1 ? "" : "s"} ${missing.join(", ")}`);
+  }
+  const extra = keys.filter((key) => !allowed.includes(key));
+  if (extra.length) {
+    throw new TrackerIdentityError(
+      `unexpected field${extra.length === 1 ? "" : "s"} ${extra.map(String).join(", ")}`
+    );
+  }
+  if (!TRACKER_KEYS.includes(identity.tracker)) {
+    throw new TrackerIdentityError(`tracker must be one of: ${TRACKER_KEYS.join(", ")}`);
+  }
+  if (typeof identity.id !== "string" || !identity.id.trim()) {
+    throw new TrackerIdentityError("id must be a non-empty opaque string");
+  }
+  if (typeof identity.ref !== "string" || !identity.ref.trim()) {
+    throw new TrackerIdentityError("ref must be a non-empty string");
+  }
+  if (Object.prototype.hasOwnProperty.call(identity, "url")) {
+    if (typeof identity.url !== "string" || !isProviderUrl(identity.url)) {
+      throw new TrackerIdentityError("url must be an absolute http(s) URL when present");
+    }
+  }
+
+  return identity;
+}
+
+function isProviderUrl(value) {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function readCapabilities(tracker, adapter) {
+  const reported = adapter.capabilities();
+  if (!Array.isArray(reported)) {
+    throw new TrackerContractError(
+      `Tracker "${tracker}" capabilities must be reported as an array.`
+    );
+  }
+
+  const invalid = reported.filter((name) => !CAPABILITY_NAMES.includes(name));
+  const duplicates = reported.filter((name, index) => reported.indexOf(name) !== index);
+  if (invalid.length || duplicates.length) {
+    const details = [];
+    if (invalid.length) details.push(`unknown: ${[...new Set(invalid)].join(", ")}`);
+    if (duplicates.length) details.push(`duplicate: ${[...new Set(duplicates)].join(", ")}`);
+    throw new TrackerContractError(
+      `Tracker "${tracker}" reported invalid capabilities (${details.join("; ")}).`
+    );
+  }
+  return Object.freeze([...reported]);
+}
+
+function invokeCapability(resolved, capability, operation, ...args) {
+  if (
+    resolved === null ||
+    typeof resolved !== "object" ||
+    typeof resolved.tracker !== "string" ||
+    resolved.adapter === null ||
+    typeof resolved.adapter !== "object"
+  ) {
+    throw new TrackerContractError("Capability invocation requires a resolved tracker.");
+  }
+  if (typeof operation !== "function") {
+    throw new TrackerContractError("Capability invocation requires an operation function.");
+  }
+
+  const supported = readCapabilities(resolved.tracker, resolved.adapter);
+  if (!supported.includes(capability)) {
+    throw new UnsupportedTrackerCapabilityError(resolved.tracker, capability);
+  }
+  return operation(...args);
+}
+
+function unavailableLocalOperation() {
+  throw new TrackerUnavailableError("local", LOCAL_UNAVAILABLE_REASON);
+}
+
+function githubCompatibilityBoundary() {
+  throw new TrackerContractError(GITHUB_LIFECYCLE_REASON);
+}
+
+const TRACKER_ADAPTERS = Object.freeze({
+  github: Object.freeze({
+    availability: () => ({ available: true }),
+    capabilities: () => [...CAPABILITY_NAMES],
+    list: githubCompatibilityBoundary,
+    read: githubCompatibilityBoundary,
+    create: githubCompatibilityBoundary,
+    update: githubCompatibilityBoundary,
+    close: githubCompatibilityBoundary,
+  }),
+  local: Object.freeze({
+    availability: () => ({ available: false, reason: LOCAL_UNAVAILABLE_REASON }),
+    capabilities: () => [],
+    list: unavailableLocalOperation,
+    read: unavailableLocalOperation,
+    create: unavailableLocalOperation,
+    update: unavailableLocalOperation,
+    close: unavailableLocalOperation,
+  }),
+});
+
+module.exports = {
+  TRACKER_KEYS,
+  REQUIRED_ADAPTER_OPERATIONS,
+  CAPABILITY_NAMES,
+  TRACKER_ADAPTERS,
+  TrackerConfigurationError,
+  TrackerContractError,
+  TrackerIdentityError,
+  TrackerUnavailableError,
+  UnsupportedTrackerCapabilityError,
+  selectTracker,
+  validateAdapter,
+  validateIdentity,
+  readCapabilities,
+  resolveTracker,
+  invokeCapability,
+};

--- a/skills/dev-backlog/scripts/tracker.test.js
+++ b/skills/dev-backlog/scripts/tracker.test.js
@@ -1,5 +1,7 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
 
 const {
   CAPABILITY_NAMES,
@@ -31,6 +33,12 @@ function makeAdapter(overrides = {}) {
 }
 
 describe("configured tracker selection", () => {
+  it("persists exactly one top-level github selection in this repository", () => {
+    const configPath = path.resolve(__dirname, "../../../backlog/config.yml");
+    const raw = fs.readFileSync(configPath, "utf8");
+    assert.deepEqual(raw.match(/^tracker:\s*github\s*$/gm), ["tracker: github"]);
+  });
+
   it("uses github as the deterministic compatibility default", () => {
     assert.equal(selectTracker({}), "github");
     assert.equal(selectTracker(), "github");
@@ -42,7 +50,7 @@ describe("configured tracker selection", () => {
   });
 
   it("rejects invalid and non-string selections before adapter use", () => {
-    for (const value of ["gitlab", "", 7, false, null, [], {}]) {
+    for (const value of ["gitlab", "", 7, false, null, undefined, [], {}]) {
       let adapterRead = false;
       const adapters = {};
       Object.defineProperty(adapters, "github", {
@@ -55,10 +63,13 @@ describe("configured tracker selection", () => {
       assert.throws(
         () => resolveTracker({ tracker: value }, { adapters }),
         (error) => {
+          const rendered = typeof value === "string"
+            ? value
+            : JSON.stringify(value) ?? String(value);
           assert.ok(error instanceof TrackerConfigurationError);
           assert.match(error.message, /github/);
           assert.match(error.message, /local/);
-          assert.match(error.message, new RegExp(String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+          assert.ok(error.message.includes(rendered));
           return true;
         }
       );
@@ -68,6 +79,27 @@ describe("configured tracker selection", () => {
 });
 
 describe("configured-only resolution", () => {
+  it("resolves the built-in github slot for missing and explicit selection", () => {
+    for (const config of [{}, { tracker: "github" }]) {
+      const resolved = resolveTracker(config);
+      assert.equal(resolved.tracker, "github");
+      assert.equal(resolved.adapter, TRACKER_ADAPTERS.github);
+      assert.deepEqual(resolved.availability, { available: true });
+    }
+  });
+
+  it("fails explicitly selected local resolution with its #276 reason", () => {
+    assert.throws(
+      () => resolveTracker({ tracker: "local" }),
+      (error) => {
+        assert.ok(error instanceof TrackerUnavailableError);
+        assert.equal(error.tracker, "local");
+        assert.match(error.reason, /#276/);
+        return true;
+      }
+    );
+  });
+
   it("probes and returns only the configured adapter", () => {
     let githubProbes = 0;
     let localProbes = 0;
@@ -205,6 +237,7 @@ describe("normalized tracker identity", () => {
       { tracker: "github", id: "id", ref: "" },
       { tracker: "github", id: "id", ref: "#1", url: "not a url" },
       { tracker: "github", id: "id", ref: "#1", number: 1 },
+      Object.create({ tracker: "github", id: "id", ref: "#1" }),
     ]) {
       assert.throws(() => validateIdentity(identity), TrackerIdentityError);
     }

--- a/skills/dev-backlog/scripts/tracker.test.js
+++ b/skills/dev-backlog/scripts/tracker.test.js
@@ -1,0 +1,281 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  CAPABILITY_NAMES,
+  REQUIRED_ADAPTER_OPERATIONS,
+  TRACKER_ADAPTERS,
+  TrackerConfigurationError,
+  TrackerContractError,
+  TrackerIdentityError,
+  TrackerUnavailableError,
+  UnsupportedTrackerCapabilityError,
+  invokeCapability,
+  resolveTracker,
+  selectTracker,
+  validateAdapter,
+  validateIdentity,
+} = require("./tracker.js");
+
+function makeAdapter(overrides = {}) {
+  return {
+    availability: () => ({ available: true }),
+    capabilities: () => [],
+    list: () => [],
+    read: () => null,
+    create: (task) => task,
+    update: (task) => task,
+    close: (task) => task,
+    ...overrides,
+  };
+}
+
+describe("configured tracker selection", () => {
+  it("uses github as the deterministic compatibility default", () => {
+    assert.equal(selectTracker({}), "github");
+    assert.equal(selectTracker(), "github");
+  });
+
+  it("accepts explicit github and local selections", () => {
+    assert.equal(selectTracker({ tracker: "github" }), "github");
+    assert.equal(selectTracker({ tracker: "local" }), "local");
+  });
+
+  it("rejects invalid and non-string selections before adapter use", () => {
+    for (const value of ["gitlab", "", 7, false, null, [], {}]) {
+      let adapterRead = false;
+      const adapters = {};
+      Object.defineProperty(adapters, "github", {
+        get() {
+          adapterRead = true;
+          return makeAdapter();
+        },
+      });
+
+      assert.throws(
+        () => resolveTracker({ tracker: value }, { adapters }),
+        (error) => {
+          assert.ok(error instanceof TrackerConfigurationError);
+          assert.match(error.message, /github/);
+          assert.match(error.message, /local/);
+          assert.match(error.message, new RegExp(String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+          return true;
+        }
+      );
+      assert.equal(adapterRead, false);
+    }
+  });
+});
+
+describe("configured-only resolution", () => {
+  it("probes and returns only the configured adapter", () => {
+    let githubProbes = 0;
+    let localProbes = 0;
+    const github = makeAdapter({
+      availability: () => {
+        githubProbes += 1;
+        return { available: true };
+      },
+    });
+    const local = makeAdapter({
+      availability: () => {
+        localProbes += 1;
+        throw new Error("must not probe local");
+      },
+    });
+
+    const resolved = resolveTracker({ tracker: "github" }, { adapters: { github, local } });
+
+    assert.equal(resolved.tracker, "github");
+    assert.equal(resolved.adapter, github);
+    assert.equal(githubProbes, 1);
+    assert.equal(localProbes, 0);
+  });
+
+  it("fails without fallback when the configured adapter is unavailable", () => {
+    let localProbes = 0;
+    const github = makeAdapter({
+      availability: () => ({ available: false, reason: "gh authentication expired" }),
+    });
+    const local = makeAdapter({
+      availability: () => {
+        localProbes += 1;
+        return { available: true };
+      },
+    });
+
+    assert.throws(
+      () => resolveTracker({ tracker: "github" }, { adapters: { github, local } }),
+      (error) => {
+        assert.ok(error instanceof TrackerUnavailableError);
+        assert.equal(error.tracker, "github");
+        assert.equal(error.reason, "gh authentication expired");
+        assert.match(error.message, /github/);
+        assert.match(error.message, /gh authentication expired/);
+        return true;
+      }
+    );
+    assert.equal(localProbes, 0);
+  });
+
+  it("wraps throwing and unusable availability probes with configured-tracker context", () => {
+    for (const availability of [
+      () => {
+        throw new Error("socket reset");
+      },
+      () => undefined,
+      () => ({ available: "yes" }),
+      () => ({ available: false }),
+    ]) {
+      assert.throws(
+        () => resolveTracker(
+          { tracker: "github" },
+          { adapters: { github: makeAdapter({ availability }), local: makeAdapter() } }
+        ),
+        (error) => {
+          assert.ok(error instanceof TrackerUnavailableError);
+          assert.equal(error.tracker, "github");
+          assert.ok(error.reason);
+          assert.match(error.message, /github/);
+          return true;
+        }
+      );
+    }
+  });
+});
+
+describe("adapter contract", () => {
+  it("contains exactly the seven required operations", () => {
+    assert.deepEqual(REQUIRED_ADAPTER_OPERATIONS, [
+      "availability",
+      "capabilities",
+      "list",
+      "read",
+      "create",
+      "update",
+      "close",
+    ]);
+  });
+
+  it("validates both built-in adapter slots against the same exact shape", () => {
+    assert.equal(validateAdapter("github", TRACKER_ADAPTERS.github), TRACKER_ADAPTERS.github);
+    assert.equal(validateAdapter("local", TRACKER_ADAPTERS.local), TRACKER_ADAPTERS.local);
+    assert.deepEqual(Object.keys(TRACKER_ADAPTERS.github), REQUIRED_ADAPTER_OPERATIONS);
+    assert.deepEqual(Object.keys(TRACKER_ADAPTERS.local), REQUIRED_ADAPTER_OPERATIONS);
+  });
+
+  it("rejects missing, non-function, and provider-specific required methods", () => {
+    const missingClose = makeAdapter();
+    delete missingClose.close;
+    assert.throws(() => validateAdapter("github", missingClose), TrackerContractError);
+    assert.throws(
+      () => validateAdapter("github", makeAdapter({ read: true })),
+      TrackerContractError
+    );
+    assert.throws(
+      () => validateAdapter("github", { ...makeAdapter(), milestones: () => [] }),
+      TrackerContractError
+    );
+  });
+});
+
+describe("normalized tracker identity", () => {
+  it("accepts opaque ids and an optional provider URL", () => {
+    const withoutUrl = { tracker: "local", id: "task:alpha/7", ref: "BACK-7" };
+    const withUrl = {
+      tracker: "github",
+      id: "I_kwDOOpaqueNodeId",
+      ref: "#273",
+      url: "https://github.com/sungjunlee/dev-backlog/issues/273",
+    };
+
+    assert.equal(validateIdentity(withoutUrl), withoutUrl);
+    assert.equal(validateIdentity(withUrl), withUrl);
+  });
+
+  it("rejects missing, empty, fabricated, and extra identity fields", () => {
+    for (const identity of [
+      null,
+      {},
+      { tracker: "github", id: "id" },
+      { tracker: "github", ref: "#1" },
+      { tracker: "", id: "id", ref: "#1" },
+      { tracker: "gitlab", id: "id", ref: "#1" },
+      { tracker: "github", id: "", ref: "#1" },
+      { tracker: "github", id: "id", ref: "" },
+      { tracker: "github", id: "id", ref: "#1", url: "not a url" },
+      { tracker: "github", id: "id", ref: "#1", number: 1 },
+    ]) {
+      assert.throws(() => validateIdentity(identity), TrackerIdentityError);
+    }
+  });
+});
+
+describe("local adapter and optional capabilities", () => {
+  it("reports local as implementation-pending and fails every lifecycle operation consistently", () => {
+    const local = TRACKER_ADAPTERS.local;
+    const report = local.availability();
+    assert.equal(report.available, false);
+    assert.match(report.reason, /#276/);
+
+    const errors = [];
+    for (const operation of ["list", "read", "create", "update", "close"]) {
+      assert.throws(
+        () => local[operation](),
+        (error) => {
+          errors.push(error);
+          assert.ok(error instanceof TrackerUnavailableError);
+          assert.equal(error.tracker, "local");
+          assert.equal(error.reason, report.reason);
+          return true;
+        }
+      );
+    }
+    assert.equal(new Set(errors.map((error) => error.message)).size, 1);
+  });
+
+  it("reports only the six named optional provider capabilities", () => {
+    assert.deepEqual(CAPABILITY_NAMES, [
+      "milestones",
+      "pull-request-relationships",
+      "mirrors",
+      "progress-issues",
+      "comments",
+      "closing-semantics",
+    ]);
+    assert.deepEqual(TRACKER_ADAPTERS.github.capabilities(), CAPABILITY_NAMES);
+    assert.deepEqual(TRACKER_ADAPTERS.local.capabilities(), []);
+  });
+
+  it("rejects unsupported capability invocation before mutation", () => {
+    let mutations = 0;
+    const resolved = {
+      tracker: "local",
+      adapter: TRACKER_ADAPTERS.local,
+    };
+
+    assert.throws(
+      () => invokeCapability(resolved, "comments", () => {
+        mutations += 1;
+      }),
+      (error) => {
+        assert.ok(error instanceof UnsupportedTrackerCapabilityError);
+        assert.equal(error.tracker, "local");
+        assert.equal(error.capability, "comments");
+        assert.match(error.message, /local/);
+        assert.match(error.message, /comments/);
+        return true;
+      }
+    );
+    assert.equal(mutations, 0);
+  });
+
+  it("invokes a supported capability only after the gate succeeds", () => {
+    const resolved = {
+      tracker: "github",
+      adapter: makeAdapter({ capabilities: () => ["comments"] }),
+    };
+    const result = invokeCapability(resolved, "comments", (value) => `commented:${value}`, 273);
+    assert.equal(result, "commented:273");
+  });
+});


### PR DESCRIPTION
## Dispatch Summary

```text
구현과 커밋을 완료했습니다. 작업 트리는 깨끗합니다.

주요 결과:

- `tracker: github` 설정 및 누락 시 GitHub 호환 기본값 추가
- 순수 설정 기반 `github`/`local` 선택과 fail-closed resolver 구현
- 정확한 7개 adapter operation과 엄격한 identity 검증 구현
- configured-only probe, no-fallback 오류 처리 구현
- local adapter의 #276 대기 상태와 일관된 lifecycle 실패 구현
- 6개 optional capability 보고 및 mutation 전 gate 구현
- 기존 GitHub 호출자·export·CLI/Markdown/JSON 동작은 유지
- #275 wiring과 #276 persistence의 경계를 문서화

핵심 위치:

- [tracker.js](/Users/sjlee/.relay/worktrees/8a8826e7/dev-backlog/ski
```

## Score Log

- Run: issue-273-20260711064832544-67bb8c7c
- Executor: codex
- Branch: issue-273