### PR TITLE
chore: record task reference completion

### DIFF
--- a/backlog/sprints/2026-07-tracker-seam.md
+++ b/backlog/sprints/2026-07-tracker-seam.md
@@ -21,7 +21,7 @@ Existing GitHub users retain compatible behavior while core sprint execution gai
 - [x] #273 Add configured tracker selection and the core adapter seam (~2hr) → PR #282 (merged)
 
 ### Batch 3 - Generalize task identity (after #273)
-- [ ] #274 Add backward-compatible tracker-neutral task references (~2hr)
+- [x] #274 Add backward-compatible tracker-neutral task references (~2hr) → PR #284 (merged)
 
 ### Batch 4 - Preserve GitHub behind the seam (after #273 and #274)
 - [ ] #275 Move existing GitHub behavior behind the tracker adapter (~3hr)
@@ -33,6 +33,7 @@ Existing GitHub users retain compatible behavior while core sprint execution gai
 - Existing GitHub markdown, CLI, JSON, and helper exports are compatibility surfaces. Additive normalized fields must not remove `issue_number` or rewrite historical sprints.
 - #272 found nine production files that invoke `gh` directly. `progress-sync.js` also has an independent exported `readActiveSprintSummary` parser for numeric Plan checkboxes; #274 must migrate that path as well as `sprint-state.js`.
 - #273 added `tracker.js`: selection comes only from configuration, a missing key defaults to GitHub, resolution probes only the configured adapter, required operations and identities are validated exactly, and provider-specific features are capability-gated. The local slot remains explicitly unavailable until #276.
+- #274 added one exact task-ref seam for GitHub `#N` and local `{PREFIX}-N[.M]`; sprint state now exposes additive `tracker`/`id`/`ref`, keeps GitHub `issue_number`, and all sprint, mirror, progress, closeout, and task-file lookup paths share the same boundary rules.
 - Sprint A is deliberately serial because #273-#275 share the tracker resolver, sprint parser, and GitHub call sites. Sprint B starts only after GitHub regression proof merges.
 
 ## Progress
@@ -40,3 +41,4 @@ Existing GitHub users retain compatible behavior while core sprint execution gai
 - 2026-07-11: Sprint A opened with four serial execution waves; task mirrors refreshed from live GitHub state.
 - 2026-07-11: #272 → PR #280 merged after internal/post-publication review (LGTM, round 4); design contract froze nine direct `gh` callers, numeric identity surfaces, compatibility promises, and #273-#275 verification ownership.
 - 2026-07-11: #273 → PR #282 merged after TDD plus internal/post-publication review (LGTM, round 2); configured-only resolution, the exact adapter/identity contract, capability gates, and GitHub/local slots landed without migrating current callers.
+- 2026-07-11: #274 → PR #284 merged after TDD, 472 Node tests, 151 smoke checks, CI, and multi-agent review; exact lookup, numeric-slug inference, punctuation/suffix, and hyphenated-prefix boundary gaps were fixed before final LGTM.

--- a/backlog/tasks/BACK-274 - feat-add-backward-compatible-tracker-neutral-task-references.md
+++ b/backlog/tasks/BACK-274 - feat-add-backward-compatible-tracker-neutral-task-references.md
@@ -1,7 +1,7 @@
 ---
 id: BACK-274
 title: 'feat: add backward-compatible tracker-neutral task references'
-status: To Do
+status: Done
 labels:
   - enhancement
 priority: medium
@@ -19,12 +19,12 @@ Introduce tracker-neutral task references and additive JSON identity while prese
 
 ## Acceptance Criteria
 
-- [ ] The sprint parser accepts legacy GitHub `#N` references and local canonical `{PREFIX}-N` references without ambiguous partial matches.
-- [ ] Machine state adds normalized tracker/task identity fields while retaining `issue_number` unchanged for GitHub entries.
-- [ ] Existing GitHub sprint markdown renders byte-for-byte compatible plan references unless a caller opts into normalized fields.
-- [ ] Progress age matching, exact task-file lookup, next-batch grouping, mirror rendering, and closeout use one normalized task-ref implementation.
-- [ ] Tests cover `#1` vs `#11`, `BACK-1` vs `BACK-11`, decimal subtask IDs where supported, invalid refs, and mixed legacy fixtures.
-- [ ] The actor integration contract documents additive fields, compatibility aliases, and local reference grammar.
+- [x] The sprint parser accepts legacy GitHub `#N` references and local canonical `{PREFIX}-N` references without ambiguous partial matches.
+- [x] Machine state adds normalized tracker/task identity fields while retaining `issue_number` unchanged for GitHub entries.
+- [x] Existing GitHub sprint markdown renders byte-for-byte compatible plan references unless a caller opts into normalized fields.
+- [x] Progress age matching, exact task-file lookup, next-batch grouping, mirror rendering, and closeout use one normalized task-ref implementation.
+- [x] Tests cover `#1` vs `#11`, `BACK-1` vs `BACK-11`, decimal subtask IDs where supported, invalid refs, and mixed legacy fixtures.
+- [x] The actor integration contract documents additive fields, compatibility aliases, and local reference grammar.
 
 ## Non-Goals
 


### PR DESCRIPTION
## Summary

- mark the #274 task mirror complete after PR #284 merged
- record the normalized task-ref contract and review-discovered boundary fixes
- advance the active sprint frontier to #275

## Validation

- `node skills/dev-backlog/scripts/backlog-doctor.js`
- `bash skills/dev-backlog/scripts/status.sh`
- `bash skills/dev-backlog/scripts/next.sh`
- `git diff --check`

Bookkeeping only; implementation and CI were reviewed in PR #284.
