### PR TITLE
feat: add tracker-neutral task references

### DIFF
--- a/skills/dev-backlog/references/integration-contract.md
+++ b/skills/dev-backlog/references/integration-contract.md
@@ -26,7 +26,7 @@ bash skills/dev-backlog/scripts/status.sh --json
 bash skills/dev-backlog/scripts/next.sh --json
 ```
 
-Both commands emit one JSON document to stdout with `schema_version: 1`. Human-readable output remains the default when `--json` is absent. Snapshots are supported through normal shell redirection only, for example `status.sh --json > sprint-state.json`; dev-backlog does not create timestamped snapshot files or maintain a snapshot store.
+Both commands emit one JSON document to stdout with `schema_version: 1`. Tracker-neutral identity is an additive schema-v1 extension: existing consumers may ignore the new fields, and no existing field or GitHub value changes. Human-readable output remains the default when `--json` is absent. Snapshots are supported through normal shell redirection only, for example `status.sh --json > sprint-state.json`; dev-backlog does not create timestamped snapshot files or maintain a snapshot store.
 
 Ambiguous active sprint state is fail-loud in JSON mode: the command exits non-zero and writes the error to stderr instead of emitting partial JSON. Missing `## ` sections degrade to empty strings or arrays as shown below.
 
@@ -56,7 +56,10 @@ Top-level schema:
 | `line` | string | Original plan line. |
 | `checkbox_state` | string | Exact marker content: `" "`, `"~"`, or `"x"`. |
 | `state` | string | Normalized state: `todo`, `in_flight`, or `done`. |
-| `issue_number` | integer | GitHub issue number parsed with `/^\- \[.\] #(\d+)/`. |
+| `tracker` | string | Identity owner: `github` for `#N`, or `local` for a configured-prefix ref. |
+| `id` | string | Stable tracker-owned ID. GitHub uses the decimal issue number as a string; local decimal subtask IDs such as `42.1` stay lossless. Treat this field as opaque. |
+| `ref` | string | Complete display ref, byte-compatible `#N` for GitHub or `{PREFIX}-N[.M]` for local. |
+| `issue_number` | integer or `null` | Compatibility alias. It remains the exact integer for GitHub items and is `null` for local items; a local numeric suffix is never coerced into a GitHub issue number. |
 | `title` | string | Plan title after removing parsed PR, branch, and run annotations. |
 | `batch_heading` | string or `null` | Current `### Batch...` heading, if any. |
 | `pr` | object or `null` | `{ "number": N, "state": "..." }` from `→ PR #N (state)` when present. |
@@ -90,7 +93,7 @@ Plan mode guarantees batch-as-wave semantics: items in one batch MUST be mutuall
 | `age_source` | string or `null` | `progress` when based on a progress entry, `started` when falling back to frontmatter. |
 | `age_basis_date` | string or `null` | The `YYYY-MM-DD` date used to compute `age_days`. |
 
-Age heuristic: for each `[~]` item, find the earliest dated `## Progress` bullet that mentions the item's issue number as `#N`; if none exists, fall back to sprint frontmatter `started:` when it is a `YYYY-MM-DD` date. `age_days` is the calendar-day distance from that basis date to the command run's local calendar date. Emit `null` for `age_days`, `age_source`, and `age_basis_date` when neither resolves. The basis date is selected only from sprint file content; no GitHub state, relay manifest, file mtime, or markdown prose outside these fields participates.
+Age heuristic: for each `[~]` item, find the earliest dated `## Progress` bullet containing that complete normalized `ref`; if none exists, fall back to sprint frontmatter `started:` when it is a `YYYY-MM-DD` date. Matching is boundary-exact (`#1` does not match `#11`; `BACK-1` does not match `BACK-11` or `BACK-1.1`) and a `PR #N` annotation is provider metadata, not a task-ref match. `age_days` is the calendar-day distance from that basis date to the command run's local calendar date. Emit `null` for `age_days`, `age_source`, and `age_basis_date` when neither resolves. The basis date is selected only from sprint file content; no GitHub state, relay manifest, file mtime, or markdown prose outside these fields participates.
 
 ### Backlog Doctor JSON Surface
 
@@ -132,10 +135,10 @@ Hard failures include ambiguous active sprint state, no active sprint while spri
 
 | What | Pattern | Example |
 |------|---------|---------|
-| Task files | `backlog/tasks/{PREFIX}-{N} - {slug}.md` | `backlog/tasks/BACK-42 - oauth-flow.md` |
+| Task files | `backlog/tasks/{PREFIX}-{N[.M]} - {slug}.md` | `backlog/tasks/BACK-42.1 - oauth-flow.md` |
 | Active sprint | `backlog/sprints/*.md` with `status: active` | `backlog/sprints/2026-03-auth-system.md` |
 | Cross-sprint context | `backlog/sprints/_context.md` | (always this exact name) |
-| Completed tasks | `backlog/completed/{PREFIX}-{N} - {slug}.md` | `backlog/completed/BACK-38 - db-schema.md` |
+| Completed tasks | `backlog/completed/{PREFIX}-{N[.M]} - {slug}.md` | `backlog/completed/BACK-38 - db-schema.md` |
 
 **PREFIX** defaults to `BACK` and is configurable via `backlog/config.yml` → `task_prefix`.
 
@@ -196,21 +199,26 @@ Sprint plan items use this format:
 - [ ] #42 OAuth2 flow (~2hr)
 - [~] #42 OAuth2 flow (~2hr) → PR #87 (reviewing)
 - [x] #42 OAuth2 flow (~2hr) → PR #87 (merged)
+- [ ] BACK-42 Local task
+- [~] BACK-42.1 Local subtask [branch:local-42.1]
 ```
 
 | Marker | Meaning | Regex | Set by |
 |--------|---------|-------|--------|
-| `[ ]` | Not started | `^\- \[ \] #` | sprint-init.js, manual |
-| `[~]` | In-flight (PR open/reviewing) | `^\- \[~\] #` | dev-relay dispatch |
-| `[x]` | Done (merged/completed) | `^\- \[x\] #` | dev-relay merge, manual |
+| `[ ]` | Not started | complete `#N` or `{PREFIX}-N[.M]` after the marker | sprint-init.js, manual |
+| `[~]` | In-flight (PR open/reviewing) | complete `#N` or `{PREFIX}-N[.M]` after the marker | dev-relay dispatch |
+| `[x]` | Done (merged/completed) | complete `#N` or `{PREFIX}-N[.M]` after the marker | dev-relay merge, manual |
 
-### Issue number extraction
+### Task reference and compatibility aliases
 
-```
-/^\- \[.\] #(\d+)/
-```
+`skills/dev-backlog/scripts/task-ref.js` is the grammar owner. It accepts only complete positive refs:
 
-Captures the GitHub issue number from any checkbox state.
+- GitHub: `#N`, where `N` is a positive decimal integer. Identity is `{ tracker: "github", id: "N", ref: "#N" }`.
+- Local: `{PREFIX}-N` or `{PREFIX}-N.M`, where `PREFIX` is the exact `backlog/config.yml` `task_prefix` and both numeric components are positive integers. Identity is `{ tracker: "local", id: "N[.M]", ref: "{PREFIX}-N[.M]" }`.
+
+Zero, negative, partial, foreign-prefix, whitespace-suffixed, and malformed refs are rejected. Decimal notation is supported for local Backlog.md subtasks, not GitHub issue refs. GitHub Plan lines and mirror Markdown continue to render byte-for-byte as `#N`.
+
+The shell `RE_CB_*` variables remain GitHub-only compatibility aliases for external consumers. Core `status.sh`, `next.sh`, checkbox counting, and closeout delegate task-ref recognition to the shared module. Machine actors should consume `tracker`/`id`/`ref`; `issue_number` remains an unchanged GitHub alias and is `null` for local entries in `plan_items`, `next_batch.items`, `in_flight`, and doctor projections.
 
 ### PR annotation (appended by dev-relay)
 
@@ -219,6 +227,7 @@ Captures the GitHub issue number from any checkbox state.
 ```
 
 Appended when dispatching: `→ PR #87 (reviewing)`. Updated on merge: `→ PR #87 (merged)`.
+This provider annotation is parsed separately and never passed through task-ref parsing.
 
 ## Trace Grammar
 
@@ -419,7 +428,7 @@ These patterns are also validated by `scripts/smoke-test.sh` (checkbox counting 
 
 ## Versioning
 
-This contract is unversioned, but its checkbox and annotation grammar is compatibility-sensitive. Any change to grammar parsed by `dev-relay` regexes must be coordinated with `dev-relay` before landing; prefer strictly additive grammar that preserves existing matches.
+This document is unversioned, while the actor JSON surface remains `schema_version: 1`. The normalized `tracker`, `id`, and `ref` fields and nullable non-GitHub `issue_number` semantics are additive schema-v1 behavior. Its checkbox and annotation grammar is compatibility-sensitive. Any change to grammar parsed by `dev-relay` regexes must be coordinated with `dev-relay` before landing; prefer strictly additive grammar that preserves existing GitHub matches and bytes.
 
 Breaking changes require:
 1. Update this document

--- a/skills/dev-backlog/scripts/backlog-doctor.js
+++ b/skills/dev-backlog/scripts/backlog-doctor.js
@@ -24,6 +24,7 @@ const {
   analyzeCapabilities,
   hasHardFailures: hasCapabilityHardFailures,
 } = require("./capabilities-doctor.js");
+const { readConfig } = require("./lib.js");
 
 const SCHEMA_VERSION = 1;
 const DEFAULT_BACKLOG_DIR = "backlog";
@@ -170,6 +171,7 @@ function runDoctor({
     checkCapabilities({ repoRoot: root, capabilitiesPath }),
     checkSprintShape({
       repoRoot: root,
+      backlogPath,
       activePath: active.detail.active_path,
       activeStatus: active.status,
     }),
@@ -394,7 +396,7 @@ function loadSprintState({ activePath, backlogPath, today }) {
   }
 }
 
-function checkSprintShape({ repoRoot, activePath, activeStatus }) {
+function checkSprintShape({ repoRoot, backlogPath, activePath, activeStatus }) {
   if (!activePath) {
     const status = activeStatus === "fail" ? "warn" : "pass";
     return verdict("sprint_shape", status, {
@@ -406,7 +408,8 @@ function checkSprintShape({ repoRoot, activePath, activeStatus }) {
   const missingSections = REQUIRED_ACTIVE_SECTIONS.filter(
     (section) => !hasSection(content, section),
   );
-  const unparseable = findUnparseablePlanLines(content);
+  const taskPrefix = readConfig(backlogPath).task_prefix;
+  const unparseable = findUnparseablePlanLines(content, { taskPrefix });
 
   if (missingSections.length > 0 || unparseable.length > 0) {
     const parts = [];
@@ -418,6 +421,7 @@ function checkSprintShape({ repoRoot, activePath, activeStatus }) {
       required_sections: REQUIRED_ACTIVE_SECTIONS,
       missing_sections: missingSections,
       checkbox_grammar: "^- \\[( |~|x)\\] #\\d+",
+      task_ref_grammar: `#N or ${taskPrefix}-N[.M]`,
       unparseable_plan_lines: unparseable,
     });
   }
@@ -429,12 +433,12 @@ function checkSprintShape({ repoRoot, activePath, activeStatus }) {
   });
 }
 
-function findUnparseablePlanLines(content) {
+function findUnparseablePlanLines(content, options = {}) {
   return extractSectionLines(content, "Plan")
     .map((line, index) => ({ line, plan_line: index + 1 }))
     .filter(({ line }) => line.trim() !== "")
     .filter(({ line }) => !/^###\s+/.test(line))
-    .filter(({ line }) => parsePlanItem(line) === null);
+    .filter(({ line }) => parsePlanItem(line, null, options) === null);
 }
 
 function checkInFlightTrace({ sprintState, activeStatus }) {
@@ -708,6 +712,9 @@ function countLines(content) {
 function publicPlanItem(item) {
   return {
     line: item.line,
+    tracker: item.tracker,
+    id: item.id,
+    ref: item.ref,
     issue_number: item.issue_number,
     age_days: item.age_days,
     age_source: item.age_source,

--- a/skills/dev-backlog/scripts/lib.sh
+++ b/skills/dev-backlog/scripts/lib.sh
@@ -2,12 +2,28 @@
 # Shared library for dev-backlog bash scripts.
 # Source this file: source "$(dirname "$0")/lib.sh"
 
-# Checkbox regex patterns — integration contract with dev-relay.
+# Legacy GitHub checkbox regex aliases — integration contract with dev-relay.
+# Core shell consumers use checkbox_lines/count_checkboxes below, which delegate
+# task-ref grammar to task-ref.js and therefore also accept configured local refs.
 # See: references/integration-contract.md
 RE_CB_ANY='^\- \[.\] #'
 RE_CB_DONE='^\- \[x\] #'
 RE_CB_INFLIGHT='^\- \[~\] #'
 RE_CB_TODO='^\- \[ \] #'
+
+TASK_REF_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Print valid Plan checkbox lines, optionally limited to one marker (space/~ /x).
+# Usage: checkbox_lines "$FILE" [marker]
+checkbox_lines() {
+  local file="$1" marker="${2-}" backlog_dir
+  backlog_dir=$(dirname "$(dirname "$file")")
+  if [ "$#" -gt 1 ]; then
+    node "$TASK_REF_SCRIPT_DIR/task-ref.js" plan-lines "$file" "$backlog_dir" "$marker"
+  else
+    node "$TASK_REF_SCRIPT_DIR/task-ref.js" plan-lines "$file" "$backlog_dir"
+  fi
+}
 
 # List active sprint files (status: active in frontmatter).
 # Usage: find_active_sprints "$SPRINTS_DIR"
@@ -46,25 +62,23 @@ find_active_sprint() {
   printf "%s\n" "$active"
 }
 
-# Count checkbox states in a sprint file (single awk pass).
+# Count checkbox states in a sprint file through the shared task-ref parser.
 # Sets: CB_TOTAL, CB_DONE, CB_IN_FLIGHT, CB_TODO
 # Usage: count_checkboxes "$FILE"
 count_checkboxes() {
   local file="$1"
-  local counts
-  # Awk patterns mirror RE_CB_* constants (awk can't reference shell vars directly)
-  counts=$(awk '/^- \[.\] #/{t++} /^- \[x\] #/{d++} /^- \[~\] #/{f++} END{print t+0, d+0, f+0}' "$file" 2>/dev/null)
-  read -r CB_TOTAL CB_DONE CB_IN_FLIGHT <<< "$counts"
-  CB_TODO=$((CB_TOTAL - CB_DONE - CB_IN_FLIGHT))
+  local backlog_dir counts
+  backlog_dir=$(dirname "$(dirname "$file")")
+  counts=$(node "$TASK_REF_SCRIPT_DIR/task-ref.js" counts "$file" "$backlog_dir")
+  read -r CB_TOTAL CB_DONE CB_IN_FLIGHT CB_TODO <<< "$counts"
 }
 
 # Return the first unchecked todo item (stripped of "- [ ] " prefix).
 # Usage: NEXT=$(next_todo_item "$FILE")
 next_todo_item() {
   local file="$1"
-  # Strip display prefix "- [ ] " but keep the "#" issue ref.
-  # Sed pattern mirrors RE_CB_TODO minus trailing "#"; keep in sync if format changes.
-  grep "$RE_CB_TODO" "$file" 2>/dev/null | head -1 | sed 's/^- \[ \] //'
+  # Strip the stable checkbox display prefix while keeping the parsed task ref.
+  checkbox_lines "$file" " " | head -1 | sed 's/^- \[ \] //'
 }
 
 # Extract a markdown section by heading (## level).

--- a/skills/dev-backlog/scripts/next.sh
+++ b/skills/dev-backlog/scripts/next.sh
@@ -76,7 +76,7 @@ fi
 # Show in-flight items (dispatched via dev-relay, marked [~])
 if [ "$CB_IN_FLIGHT" -gt 0 ]; then
   echo "In flight:"
-  grep "$RE_CB_INFLIGHT" "$ACTIVE" | while IFS= read -r line; do
+  checkbox_lines "$ACTIVE" "~" | while IFS= read -r line; do
     echo "  $line"
   done
   echo ""
@@ -85,11 +85,12 @@ fi
 # Find current batch (first batch with unchecked items)
 CURRENT_BATCH=""
 IN_BATCH=""
+TODO_ITEMS=$(checkbox_lines "$ACTIVE" " ")
 while IFS= read -r line; do
   if echo "$line" | grep -q '^### Batch'; then
     IN_BATCH="$line"
   fi
-  if [ -n "$IN_BATCH" ] && echo "$line" | grep -q "$RE_CB_TODO"; then
+  if [ -n "$IN_BATCH" ] && printf '%s\n' "$TODO_ITEMS" | grep -Fqx -- "$line"; then
     if [ -z "$CURRENT_BATCH" ]; then
       CURRENT_BATCH="$IN_BATCH"
       echo "Next: $CURRENT_BATCH"
@@ -105,7 +106,8 @@ done < "$ACTIVE"
 # If no batch headers, show all unchecked items
 if [ -z "$CURRENT_BATCH" ]; then
   echo "Next items:"
-  grep "$RE_CB_TODO" "$ACTIVE" | while IFS= read -r line; do
+  printf '%s\n' "$TODO_ITEMS" | while IFS= read -r line; do
+    [ -z "$line" ] && continue
     echo "  $line"
   done
 fi

--- a/skills/dev-backlog/scripts/progress-sync-render.js
+++ b/skills/dev-backlog/scripts/progress-sync-render.js
@@ -2,6 +2,11 @@ const MARKER_PREFIX = "<!-- dev-backlog:progress-issue month=";
 const MARKER_SUFFIX = " -->";
 const COMMENT_MARKER_PREFIX = "<!-- dev-backlog:progress-comment id=";
 const COMMENT_MARKER_SUFFIX = " -->";
+const {
+  githubIssueNumber,
+  parseTaskFileName,
+  sameTaskIdentity,
+} = require("./task-ref.js");
 
 function makeMarker(month) {
   return `${MARKER_PREFIX}${month}${MARKER_SUFFIX}`;
@@ -47,9 +52,8 @@ function relayStuckEntryKey(runId) {
   return `run/${runId}/stuck`;
 }
 
-function parseTaskIssueNumber(taskFile) {
-  const match = String(taskFile || "").match(/^[A-Za-z]+-(\d+)\b/);
-  return match ? Number(match[1]) : null;
+function parseTaskIssueNumber(taskFile, options = {}) {
+  return githubIssueNumber(parseTaskFileName(taskFile, { ...options, tracker: "github" }));
 }
 
 function monthTitle(month) {
@@ -226,8 +230,15 @@ function buildDesiredCommentEntries({ mergedPRs, stuckTasks, month, relayMetadat
   }
 
   for (const task of stuckTasks) {
-    const taskIssueNumber = task.issueNumber ?? parseTaskIssueNumber(task.file);
-    const relay = relayMetadata?.runId && relayMetadata.issueNumber === taskIssueNumber ? relayMetadata : null;
+    const taskIdentity = task.tracker && task.id
+      ? task
+      : parseTaskFileName(task.file, { tracker: "github" });
+    const relayIdentity = Number.isFinite(relayMetadata?.issueNumber)
+      ? { tracker: "github", id: String(relayMetadata.issueNumber) }
+      : null;
+    const relay = relayMetadata?.runId && sameTaskIdentity(relayIdentity, taskIdentity)
+      ? relayMetadata
+      : null;
     desired.push({
       entryId: relay ? relayStuckEntryKey(relay.runId) : stuckEntryKey(month, task.file),
       aliasIds: relay ? [stuckEntryKey(month, task.file)] : [],

--- a/skills/dev-backlog/scripts/progress-sync.js
+++ b/skills/dev-backlog/scripts/progress-sync.js
@@ -17,6 +17,12 @@
 const { execFileSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
+const { readConfig } = require("./lib.js");
+const {
+  githubIssueNumber,
+  parsePlanCheckbox,
+  parseTaskFileName,
+} = require("./task-ref.js");
 const {
   makeMarker,
   parseMarkerMonth,
@@ -133,16 +139,25 @@ function parseArgs(args) {
 
 function readTaskFiles(tasksDir) {
   if (!fs.existsSync(tasksDir)) return [];
+  const config = readConfig(path.dirname(tasksDir));
+  const refOptions = { taskPrefix: config.task_prefix, tracker: config.tracker };
   return fs.readdirSync(tasksDir)
     .filter((f) => f.endsWith(".md"))
     .map((f) => {
       const content = fs.readFileSync(path.join(tasksDir, f), "utf-8");
+      const identity = parseTaskFileName(f, refOptions);
       const fm = content.match(/^---\n([\s\S]*?)\n---/);
-      if (!fm) return { file: f, issueNumber: parseTaskIssueNumber(f), status: "unknown" };
+      const task = {
+        file: f,
+        tracker: identity?.tracker ?? null,
+        id: identity?.id ?? null,
+        ref: identity?.ref ?? null,
+        issueNumber: githubIssueNumber(identity),
+      };
+      if (!fm) return { ...task, status: "unknown" };
       const statusMatch = fm[1].match(/^status:\s*(.+)$/m);
       return {
-        file: f,
-        issueNumber: parseTaskIssueNumber(f),
+        ...task,
         status: statusMatch ? statusMatch[1].trim() : "unknown",
       };
     });
@@ -150,15 +165,19 @@ function readTaskFiles(tasksDir) {
 
 function readActiveSprintSummary(sprintsDir) {
   if (!fs.existsSync(sprintsDir)) return null;
+  const config = readConfig(path.dirname(sprintsDir));
   const files = fs.readdirSync(sprintsDir).filter(
     (f) => f.endsWith(".md") && !f.startsWith("_")
   );
   for (const f of files) {
     const content = fs.readFileSync(path.join(sprintsDir, f), "utf-8");
     if (/^status:\s*active$/m.test(content)) {
-      const done = (content.match(/^- \[x\] #/gm) || []).length;
-      const inflight = (content.match(/^- \[~\] #/gm) || []).length;
-      const todo = (content.match(/^- \[ \] #/gm) || []).length;
+      const items = content.split(/\r?\n/)
+        .map((line) => parsePlanCheckbox(line, { taskPrefix: config.task_prefix }))
+        .filter(Boolean);
+      const done = items.filter((item) => item.checkboxState === "x").length;
+      const inflight = items.filter((item) => item.checkboxState === "~").length;
+      const todo = items.filter((item) => item.checkboxState === " ").length;
       const total = done + inflight + todo;
       return { file: f, done, inflight, todo, total };
     }

--- a/skills/dev-backlog/scripts/progress-sync.test.js
+++ b/skills/dev-backlog/scripts/progress-sync.test.js
@@ -181,6 +181,40 @@ describe("readTaskFiles", () => {
     assert.ok(tasks.some((t) => t.status === "To Do"));
     assert.ok(tasks.some((t) => t.issueNumber === 1));
     assert.ok(tasks.some((t) => t.issueNumber === 2));
+    assert.deepEqual(tasks.find((t) => t.issueNumber === 1), {
+      file: "BACK-1 - foo.md",
+      tracker: "github",
+      id: "1",
+      ref: "#1",
+      issueNumber: 1,
+      status: "In Progress",
+    });
+  });
+
+  it("matches complete task filenames without BACK-1/BACK-11 collisions", () => {
+    fs.writeFileSync(path.join(tmpDir, "BACK-1 - short.md"), "---\nstatus: In Progress\n---\n");
+    fs.writeFileSync(path.join(tmpDir, "BACK-11 - long.md"), "---\nstatus: To Do\n---\n");
+    assert.deepEqual(readTaskFiles(tmpDir).map((task) => [task.ref, task.issueNumber]), [
+      ["#1", 1],
+      ["#11", 11],
+    ]);
+  });
+
+  it("reads configured local decimal task identities without issueNumber aliases", () => {
+    const backlogDir = path.join(tmpDir, "backlog");
+    const tasksDir = path.join(backlogDir, "tasks");
+    fs.mkdirSync(tasksDir, { recursive: true });
+    fs.writeFileSync(path.join(backlogDir, "config.yml"), "tracker: local\ntask_prefix: BACK\n");
+    fs.writeFileSync(path.join(tasksDir, "BACK-1.2 - child.md"), "---\nstatus: In Progress\n---\n");
+
+    assert.deepEqual(readTaskFiles(tasksDir), [{
+      file: "BACK-1.2 - child.md",
+      tracker: "local",
+      id: "1.2",
+      ref: "BACK-1.2",
+      issueNumber: null,
+      status: "In Progress",
+    }]);
   });
 
   it("returns empty array for missing dir", () => {
@@ -203,6 +237,7 @@ describe("parseTaskIssueNumber", () => {
 
   it("returns null when filename does not follow task naming", () => {
     assert.equal(parseTaskIssueNumber("notes.md"), null);
+    assert.equal(parseTaskIssueNumber("BACK-1.2 - local.md"), null);
   });
 });
 
@@ -227,6 +262,25 @@ describe("readActiveSprintSummary", () => {
     assert.equal(s.todo, 2);
     assert.equal(s.total, 4);
     assert.equal(s.file, "2026-04-auth.md");
+  });
+
+  it("counts mixed GitHub and configured-prefix Plan refs", () => {
+    fs.writeFileSync(path.join(tmpDir, "2026-04-mixed.md"), [
+      "---", "status: active", "---",
+      "## Plan",
+      "- [x] #1 Done task",
+      "- [~] BACK-11 In-flight local task",
+      "- [ ] BACK-11.2 Local subtask",
+      "- [ ] BACK-0 Invalid task",
+      "- [ ] OTHER-1 Foreign prefix",
+    ].join("\n"));
+    const s = readActiveSprintSummary(tmpDir);
+    assert.deepEqual({ done: s.done, inflight: s.inflight, todo: s.todo, total: s.total }, {
+      done: 1,
+      inflight: 1,
+      todo: 1,
+      total: 3,
+    });
   });
 
   it("returns null when no active sprint", () => {
@@ -294,16 +348,30 @@ describe("renderBody", () => {
       nextIssueNumber: 44,
     });
 
-    assert.ok(body.includes("<!-- dev-backlog:progress-issue month=2026-04 -->"));
-    assert.ok(body.includes("# Progress: April 2026"));
-    assert.ok(body.includes("| Merged PRs (month) | 5 |"));
-    assert.ok(body.includes("| In-flight (open PRs) | 2 |"));
-    assert.ok(body.includes("| Stuck candidates | 1 |"));
-    assert.ok(body.includes("2026-04-auth.md"));
-    assert.ok(body.includes("3/6 done"));
-    assert.ok(body.includes("#42"));
-    assert.ok(body.includes("## Next"));
-    assert.ok(body.includes("#44"));
+    assert.equal(body, `<!-- dev-backlog:progress-issue month=2026-04 -->
+
+# Progress: April 2026
+
+## Summary
+
+| Metric | Count |
+| --- | --- |
+| Merged PRs (month) | 5 |
+| In-flight (open PRs) | 2 |
+| Stuck candidates | 1 |
+
+## Active Sprint
+
+**2026-04-auth.md** — 3/6 done, 1 in-flight, 2 remaining
+
+## Previous
+
+- #42
+
+## Next
+
+- #44
+`);
   });
 
   it("renders no-sprint and no-prev gracefully", () => {
@@ -916,9 +984,10 @@ describe("renderMergeComment", () => {
         { number: 53, url: "https://github.com/sungjunlee/dev-backlog/issues/53" },
       ],
     });
-    assert.ok(body.includes("**Merged:** [#54](https://github.com/sungjunlee/dev-backlog/pull/54) — Refresh root contract docs"));
-    assert.ok(body.includes("- Task: [#53](https://github.com/sungjunlee/dev-backlog/issues/53)"));
-    assert.ok(body.includes("- Landed: 2026-04-16 22:54 UTC"));
+    assert.equal(body, `<!-- dev-backlog:progress-comment id=2026-04/merge/pr-54 -->
+**Merged:** [#54](https://github.com/sungjunlee/dev-backlog/pull/54) — Refresh root contract docs
+- Task: [#53](https://github.com/sungjunlee/dev-backlog/issues/53)
+- Landed: 2026-04-16 22:54 UTC`);
   });
 
   it("marker is parseable back to entry id", () => {

--- a/skills/dev-backlog/scripts/smoke-test.sh
+++ b/skills/dev-backlog/scripts/smoke-test.sh
@@ -269,6 +269,45 @@ assert_equals "count: done" "$CB_DONE" "2"
 assert_equals "count: in-flight" "$CB_IN_FLIGHT" "1"
 assert_equals "count: todo" "$CB_TODO" "2"
 
+# Configured local refs use the same shell parser, including decimal subtasks.
+mkdir -p "$TEST_DIR/local-backlog/sprints"
+cat > "$TEST_DIR/local-backlog/config.yml" << 'EOF'
+tracker: local
+task_prefix: BACK
+EOF
+cat > "$TEST_DIR/local-backlog/sprints/active.md" << 'EOF'
+---
+status: active
+---
+
+## Goal
+Exercise local refs.
+
+## Plan
+- [x] BACK-1 Done
+- [~] BACK-11 In flight [branch:local-11]
+- [ ] BACK-11.2 Next subtask
+- [ ] BACK-0 Invalid and ignored
+
+## Running Context
+
+## Progress
+EOF
+
+count_checkboxes "$TEST_DIR/local-backlog/sprints/active.md"
+assert_equals "count local: total" "$CB_TOTAL" "3"
+assert_equals "count local: done" "$CB_DONE" "1"
+assert_equals "count local: in-flight" "$CB_IN_FLIGHT" "1"
+assert_equals "count local: todo" "$CB_TODO" "1"
+
+OUT=$(bash "$SCRIPT_DIR/next.sh" "$TEST_DIR/local-backlog")
+assert_contains "next local: displays in-flight ref" "$OUT" "BACK-11 In flight"
+assert_contains "next local: displays decimal todo ref" "$OUT" "BACK-11.2 Next subtask"
+
+OUT=$(bash "$SCRIPT_DIR/status.sh" "$TEST_DIR/local-backlog")
+assert_contains "status local: counts all valid refs" "$OUT" "1/3 tasks (33%)"
+assert_contains "status local: displays decimal next ref" "$OUT" "BACK-11.2 Next subtask"
+
 # Empty file
 cat > "$TEST_DIR/empty.md" << 'EOF'
 No checkboxes here.
@@ -892,6 +931,43 @@ EOF
 bash "$SCRIPT_DIR/sprint-close.sh" "$TEST_DIR/backlog" >/dev/null 2>&1
 assert_equals "ambig: BACK-1 moved" "$(ls "$TEST_DIR/backlog/completed/" 2>/dev/null | grep -c 'BACK-1 ')" "1"
 assert_equals "ambig: BACK-11 NOT moved" "$(ls "$TEST_DIR/backlog/tasks/" 2>/dev/null | grep -c 'BACK-11')" "1"
+
+# --- local decimal closeout (BACK-1.2 must not match BACK-1.20) ---
+rm -rf "$TEST_DIR/backlog"
+mkdir -p "$TEST_DIR/backlog/sprints" "$TEST_DIR/backlog/tasks" "$TEST_DIR/backlog/completed"
+cat > "$TEST_DIR/backlog/config.yml" << 'EOF'
+tracker: local
+task_prefix: BACK
+EOF
+cat > "$TEST_DIR/backlog/sprints/2026-03-local.md" << 'EOF'
+---
+status: active
+---
+
+## Goal
+Close one local subtask.
+
+## Plan
+- [x] BACK-1.2 Short subtask
+
+## Running Context
+
+## Progress
+EOF
+cat > "$TEST_DIR/backlog/tasks/BACK-1.2 - short-subtask.md" << 'EOF'
+---
+id: BACK-1.2
+---
+EOF
+cat > "$TEST_DIR/backlog/tasks/BACK-1.20 - longer-subtask.md" << 'EOF'
+---
+id: BACK-1.20
+---
+EOF
+
+bash "$SCRIPT_DIR/sprint-close.sh" "$TEST_DIR/backlog" >/dev/null 2>&1
+assert_equals "local close: BACK-1.2 moved" "$(ls "$TEST_DIR/backlog/completed/" | grep -c 'BACK-1.2 ')" "1"
+assert_equals "local close: BACK-1.20 stayed" "$(ls "$TEST_DIR/backlog/tasks/" | grep -c 'BACK-1.20 ')" "1"
 
 # --- no active sprint ---
 OUT=$(bash "$SCRIPT_DIR/sprint-close.sh" "$TEST_DIR/backlog" 2>&1)

--- a/skills/dev-backlog/scripts/sprint-close.sh
+++ b/skills/dev-backlog/scripts/sprint-close.sh
@@ -91,17 +91,23 @@ else
 fi
 
 # --- Step 3: Move completed task files ---
-# Collect issue numbers from checked items
-DONE_ISSUES=$(grep "$RE_CB_DONE" "$ACTIVE" | sed "s/${RE_CB_DONE}\([0-9]*\).*/\1/" || true)
+# Collect exact task-file refs from checked items through the shared parser.
+DONE_FILE_REFS=$(node "$SCRIPT_DIR/task-ref.js" completed-file-refs "$ACTIVE" "$BACKLOG_DIR")
 
-if [ -d "$TASKS_DIR" ] && [ -n "$DONE_ISSUES" ]; then
+if [ -d "$TASKS_DIR" ] && [ -n "$DONE_FILE_REFS" ]; then
   if ! $DRY_RUN; then
     mkdir -p "$COMPLETED_DIR"
   fi
-  echo "$DONE_ISSUES" | while IFS= read -r num; do
-    # Find task file matching this issue number (exact match: PREFIX-NUM space)
+  echo "$DONE_FILE_REFS" | while IFS= read -r file_ref; do
+    # Match the complete storage ref, never a numeric prefix (1 vs 11).
     TASK_FILE=$(find "$TASKS_DIR" -maxdepth 1 -name "*.md" 2>/dev/null \
-      | grep -E "/[A-Z]+-${num} - " | head -1)
+      | while IFS= read -r candidate; do
+          basename=$(basename "$candidate")
+          if [ "$basename" = "${file_ref}.md" ] || [[ "$basename" == "${file_ref} - "* ]]; then
+            printf '%s\n' "$candidate"
+            break
+          fi
+        done)
     if [ -n "$TASK_FILE" ]; then
       BASENAME=$(basename "$TASK_FILE")
       if $DRY_RUN; then

--- a/skills/dev-backlog/scripts/sprint-init.js
+++ b/skills/dev-backlog/scripts/sprint-init.js
@@ -14,6 +14,7 @@
 const { execFileSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
+const { renderTaskRef } = require("./task-ref.js");
 const { slugify, estimateSize, GH_EXEC_DEFAULTS } = require("./lib");
 const { resolveCharterPath } = require("./spec-paths.js");
 
@@ -47,7 +48,8 @@ function buildIssueLines(issues) {
     const labels = (issue.labels || []).map((l) => l.name);
     const est = estimateSize(labels);
     const suffix = est ? ` (${est})` : "";
-    return `- [ ] #${issue.number} ${issue.title}${suffix}`;
+    const ref = renderTaskRef({ tracker: "github", id: String(issue.number) });
+    return `- [ ] ${ref} ${issue.title}${suffix}`;
   });
 }
 

--- a/skills/dev-backlog/scripts/sprint-mirror.js
+++ b/skills/dev-backlog/scripts/sprint-mirror.js
@@ -20,6 +20,7 @@
 const { execFileSync } = require("child_process");
 const path = require("path");
 const { GH_EXEC_DEFAULTS } = require("./lib.js");
+const { parseTaskRef, renderTaskRef } = require("./task-ref.js");
 
 const MARKER_PREFIX = "<!-- dev-backlog:sprint-mirror sprint=";
 const MARKER_SUFFIX = " -->";
@@ -107,7 +108,10 @@ function formatPointer(item) {
 
 function formatPlanItem(item) {
   const title = item.title ? ` ${item.title}` : "";
-  return `- [${item.checkbox_state}] #${item.issue_number}${title}${formatPointer(item)}`;
+  const identity = item.tracker
+    ? item
+    : parseTaskRef(`#${item.issue_number}`);
+  return `- [${item.checkbox_state}] ${renderTaskRef(identity)}${title}${formatPointer(item)}`;
 }
 
 function renderPlanSection(planItems) {

--- a/skills/dev-backlog/scripts/sprint-mirror.test.js
+++ b/skills/dev-backlog/scripts/sprint-mirror.test.js
@@ -16,11 +16,17 @@ const {
 // --- Test fixtures ---
 
 function planItem(overrides = {}) {
+  const tracker = overrides.tracker || "github";
+  const id = overrides.id || String(overrides.issue_number || 1);
+  const ref = overrides.ref || (tracker === "github" ? `#${id}` : `BACK-${id}`);
   return {
     line: "- [ ] #1 Do the thing",
     checkbox_state: " ",
     state: "todo",
-    issue_number: 1,
+    tracker,
+    id,
+    ref,
+    issue_number: tracker === "github" ? Number(id) : null,
     title: "Do the thing",
     batch_heading: null,
     pr: null,
@@ -192,6 +198,20 @@ describe("formatPlanItem", () => {
     const item = planItem({ pr: { number: 7, state: "open" } });
     assert.equal(formatPlanItem(item), "- [ ] #1 Do the thing — PR #7 (open)");
   });
+
+  it("keeps the exported formatter compatible with legacy GitHub item input", () => {
+    const item = planItem();
+    delete item.tracker;
+    delete item.id;
+    delete item.ref;
+    assert.equal(formatPlanItem(item), "- [ ] #1 Do the thing");
+  });
+
+  it("renders local normalized refs without fabricating a GitHub issue number", () => {
+    const item = planItem({ tracker: "local", id: "11.2", ref: "BACK-11.2" });
+    assert.equal(item.issue_number, null);
+    assert.equal(formatPlanItem(item), "- [ ] BACK-11.2 Do the thing");
+  });
 });
 
 // --- renderPlanSection / renderProgressSection / renderMirrorBody ---
@@ -255,11 +275,26 @@ describe("renderMirrorBody", () => {
     });
     const body = renderMirrorBody({ state, slug: "2026-07-sample-sprint", now: new Date("2026-07-04T12:00:00Z") });
 
-    assert.ok(body.startsWith("<!-- dev-backlog:sprint-mirror sprint=2026-07-sample-sprint -->"));
-    assert.match(body, /read-only/);
-    assert.match(body, /Ship the thing\./);
-    assert.match(body, /No progress recorded yet\./);
-    assert.match(body, /Last explicit sync: 2026-07-04T12:00:00\.000Z/);
+    assert.equal(body, `<!-- dev-backlog:sprint-mirror sprint=2026-07-sample-sprint -->
+
+> The local sprint file is canonical. This mirror is read-only — it is
+> not edited by hand — and sync is always explicit; there is no daemon.
+
+## Goal
+
+Ship the thing.
+
+## Plan
+
+- [ ] #1 PR item — PR #7 (merged)
+- [ ] #2 Run item — run:run-1
+- [~] #3 Unmoored — (unmoored)
+
+## Latest Progress
+
+_No progress recorded yet._
+
+Last explicit sync: 2026-07-04T12:00:00.000Z`);
   });
 });
 

--- a/skills/dev-backlog/scripts/sprint-state.js
+++ b/skills/dev-backlog/scripts/sprint-state.js
@@ -8,13 +8,17 @@
 
 const fs = require("fs");
 const path = require("path");
-const { parseSimpleYaml } = require("./lib.js");
+const { parseSimpleYaml, readConfig } = require("./lib.js");
+const {
+  containsTaskRef,
+  githubIssueNumber,
+  parsePlanCheckbox,
+} = require("./task-ref.js");
 
 const SCHEMA_VERSION = 1;
 const DEFAULT_BACKLOG_DIR = "backlog";
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
-const CHECKBOX_RE = /^- \[( |~|x)\] #(\d+)(?:\s+(.*))?$/;
 const RUN_ID_RE = /\[run:([^\]]+)\]$/;
 const BRANCH_RE = /\[branch:([^\]\s]+)\]/;
 const PR_RE = /→ PR #(\d+) \((\w+)\)$/;
@@ -146,7 +150,7 @@ function parseProgressEntries(progressLines) {
     });
 }
 
-function parsePlanItems(planLines) {
+function parsePlanItems(planLines, options = {}) {
   const items = [];
   let batchHeading = null;
 
@@ -156,20 +160,20 @@ function parsePlanItems(planLines) {
       continue;
     }
 
-    const item = parsePlanItem(line, batchHeading);
+    const item = parsePlanItem(line, batchHeading, options);
     if (item) items.push(item);
   }
 
   return items;
 }
 
-function parsePlanItem(line, batchHeading = null) {
-  const checkbox = line.match(CHECKBOX_RE);
+function parsePlanItem(line, batchHeading = null, options = {}) {
+  const checkbox = parsePlanCheckbox(line, options);
   if (!checkbox) return null;
 
-  const checkboxState = checkbox[1];
-  const issueNumber = Number.parseInt(checkbox[2], 10);
-  let title = (checkbox[3] || "").trim();
+  const checkboxState = checkbox.checkboxState;
+  const identity = checkbox.identity;
+  let title = checkbox.title;
 
   const runMatch = line.match(RUN_ID_RE);
   const runId = runMatch ? runMatch[1] : null;
@@ -191,7 +195,10 @@ function parsePlanItem(line, batchHeading = null) {
     line,
     checkbox_state: checkboxState,
     state,
-    issue_number: issueNumber,
+    tracker: identity.tracker,
+    id: identity.id,
+    ref: identity.ref,
+    issue_number: githubIssueNumber(identity),
     title,
     batch_heading: batchHeading,
     pr,
@@ -241,10 +248,12 @@ function daysBetween(startDate, endDate) {
   return Math.max(0, Math.floor((dateToUtcMs(endDate) - dateToUtcMs(startDate)) / MS_PER_DAY));
 }
 
-function computeAge(issueNumber, progressEntries, startedDate, today) {
-  const issueRe = new RegExp(`#${issueNumber}(?!\\d)`);
+function computeAge(identityOrIssueNumber, progressEntries, startedDate, today) {
+  const identity = typeof identityOrIssueNumber === "number"
+    ? { tracker: "github", id: String(identityOrIssueNumber), ref: `#${identityOrIssueNumber}` }
+    : identityOrIssueNumber;
   const progressDates = progressEntries
-    .filter((entry) => entry.date && issueRe.test(entry.line))
+    .filter((entry) => entry.date && containsTaskRef(entry.line, identity))
     .map((entry) => entry.date)
     .sort();
 
@@ -277,17 +286,18 @@ function parseSprintContent({
   sprintPath,
   content,
   today = new Date(),
+  taskPrefix = "BACK",
 }) {
   const frontmatter = parseFrontmatter(content);
   const goal = extractSectionLines(content, "Goal").join("\n").trim();
-  const planItems = parsePlanItems(extractSectionLines(content, "Plan"));
+  const planItems = parsePlanItems(extractSectionLines(content, "Plan"), { taskPrefix });
   const progressEntries = parseProgressEntries(extractSectionLines(content, "Progress"));
   const nextBatch = findNextBatch(planItems);
   const inFlight = planItems
     .filter((item) => item.state === "in_flight")
     .map((item) => ({
       ...item,
-      ...computeAge(item.issue_number, progressEntries, frontmatter.started, today),
+      ...computeAge(item, progressEntries, frontmatter.started, today),
     }));
 
   return {
@@ -333,6 +343,7 @@ function readSprintState({
     sprintPath,
     content: readFileSync(sprintPath, "utf-8"),
     today,
+    taskPrefix: readConfig(backlogDir).task_prefix,
   });
 }
 

--- a/skills/dev-backlog/scripts/sprint-state.test.js
+++ b/skills/dev-backlog/scripts/sprint-state.test.js
@@ -81,6 +81,9 @@ Expose actor-readable execution state.
       line: "- [~] #211 Add JSON surfaces (~2hr) → PR #224 (reviewing) [run:issue-211-20260701120000000]",
       checkbox_state: "~",
       state: "in_flight",
+      tracker: "github",
+      id: "211",
+      ref: "#211",
       issue_number: 211,
       title: "Add JSON surfaces (~2hr)",
       batch_heading: "### Batch 2 - Active",
@@ -123,6 +126,39 @@ Expose actor-readable execution state.
       () => readSprintState({ backlogDir }),
       /Multiple active sprint files found/
     );
+  });
+
+  it("uses the configured prefix for mixed GitHub and local Plan identities", () => {
+    writeFile(path.join(backlogDir, "config.yml"), "task_prefix: TASK\n");
+    writeFile(path.join(backlogDir, "sprints", "mixed.md"), `---
+status: active
+started: 2026-07-01
+---
+
+## Plan
+- [~] #1 Legacy task → PR #11 (reviewing)
+- [ ] TASK-11.2 Local subtask
+
+## Progress
+- 2026-07-02: #11 is a different GitHub task.
+- 2026-07-03: #1 dispatched → PR #11
+`);
+
+    const state = readSprintState({
+      backlogDir,
+      today: new Date("2026-07-04T00:00:00Z"),
+    });
+
+    assert.equal(state.schema_version, 1);
+    assert.deepEqual(state.plan_items.map(({ tracker, id, ref, issue_number }) => ({
+      tracker, id, ref, issue_number,
+    })), [
+      { tracker: "github", id: "1", ref: "#1", issue_number: 1 },
+      { tracker: "local", id: "11.2", ref: "TASK-11.2", issue_number: null },
+    ]);
+    assert.equal(state.plan_items[0].pr.number, 11);
+    assert.equal(state.in_flight[0].age_basis_date, "2026-07-03");
+    assert.deepEqual(state.next_batch.items.map((item) => item.ref), ["TASK-11.2"]);
   });
 });
 
@@ -213,5 +249,32 @@ status: active
     assert.equal(withoutDate.in_flight[0].age_days, null);
     assert.equal(withoutDate.in_flight[0].age_source, null);
     assert.equal(withoutDate.in_flight[0].age_basis_date, null);
+  });
+
+  it("matches local Progress refs exactly across parents and decimal subtasks", () => {
+    const state = parseSprintContent({
+      sprintPath: "backlog/sprints/local-age.md",
+      taskPrefix: "BACK",
+      content: `---
+status: active
+started: 2026-06-30
+---
+
+## Plan
+- [~] BACK-1 Parent
+- [~] BACK-1.1 Subtask
+
+## Progress
+- 2026-07-01: BACK-11 is unrelated.
+- 2026-07-02: BACK-1.1 started.
+- 2026-07-03: BACK-1 started.
+`,
+      today: new Date("2026-07-04T00:00:00Z"),
+    });
+
+    assert.deepEqual(state.in_flight.map((item) => [item.ref, item.age_basis_date]), [
+      ["BACK-1", "2026-07-03"],
+      ["BACK-1.1", "2026-07-02"],
+    ]);
   });
 });

--- a/skills/dev-backlog/scripts/status.sh
+++ b/skills/dev-backlog/scripts/status.sh
@@ -47,7 +47,7 @@ if [ -d "$SPRINTS_DIR" ]; then
     fi
 
     # Show in-flight items (dispatched via dev-relay)
-    IN_FLIGHT_ITEMS=$(grep "$RE_CB_INFLIGHT" "$ACTIVE" | head -3)
+    IN_FLIGHT_ITEMS=$(checkbox_lines "$ACTIVE" "~" | head -3)
     if [ -n "$IN_FLIGHT_ITEMS" ]; then
       echo ""
       echo "In flight:"
@@ -55,7 +55,7 @@ if [ -d "$SPRINTS_DIR" ]; then
     fi
 
     # Show next unchecked items
-    NEXT_ITEMS=$(grep "$RE_CB_TODO" "$ACTIVE" | head -3)
+    NEXT_ITEMS=$(checkbox_lines "$ACTIVE" " " | head -3)
     if [ -n "$NEXT_ITEMS" ]; then
       echo ""
       echo "Next up:"

--- a/skills/dev-backlog/scripts/sync-pull.js
+++ b/skills/dev-backlog/scripts/sync-pull.js
@@ -23,6 +23,12 @@ const {
   getOpenIssueCount: getSharedOpenIssueCount,
 } = require("./lib");
 const { parseMarkerMonth } = require("./progress-sync-render");
+const {
+  parseTaskFileName,
+  parseTaskRef,
+  sameTaskIdentity,
+  taskFileRef,
+} = require("./task-ref.js");
 
 const ISSUE_JSON_FIELDS = "number,title,body,labels,milestone,assignees";
 
@@ -146,18 +152,31 @@ function recordOperation(result, type, file) {
   if (type === "skipped") result.skippedFiles.push(file);
 }
 
-function findExistingTaskFile({ tasksDir, prefix, issueNumber }) {
-  const prefixMatch = `${prefix}-${issueNumber} - `;
+function githubTaskIdentity(issueNumber) {
+  const identity = parseTaskRef(`#${issueNumber}`);
+  if (!identity) throw new Error(`Invalid GitHub issue number: ${issueNumber}`);
+  return identity;
+}
+
+function findExistingTaskFile({ tasksDir, prefix, identity }) {
   if (!fs.existsSync(tasksDir)) return undefined;
-  return fs.readdirSync(tasksDir).find((file) => file.startsWith(prefixMatch) && file.endsWith(".md"));
+  return fs.readdirSync(tasksDir).find((file) => sameTaskIdentity(
+    parseTaskFileName(file, { taskPrefix: prefix, tracker: "github" }),
+    identity,
+  ));
 }
 
-function buildTaskFilename({ issue, prefix }) {
+function buildTaskFilename({ issue, prefix, identity = githubTaskIdentity(issue.number) }) {
   const slug = slugify(issue.title) || String(issue.number);
-  return `${prefix}-${issue.number} - ${slug}.md`;
+  return `${taskFileRef(identity, { taskPrefix: prefix })} - ${slug}.md`;
 }
 
-function buildTaskFrontmatter({ issue, prefix, today = new Date().toISOString().slice(0, 10) }) {
+function buildTaskFrontmatter({
+  issue,
+  prefix,
+  identity = githubTaskIdentity(issue.number),
+  today = new Date().toISOString().slice(0, 10),
+}) {
   const labelNames = (issue.labels || []).map((label) => label.name);
   const milestone = issue.milestone?.title || "";
   const status = statusFromLabels(labelNames);
@@ -170,7 +189,7 @@ function buildTaskFrontmatter({ issue, prefix, today = new Date().toISOString().
     : " []";
 
   return `---
-id: ${prefix}-${issue.number}
+id: ${taskFileRef(identity, { taskPrefix: prefix })}
 title: ${escapeYaml(issue.title)}
 status: ${status}
 labels:${labelsYaml}
@@ -190,10 +209,11 @@ function isMachineManagedIssueBody(body) {
 }
 
 function syncIssueToTaskFile({ issue, tasksDir, prefix, update, dryRun, result }) {
-  const filename = buildTaskFilename({ issue, prefix });
+  const identity = githubTaskIdentity(issue.number);
+  const filename = buildTaskFilename({ issue, prefix, identity });
   const filepath = path.join(tasksDir, filename);
-  const existing = findExistingTaskFile({ tasksDir, prefix, issueNumber: issue.number });
-  const frontmatter = buildTaskFrontmatter({ issue, prefix });
+  const existing = findExistingTaskFile({ tasksDir, prefix, identity });
+  const frontmatter = buildTaskFrontmatter({ issue, prefix, identity });
   const structuredBody = structureBody(issue.body || "");
 
   if (existing) {

--- a/skills/dev-backlog/scripts/sync-pull.test.js
+++ b/skills/dev-backlog/scripts/sync-pull.test.js
@@ -328,6 +328,46 @@ describe("run (integration)", () => {
     assert.equal(files[2], "BACK-3 - third.md");
   });
 
+  it("uses normalized identity for exact #1/#11 task-file lookup", () => {
+    const longerTask = "---\nid: BACK-11\n---\nLonger task body";
+    fs.writeFileSync(path.join(tasksDir, "BACK-11 - longer.md"), longerTask);
+
+    const result = run({
+      issues: [makeIssue({ number: 1, title: "Short" })],
+      tasksDir,
+      prefix: "BACK",
+      update: false,
+      dryRun: false,
+    });
+
+    assert.deepEqual(fs.readdirSync(tasksDir).sort(), [
+      "BACK-1 - short.md",
+      "BACK-11 - longer.md",
+    ]);
+    assert.equal(
+      fs.readFileSync(path.join(tasksDir, "BACK-11 - longer.md"), "utf-8"),
+      longerTask,
+    );
+    assert.deepEqual(result.createdFiles, ["BACK-1 - short.md"]);
+    assert.deepEqual(result.skippedFiles, []);
+  });
+
+  it("preserves the existing GitHub task filename and frontmatter id byte shape", () => {
+    run({
+      issues: [makeIssue({ number: 11, title: "Existing GitHub Shape" })],
+      tasksDir,
+      prefix: "TASK",
+      update: false,
+      dryRun: false,
+    });
+
+    const file = "TASK-11 - existing-github-shape.md";
+    assert.deepEqual(fs.readdirSync(tasksDir), [file]);
+    const content = fs.readFileSync(path.join(tasksDir, file), "utf-8");
+    assert.match(content, /^---\nid: TASK-11\ntitle: Existing GitHub Shape\n/);
+    assert.match(content, /\n---\n## Description\nImplement OAuth2\n$/);
+  });
+
   it("skips existing files without --update", () => {
     // Pre-create a file
     fs.writeFileSync(

--- a/skills/dev-backlog/scripts/task-ref.js
+++ b/skills/dev-backlog/scripts/task-ref.js
@@ -88,7 +88,7 @@ function containsTaskRef(text, identity) {
   if (typeof text !== "string" || !identity) return false;
   const ref = renderTaskRef(identity);
   const escaped = escapeRegExp(ref);
-  const left = identity.tracker === "github" ? "[^A-Za-z0-9_#]" : "[^A-Za-z0-9_]";
+  const left = identity.tracker === "github" ? "[^A-Za-z0-9_#]" : "[^A-Za-z0-9_-]";
   const right = identity.tracker === "github"
     ? "(?![A-Za-z0-9_]|\\.\\d)"
     : "(?![A-Za-z0-9_-]|\\.\\d)";

--- a/skills/dev-backlog/scripts/task-ref.js
+++ b/skills/dev-backlog/scripts/task-ref.js
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+/**
+ * Canonical task-reference parsing, rendering, and identity helpers.
+ *
+ * Task refs are complete tokens: GitHub #N or configured local PREFIX-N,
+ * where local IDs may use Backlog.md decimal subtask notation (N.M).
+ * Provider metadata such as `PR #N` is intentionally outside this module.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const DEFAULT_TASK_PREFIX = "BACK";
+const GITHUB_ID_RE = /^[1-9]\d*$/;
+const LOCAL_ID_RE = /^[1-9]\d*(?:\.[1-9]\d*)?$/;
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function taskPrefix(options = {}) {
+  const prefix = options.taskPrefix ?? DEFAULT_TASK_PREFIX;
+  if (typeof prefix !== "string" || !prefix || /\s/.test(prefix)) {
+    throw new Error("taskPrefix must be a non-empty string without whitespace");
+  }
+  return prefix;
+}
+
+function parseTaskRef(value, options = {}) {
+  if (typeof value !== "string") return null;
+
+  if (value.startsWith("#")) {
+    const id = value.slice(1);
+    return GITHUB_ID_RE.test(id) ? { tracker: "github", id, ref: value } : null;
+  }
+
+  const prefix = taskPrefix(options);
+  const localPrefix = `${prefix}-`;
+  if (!value.startsWith(localPrefix)) return null;
+  const id = value.slice(localPrefix.length);
+  return LOCAL_ID_RE.test(id) ? { tracker: "local", id, ref: value } : null;
+}
+
+function renderTaskRef(identity, options = {}) {
+  if (!identity || typeof identity !== "object") {
+    throw new Error("task identity must be an object");
+  }
+
+  const { tracker, id } = identity;
+  if (typeof id !== "string") throw new Error("task identity id must be a string");
+
+  let ref;
+  if (tracker === "github" && GITHUB_ID_RE.test(id)) {
+    ref = `#${id}`;
+  } else if (tracker === "local" && LOCAL_ID_RE.test(id)) {
+    if (options.taskPrefix === undefined && typeof identity.ref === "string") {
+      const suffix = `-${id}`;
+      const prefix = identity.ref.endsWith(suffix)
+        ? identity.ref.slice(0, -suffix.length)
+        : "";
+      if (!prefix || /\s/.test(prefix)) throw new Error("invalid local task identity ref");
+      ref = identity.ref;
+    } else {
+      ref = `${taskPrefix(options)}-${id}`;
+    }
+  } else {
+    throw new Error(`invalid ${String(tracker)} task identity: ${String(id)}`);
+  }
+
+  if (identity.ref !== undefined && identity.ref !== ref) {
+    throw new Error(`task identity ref ${identity.ref} does not match ${ref}`);
+  }
+  return ref;
+}
+
+function sameTaskIdentity(left, right) {
+  return Boolean(
+    left
+      && right
+      && typeof left.id === "string"
+      && typeof right.id === "string"
+      && left.tracker === right.tracker
+      && left.id === right.id
+  );
+}
+
+function containsTaskRef(text, identity) {
+  if (typeof text !== "string" || !identity) return false;
+  const ref = renderTaskRef(identity);
+  const escaped = escapeRegExp(ref);
+  const left = identity.tracker === "github" ? "[^A-Za-z0-9_#]" : "[^A-Za-z0-9_]";
+  const right = identity.tracker === "github" ? "(?![\\d.])" : "(?![A-Za-z0-9_.-])";
+  const matcher = new RegExp(`(^|${left})(${escaped})${right}`, "g");
+
+  for (const match of text.matchAll(matcher)) {
+    const refStart = match.index + match[1].length;
+    if (/PR\s$/.test(text.slice(Math.max(0, refStart - 3), refStart))) continue;
+    return true;
+  }
+  return false;
+}
+
+function parsePlanCheckbox(line, options = {}) {
+  if (typeof line !== "string") return null;
+  const match = line.match(/^- \[( |~|x)\] (\S+)(?:\s+(.*))?$/);
+  if (!match) return null;
+  const identity = parseTaskRef(match[2], options);
+  if (!identity) return null;
+  return {
+    checkboxState: match[1],
+    identity,
+    title: (match[3] || "").trim(),
+  };
+}
+
+function githubIssueNumber(identity) {
+  return identity?.tracker === "github" ? Number(identity.id) : null;
+}
+
+function taskFileRef(identity, options = {}) {
+  if (!identity) throw new Error("task identity is required");
+  if (identity.tracker === "github") {
+    if (!GITHUB_ID_RE.test(identity.id)) throw new Error("invalid GitHub task identity");
+    return `${taskPrefix(options)}-${identity.id}`;
+  }
+  return renderTaskRef(identity, options);
+}
+
+function parseTaskFileName(fileName, options = {}) {
+  const base = path.basename(String(fileName || ""));
+  const inferred = base.match(/^(.+)-[1-9]\d*(?:\.[1-9]\d*)?(?: - .+)?\.md$/);
+  const prefix = options.taskPrefix === undefined && inferred
+    ? inferred[1]
+    : taskPrefix(options);
+  const match = base.match(
+    new RegExp(`^(${escapeRegExp(prefix)}-([1-9]\\d*(?:\\.[1-9]\\d*)?))(?: - .+)?\\.md$`)
+  );
+  if (!match) return null;
+
+  const tracker = options.tracker ?? "github";
+  if (tracker === "github") {
+    if (!GITHUB_ID_RE.test(match[2])) return null;
+    return { tracker, id: match[2], ref: `#${match[2]}` };
+  }
+  if (tracker === "local") return { tracker, id: match[2], ref: match[1] };
+  return null;
+}
+
+function cliOptions(backlogDir) {
+  const { readConfig } = require("./lib.js");
+  return { taskPrefix: readConfig(backlogDir).task_prefix };
+}
+
+function parsedPlanLines(file, backlogDir) {
+  const options = cliOptions(backlogDir);
+  return fs.readFileSync(file, "utf-8").split(/\r?\n/)
+    .map((line) => ({ line, parsed: parsePlanCheckbox(line, options) }))
+    .filter((entry) => entry.parsed);
+}
+
+function main() {
+  const [command, file, backlogDir, marker] = process.argv.slice(2);
+  if (!command || !file || !backlogDir) {
+    console.error("Usage: task-ref.js plan-lines|counts|completed-file-refs <file> <backlog-dir> [marker]");
+    process.exit(1);
+  }
+
+  const entries = parsedPlanLines(file, backlogDir);
+  if (command === "plan-lines") {
+    const filtered = marker === undefined
+      ? entries
+      : entries.filter(({ parsed }) => parsed.checkboxState === marker);
+    process.stdout.write(filtered.map(({ line }) => line).join("\n"));
+    if (filtered.length > 0) process.stdout.write("\n");
+    return;
+  }
+  if (command === "counts") {
+    const counts = { x: 0, "~": 0, " ": 0 };
+    for (const { parsed } of entries) counts[parsed.checkboxState] += 1;
+    process.stdout.write(`${entries.length} ${counts.x} ${counts["~"]} ${counts[" "]}\n`);
+    return;
+  }
+  if (command === "completed-file-refs") {
+    const options = cliOptions(backlogDir);
+    const refs = entries
+      .filter(({ parsed }) => parsed.checkboxState === "x")
+      .map(({ parsed }) => taskFileRef(parsed.identity, options));
+    process.stdout.write(refs.join("\n"));
+    if (refs.length > 0) process.stdout.write("\n");
+    return;
+  }
+
+  console.error(`Unknown command: ${command}`);
+  process.exit(1);
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  DEFAULT_TASK_PREFIX,
+  parseTaskRef,
+  renderTaskRef,
+  sameTaskIdentity,
+  containsTaskRef,
+  parsePlanCheckbox,
+  githubIssueNumber,
+  taskFileRef,
+  parseTaskFileName,
+};

--- a/skills/dev-backlog/scripts/task-ref.js
+++ b/skills/dev-backlog/scripts/task-ref.js
@@ -89,7 +89,9 @@ function containsTaskRef(text, identity) {
   const ref = renderTaskRef(identity);
   const escaped = escapeRegExp(ref);
   const left = identity.tracker === "github" ? "[^A-Za-z0-9_#]" : "[^A-Za-z0-9_]";
-  const right = identity.tracker === "github" ? "(?![\\d.])" : "(?![A-Za-z0-9_.-])";
+  const right = identity.tracker === "github"
+    ? "(?![A-Za-z0-9_]|\\.\\d)"
+    : "(?![A-Za-z0-9_-]|\\.\\d)";
   const matcher = new RegExp(`(^|${left})(${escaped})${right}`, "g");
 
   for (const match of text.matchAll(matcher)) {
@@ -128,12 +130,17 @@ function taskFileRef(identity, options = {}) {
 
 function parseTaskFileName(fileName, options = {}) {
   const base = path.basename(String(fileName || ""));
-  const inferred = base.match(/^(.+)-[1-9]\d*(?:\.[1-9]\d*)?(?: - .+)?\.md$/);
+  if (!base.endsWith(".md")) return null;
+  const stem = base.slice(0, -3);
+  const slugSeparator = stem.indexOf(" - ");
+  if (slugSeparator !== -1 && slugSeparator === stem.length - 3) return null;
+  const taskStem = slugSeparator === -1 ? stem : stem.slice(0, slugSeparator);
+  const inferred = taskStem.match(/^(.+)-([1-9]\d*(?:\.[1-9]\d*)?)$/);
   const prefix = options.taskPrefix === undefined && inferred
     ? inferred[1]
     : taskPrefix(options);
-  const match = base.match(
-    new RegExp(`^(${escapeRegExp(prefix)}-([1-9]\\d*(?:\\.[1-9]\\d*)?))(?: - .+)?\\.md$`)
+  const match = taskStem.match(
+    new RegExp(`^(${escapeRegExp(prefix)}-([1-9]\\d*(?:\\.[1-9]\\d*)?))$`)
   );
   if (!match) return null;
 

--- a/skills/dev-backlog/scripts/task-ref.test.js
+++ b/skills/dev-backlog/scripts/task-ref.test.js
@@ -101,6 +101,13 @@ describe("containsTaskRef", () => {
     assert.equal(containsTaskRef("- 2026-07-01: BACK-42_suffix is not exact", task), false);
     assert.equal(containsTaskRef("- 2026-07-01: BACK-42.1 is a descendant", task), false);
   });
+
+  it("rejects hyphenated identifier prefixes while allowing a list delimiter", () => {
+    const task = parseTaskRef("BACK-1", OPTIONS);
+    assert.equal(containsTaskRef("- 2026-07-01: MY-BACK-1 is not exact", task), false);
+    assert.equal(containsTaskRef("- 2026-07-01: prefix-BACK-1 is not exact", task), false);
+    assert.equal(containsTaskRef("- 2026-07-01: - BACK-1 started", task), true);
+  });
 });
 
 describe("Plan and task-file boundaries", () => {

--- a/skills/dev-backlog/scripts/task-ref.test.js
+++ b/skills/dev-backlog/scripts/task-ref.test.js
@@ -3,6 +3,8 @@ const assert = require("node:assert/strict");
 
 const {
   containsTaskRef,
+  parsePlanCheckbox,
+  parseTaskFileName,
   parseTaskRef,
   renderTaskRef,
 } = require("./task-ref.js");
@@ -71,6 +73,7 @@ describe("containsTaskRef", () => {
     assert.equal(containsTaskRef("- 2026-07-01: #1 started", one), true);
     assert.equal(containsTaskRef("- 2026-07-01: #11 started", one), false);
     assert.equal(containsTaskRef("- 2026-07-01: note#1 started", one), false);
+    assert.equal(containsTaskRef("- 2026-07-01: review → PR #1", one), false);
   });
 
   it("keeps BACK-1 distinct from BACK-11 and decimal descendants", () => {
@@ -79,5 +82,29 @@ describe("containsTaskRef", () => {
     assert.equal(containsTaskRef("- 2026-07-01: BACK-11 started", one), false);
     assert.equal(containsTaskRef("- 2026-07-01: BACK-1.1 started", one), false);
     assert.equal(containsTaskRef("- 2026-07-01: XBACK-1 started", one), false);
+  });
+});
+
+describe("Plan and task-file boundaries", () => {
+  it("parses only a complete task token after a supported checkbox", () => {
+    assert.deepEqual(parsePlanCheckbox("- [~] BACK-1.2 Child [branch:child]", OPTIONS), {
+      checkboxState: "~",
+      identity: { tracker: "local", id: "1.2", ref: "BACK-1.2" },
+      title: "Child [branch:child]",
+    });
+    assert.equal(parsePlanCheckbox("- [ ] BACK-1.2x Partial", OPTIONS), null);
+  });
+
+  it("parses exact configured task filenames and keeps tracker aliases explicit", () => {
+    assert.deepEqual(parseTaskFileName("BACK-1 - short.md", {
+      ...OPTIONS,
+      tracker: "github",
+    }), { tracker: "github", id: "1", ref: "#1" });
+    assert.deepEqual(parseTaskFileName("BACK-11.2 - child.md", {
+      ...OPTIONS,
+      tracker: "local",
+    }), { tracker: "local", id: "11.2", ref: "BACK-11.2" });
+    assert.equal(parseTaskFileName("BACK-1x - partial.md", OPTIONS), null);
+    assert.equal(parseTaskFileName("OTHER-1 - foreign.md", OPTIONS), null);
   });
 });

--- a/skills/dev-backlog/scripts/task-ref.test.js
+++ b/skills/dev-backlog/scripts/task-ref.test.js
@@ -76,12 +76,30 @@ describe("containsTaskRef", () => {
     assert.equal(containsTaskRef("- 2026-07-01: review → PR #1", one), false);
   });
 
+  it("accepts sentence punctuation but rejects GitHub token suffixes and decimals", () => {
+    const task = parseTaskRef("#42", OPTIONS);
+    assert.equal(containsTaskRef("- 2026-07-01: completed #42.", task), true);
+    assert.equal(containsTaskRef("- 2026-07-01: completed (#42),", task), true);
+    assert.equal(containsTaskRef("- 2026-07-01: #42abc is not exact", task), false);
+    assert.equal(containsTaskRef("- 2026-07-01: #42_suffix is not exact", task), false);
+    assert.equal(containsTaskRef("- 2026-07-01: #42.1 is not an issue ref", task), false);
+  });
+
   it("keeps BACK-1 distinct from BACK-11 and decimal descendants", () => {
     const one = parseTaskRef("BACK-1", OPTIONS);
     assert.equal(containsTaskRef("- 2026-07-01: BACK-1 started", one), true);
     assert.equal(containsTaskRef("- 2026-07-01: BACK-11 started", one), false);
     assert.equal(containsTaskRef("- 2026-07-01: BACK-1.1 started", one), false);
     assert.equal(containsTaskRef("- 2026-07-01: XBACK-1 started", one), false);
+  });
+
+  it("accepts local sentence punctuation but rejects token suffixes and descendants", () => {
+    const task = parseTaskRef("BACK-42", OPTIONS);
+    assert.equal(containsTaskRef("- 2026-07-01: completed BACK-42.", task), true);
+    assert.equal(containsTaskRef("- 2026-07-01: completed (BACK-42),", task), true);
+    assert.equal(containsTaskRef("- 2026-07-01: BACK-42abc is not exact", task), false);
+    assert.equal(containsTaskRef("- 2026-07-01: BACK-42_suffix is not exact", task), false);
+    assert.equal(containsTaskRef("- 2026-07-01: BACK-42.1 is a descendant", task), false);
   });
 });
 
@@ -106,5 +124,14 @@ describe("Plan and task-file boundaries", () => {
     }), { tracker: "local", id: "11.2", ref: "BACK-11.2" });
     assert.equal(parseTaskFileName("BACK-1x - partial.md", OPTIONS), null);
     assert.equal(parseTaskFileName("OTHER-1 - foreign.md", OPTIONS), null);
+  });
+
+  it("infers identity before a numeric slug instead of treating the slug as the id", () => {
+    assert.deepEqual(parseTaskFileName("BACK-1 - phase-2.md", {
+      tracker: "github",
+    }), { tracker: "github", id: "1", ref: "#1" });
+    assert.deepEqual(parseTaskFileName("BACK-11.2 - phase-3.md", {
+      tracker: "local",
+    }), { tracker: "local", id: "11.2", ref: "BACK-11.2" });
   });
 });

--- a/skills/dev-backlog/scripts/task-ref.test.js
+++ b/skills/dev-backlog/scripts/task-ref.test.js
@@ -1,0 +1,83 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  containsTaskRef,
+  parseTaskRef,
+  renderTaskRef,
+} = require("./task-ref.js");
+
+const OPTIONS = { taskPrefix: "BACK" };
+
+describe("parseTaskRef", () => {
+  it("normalizes complete GitHub and configured-prefix refs", () => {
+    assert.deepEqual(parseTaskRef("#1", OPTIONS), {
+      tracker: "github",
+      id: "1",
+      ref: "#1",
+    });
+    assert.deepEqual(parseTaskRef("BACK-42", OPTIONS), {
+      tracker: "local",
+      id: "42",
+      ref: "BACK-42",
+    });
+  });
+
+  it("preserves supported decimal local subtask identities", () => {
+    assert.deepEqual(parseTaskRef("BACK-42.10", OPTIONS), {
+      tracker: "local",
+      id: "42.10",
+      ref: "BACK-42.10",
+    });
+    assert.equal(parseTaskRef("#42.10", OPTIONS), null);
+  });
+
+  it("rejects zero, negative, malformed, partial, and foreign-prefix refs", () => {
+    for (const ref of [
+      "#0",
+      "#-1",
+      "#1 trailing",
+      "prefix #1",
+      "BACK-0",
+      "BACK--1",
+      "BACK-1.",
+      "BACK-1.0",
+      "BACK-1.2.3",
+      "BACK-1 trailing",
+      "OTHER-1",
+      "",
+    ]) {
+      assert.equal(parseTaskRef(ref, OPTIONS), null, ref);
+    }
+  });
+});
+
+describe("renderTaskRef", () => {
+  it("renders normalized identities without changing GitHub refs", () => {
+    assert.equal(renderTaskRef({ tracker: "github", id: "11" }, OPTIONS), "#11");
+    assert.equal(renderTaskRef({ tracker: "local", id: "11.2" }, OPTIONS), "BACK-11.2");
+  });
+
+  it("rejects identities outside the task-ref grammar", () => {
+    assert.throws(() => renderTaskRef({ tracker: "github", id: "1.2" }, OPTIONS));
+    assert.throws(() => renderTaskRef({ tracker: "local", id: "0" }, OPTIONS));
+    assert.throws(() => renderTaskRef({ tracker: "other", id: "1" }, OPTIONS));
+  });
+});
+
+describe("containsTaskRef", () => {
+  it("keeps #1 distinct from #11 at both boundaries", () => {
+    const one = parseTaskRef("#1", OPTIONS);
+    assert.equal(containsTaskRef("- 2026-07-01: #1 started", one), true);
+    assert.equal(containsTaskRef("- 2026-07-01: #11 started", one), false);
+    assert.equal(containsTaskRef("- 2026-07-01: note#1 started", one), false);
+  });
+
+  it("keeps BACK-1 distinct from BACK-11 and decimal descendants", () => {
+    const one = parseTaskRef("BACK-1", OPTIONS);
+    assert.equal(containsTaskRef("- 2026-07-01: BACK-1 started", one), true);
+    assert.equal(containsTaskRef("- 2026-07-01: BACK-11 started", one), false);
+    assert.equal(containsTaskRef("- 2026-07-01: BACK-1.1 started", one), false);
+    assert.equal(containsTaskRef("- 2026-07-01: XBACK-1 started", one), false);
+  });
+});


### PR DESCRIPTION
## Summary

- add one exported task-reference module for exact GitHub `#N` and local `{PREFIX}-N[.M]` identities
- migrate sprint state, shell status/next/counting, closeout, mirror, and progress readers to shared semantics
- preserve schema v1 and GitHub `issue_number`/Markdown compatibility while adding `tracker`, `id`, and `ref`
- document the additive actor contract and extend collision, mixed-fixture, golden-output, and smoke coverage

## Validation

- `git diff --check b86d147..HEAD`
- `node --test skills/*/scripts/*.test.js` (466 pass, 1 skip)
- `bash skills/dev-backlog/scripts/smoke-test.sh` (151/151)
- component lint, capabilities doctor, and backlog doctor (all pass)

## Review

- independent Cursor primary review: all Done Criteria verified, contract/quality pass, evaluated factors 9/10
- relay hardened advisory providers failed by timeout/transport without returning a code finding; the audit trail remains attached to run `issue-274-20260711070944536-8a833b7d`
- two fresh read-only sub-agent review loops found and closed `sync-pull` identity, filename inference, punctuation/suffix, and hyphenated-prefix boundary gaps; final verdict LGTM at `63bdbb9`
- all GitHub review threads are resolved

Fixes #274
