### PR TITLE
feat: move GitHub behavior behind tracker adapter (#275)

### DIFF
--- a/docs/tracker-adapter-design.md
+++ b/docs/tracker-adapter-design.md
@@ -1,17 +1,19 @@
 # Tracker Adapter Design Contract
 
 Status: accepted target design for issue #272. Runtime evidence was inventoried
-at commit `019a6ec`. Issue #273 now implements only the configured runtime seam
-described below; GitHub caller wiring (#275) and local persistence (#276) remain
-future work. GitHub is the compatibility baseline for issues #273-#275.
+at commit `019a6ec`. Issues #273-#275 now implement configured selection,
+tracker-neutral references, and the GitHub adapter wiring described below.
+Local persistence (#276) remains future work. GitHub remains the compatibility
+baseline.
 
 This document froze the smallest tracker boundary that can support another
 canonical task store without weakening existing GitHub behavior. The #272
-freeze itself did not configure a tracker or implement an adapter; the #273
-state is recorded separately below. Neither issue persists local tasks, changes
-setup, or alters command, Markdown, JSON, sprint, or task-mirror behavior.
+freeze itself did not configure a tracker or implement an adapter; the current
+foundation state is recorded separately below. These changes do not persist
+local tasks, alter setup, or rewrite command, Markdown, JSON, sprint, or
+task-mirror compatibility surfaces.
 
-## Runtime Seam State (#273)
+## Runtime Adapter State (#273-#275)
 
 `backlog/config.yml` selects one `tracker`, initially `github` or `local`.
 Repositories without that key use `github` as a deterministic compatibility
@@ -21,11 +23,15 @@ CLI, authentication, remote, adapter, or filesystem detection.
 `skills/dev-backlog/scripts/tracker.js` owns selection, exact adapter-shape and
 identity validation, configured-only availability probing, and optional
 capability gates. An unavailable or throwing configured adapter fails with no
-probe or fallback to the other slot. The GitHub slot declares the accepted
-capabilities, but existing GitHub command transports and injection seams remain
-where they are until #275; no current caller has moved. The local slot reports
-one implementation-pending reason and fails all lifecycle calls consistently
-until #276 adds persistence. This seam does not make local task files canonical.
+probe or fallback to the other slot. The GitHub slot now delegates its required
+task lifecycle to `github-tracker.js`; generic sync and orientation callers use
+configured-only resolution. Milestone, mirror, progress/PR/comment, and triage
+GitHub transports live in explicitly named provider modules and are reached only
+after their declared capability gates. Legacy helper exports remain compatibility
+shims over those owners, including their injected execution seams. The local slot
+still reports one implementation-pending reason and fails all lifecycle calls
+consistently until #276 adds persistence. This runtime does not make local task
+files canonical.
 
 ## Current Runtime Evidence
 

--- a/skills/backlog-triage/scripts/triage-apply.js
+++ b/skills/backlog-triage/scripts/triage-apply.js
@@ -3,7 +3,17 @@
 const fs = require("fs");
 const path = require("path");
 const { execFileSync } = require("node:child_process");
+const { readConfig } = require("../../dev-backlog/scripts/lib.js");
+const {
+  githubIdentity,
+  stripNormalizedIdentity,
+} = require("../../dev-backlog/scripts/github-tracker.js");
+const {
+  invokeCapability,
+  resolveConfiguredTracker,
+} = require("../../dev-backlog/scripts/tracker.js");
 const { ANCHOR_PATTERN, parseAnchor } = require("./triage-report.js");
+const { runGh: runGithubCommand } = require("./triage-github.js");
 
 const DEFAULT_TRIAGE_DIR = path.join("backlog", "triage");
 const CHECKBOX_PATTERN = /^\s*-\s+\[([ xX])\]\s+/;
@@ -312,23 +322,87 @@ function trimStderr(stderr) {
 }
 
 function runGh(argv, { execFile = execFileSync } = {}) {
+  return runGithubCommand(argv, { execFile });
+}
+
+function execFileFromRunGh(runCommand) {
+  return (_command, argv) => {
+    const result = runCommand(argv);
+    if (result.status === 0) return result.stdout || "";
+    const error = new Error(result.stderr || `gh exited with status ${result.status}`);
+    error.status = result.status;
+    error.stdout = result.stdout;
+    error.stderr = result.stderr;
+    error.ghResult = result;
+    throw error;
+  };
+}
+
+function parseOptionValues(argv, option) {
+  const values = [];
+  for (let index = 0; index < argv.length - 1; index += 1) {
+    if (argv[index] === option) values.push(argv[index + 1]);
+  }
+  return values;
+}
+
+function runTrackerCommand(argv, { resolved, providerRunGh }) {
   try {
-    const stdout = execFile("gh", argv, {
-      encoding: "utf-8",
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    return {
-      status: 0,
-      stdout: stdout || "",
-      stderr: "",
-    };
+    const [resource, verb, issue] = argv;
+    if (resource !== "issue") return providerRunGh(argv);
+    const identity = githubIdentity(issue);
+
+    if (verb === "comment") {
+      return invokeCapability(resolved, "comments", () => providerRunGh(argv));
+    }
+    if (verb === "view") {
+      const fields = argv[argv.indexOf("--json") + 1];
+      const task = resolved.adapter.read(identity, { fields });
+      return {
+        status: 0,
+        stdout: JSON.stringify(stripNormalizedIdentity(task)),
+        stderr: "",
+      };
+    }
+    if (verb === "edit") {
+      const milestone = parseOptionValues(argv, "--milestone")[0];
+      if (milestone !== undefined) {
+        invokeCapability(resolved, "milestones", () => undefined);
+      }
+      resolved.adapter.update(identity, {
+        addLabels: parseOptionValues(argv, "--add-label"),
+        removeLabels: parseOptionValues(argv, "--remove-label"),
+        ...(milestone === undefined ? {} : { milestone }),
+      });
+      return { status: 0, stdout: "", stderr: "" };
+    }
+    if (verb === "close") {
+      const reason = parseOptionValues(argv, "-r")[0];
+      if (reason) invokeCapability(resolved, "closing-semantics", () => undefined);
+      resolved.adapter.close(identity, { reason });
+      return { status: 0, stdout: "", stderr: "" };
+    }
+    return providerRunGh(argv);
   } catch (error) {
-    return {
+    return error.ghResult || {
       status: error.status || 1,
-      stdout: typeof error.stdout === "string" ? error.stdout : error.stdout?.toString?.("utf-8") || "",
-      stderr: typeof error.stderr === "string" ? error.stderr : error.stderr?.toString?.("utf-8") || error.message,
+      stdout: error.stdout || "",
+      stderr: error.stderr || error.message,
     };
   }
+}
+
+function requiredCapabilitiesForActions(actions) {
+  const capabilities = new Set();
+  for (const action of actions) {
+    if (!action.checked || !action.knownVerb) continue;
+    if (["close", "revisit", "close-duplicate"].includes(action.verb)) {
+      capabilities.add("comments");
+    }
+    if (action.verb === "close-duplicate") capabilities.add("closing-semantics");
+    if (action.verb === "assign-milestone") capabilities.add("milestones");
+  }
+  return [...capabilities];
 }
 
 function parseGhLabels(stdout) {
@@ -742,7 +816,23 @@ function execute(argv = process.argv.slice(2), deps = {}) {
 
   let logPath;
   let appliedCommandsByAction = new Map();
+  let resolved;
+  let providerRunGh;
   if (options.apply) {
+    providerRunGh = deps.runGh
+      || ((argvToRun) => runGh(argvToRun, { execFile: deps.execFile || execFileSync }));
+    try {
+      resolved = resolveConfiguredTracker(
+        deps.trackerConfig || readConfig(path.join(cwd, "backlog")),
+        { execFile: execFileFromRunGh(providerRunGh) }
+      );
+      for (const capability of requiredCapabilitiesForActions(deduped)) {
+        invokeCapability(resolved, capability, () => undefined);
+      }
+    } catch (error) {
+      return { ...result, exitCode: 1, error: error.message };
+    }
+
     const reportDate = resolveReportDate(report.frontmatter, now());
     logPath = resolveLogPath(reportDate, cwd);
 
@@ -759,7 +849,9 @@ function execute(argv = process.argv.slice(2), deps = {}) {
 
   const effectDeps = {
     now,
-    runGh: deps.runGh || ((argvToRun) => runGh(argvToRun, { execFile: deps.execFile || execFileSync })),
+    runGh: options.apply
+      ? (argvToRun) => runTrackerCommand(argvToRun, { resolved, providerRunGh })
+      : deps.runGh || ((argvToRun) => runGh(argvToRun, { execFile: deps.execFile || execFileSync })),
     appendFile: deps.appendFile || fs.appendFileSync,
     mkdir: deps.mkdir || fs.mkdirSync,
   };

--- a/skills/backlog-triage/scripts/triage-collect.js
+++ b/skills/backlog-triage/scripts/triage-collect.js
@@ -5,9 +5,17 @@ const fs = require("fs");
 const path = require("path");
 const {
   GH_EXEC_DEFAULTS,
+  readConfig,
   readTriageConfig,
 } = require("../../dev-backlog/scripts/lib");
+const {
+  TRACKER_ADAPTERS,
+  createGithubAdapter,
+  invokeCapability,
+  resolveConfiguredTracker,
+} = require("../../dev-backlog/scripts/tracker.js");
 const { parseMarkerMonth } = require("../../dev-backlog/scripts/progress-sync-render");
+const { executeGithub } = require("./triage-github.js");
 
 const CONFIG_PATH = path.join("backlog", "triage-config.yml");
 const SNAPSHOT_DIR = path.join("backlog", "triage", ".cache");
@@ -300,8 +308,8 @@ function fetchOpenIssuesGraphql({ repo, limit, execFile = execFileSync }) {
   const { owner, name } = parseRepoParts(repo);
   const pageSize = Math.min(resolvedLimit, GRAPHQL_PAGE_SIZE);
   const paginate = resolvedLimit > GRAPHQL_PAGE_SIZE || resolvedLimit === TRIAGE_DEFAULT_FETCH_LIMIT;
-  const output = execFile(
-    "gh",
+  const output = executeGithub(
+    execFile,
     graphqlArgs(
       OPEN_ISSUES_QUERY,
       { owner, name, pageSize },
@@ -343,8 +351,8 @@ function normalizeIssueComments(comments) {
 
 function fetchIssueComments({ repo, issueNumber, execFile = execFileSync }) {
   const { owner, name } = parseRepoParts(repo);
-  const output = execFile(
-    "gh",
+  const output = executeGithub(
+    execFile,
     [
       "api",
       `repos/${owner}/${name}/issues/${issueNumber}/comments`,
@@ -418,8 +426,8 @@ function fetchClosedIssues({ repo, generated, config, execFile = execFileSync })
     "is:closed",
     `closed:>=${isoDateDaysAgo(generated, resolveClosedIssueDays(config))}`,
   ].join(" ");
-  const output = execFile(
-    "gh",
+  const output = executeGithub(
+    execFile,
     graphqlArgs(
       CLOSED_ISSUES_QUERY,
       { searchQuery, pageSize: Math.min(closedIssueLimit, GRAPHQL_PAGE_SIZE) },
@@ -574,15 +582,30 @@ async function collectSnapshot({
   execFile = execFileSync,
   generated = new Date().toISOString(),
   config = undefined,
+  trackerConfig = undefined,
   configPath = CONFIG_PATH,
   snapshotDir = SNAPSHOT_DIR,
 } = {}) {
-  const resolvedRepo = repo || detectRepo(execFile);
+  let resolvedRepo;
+  const github = createGithubAdapter({
+    execFile,
+    listTransport: ({ limit: requestedLimit }) => fetchOpenIssuesGraphql({
+      repo: resolvedRepo,
+      limit: requestedLimit,
+      execFile,
+    }),
+  });
+  const resolved = resolveConfiguredTracker(trackerConfig || readConfig("backlog"), {
+    adapters: { ...TRACKER_ADAPTERS, github },
+  });
+  invokeCapability(resolved, "pull-request-relationships", () => undefined);
+  if (withComments) invokeCapability(resolved, "comments", () => undefined);
+  if (withClosedIssues) invokeCapability(resolved, "closing-semantics", () => undefined);
+  resolvedRepo = repo || detectRepo(execFile);
   const triageConfig = config || readTriageConfig("backlog");
-  const issues = fetchOpenIssuesGraphql({
+  const issues = resolved.adapter.list({
     repo: resolvedRepo,
     limit,
-    execFile,
   });
   const candidateIssues = issues.filter((issue) => !isProgressIssue(issue));
   const issuesWithComments = withComments

--- a/skills/backlog-triage/scripts/triage-github.js
+++ b/skills/backlog-triage/scripts/triage-github.js
@@ -1,0 +1,30 @@
+/** Explicit GitHub transport retained for triage compatibility surfaces. */
+
+const { execFileSync } = require("node:child_process");
+const { GH_EXEC_DEFAULTS } = require("../../dev-backlog/scripts/github-tracker.js");
+
+function executeGithub(execFile, args, options = GH_EXEC_DEFAULTS) {
+  return execFile("gh", args, options);
+}
+
+function runGh(argv, { execFile = execFileSync } = {}) {
+  try {
+    const stdout = executeGithub(execFile, argv, {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { status: 0, stdout: stdout || "", stderr: "" };
+  } catch (error) {
+    return {
+      status: error.status || 1,
+      stdout: typeof error.stdout === "string"
+        ? error.stdout
+        : error.stdout?.toString?.("utf-8") || "",
+      stderr: typeof error.stderr === "string"
+        ? error.stderr
+        : error.stderr?.toString?.("utf-8") || error.message,
+    };
+  }
+}
+
+module.exports = { executeGithub, runGh };

--- a/skills/dev-backlog/scripts/github-capabilities.test.js
+++ b/skills/dev-backlog/scripts/github-capabilities.test.js
@@ -1,0 +1,201 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const {
+  closeMilestone,
+  getMilestoneDue,
+  getMilestoneIssues,
+} = require("./github-milestones.js");
+const {
+  createMirrorIssue,
+  findMirrorIssue,
+  updateMirrorIssue,
+} = require("./github-mirrors.js");
+const { loadOpenIssues } = require("./sync-pull.js");
+const { sync: syncMirror } = require("./sprint-mirror.js");
+const { sync: syncProgress } = require("./progress-sync.js");
+const { createSprintFile } = require("./sprint-init.js");
+const { listStatusRows } = require("./tracker-status-list.js");
+const { collectSnapshot } = require("../../backlog-triage/scripts/triage-collect.js");
+const { execute: applyTriage } = require("../../backlog-triage/scripts/triage-apply.js");
+
+function makeExec(responses) {
+  const calls = [];
+  return {
+    calls,
+    execFile(command, args, options) {
+      calls.push({ command, args, options });
+      return responses.shift() ?? "";
+    },
+  };
+}
+
+describe("GitHub optional capability transports", () => {
+  it("preserves milestone lookup, list, and close argv", () => {
+    const { calls, execFile } = makeExec([
+      "2026-07-31T00:00:00Z\n",
+      '[{"number":275,"title":"Adapter","labels":[]}]',
+      "9\n",
+      "",
+    ]);
+
+    assert.equal(getMilestoneDue("Batch 4", execFile), "2026-07-31");
+    assert.deepEqual(getMilestoneIssues("Batch 4", execFile), [{
+      number: 275,
+      title: "Adapter",
+      labels: [],
+      tracker: "github",
+      id: "275",
+      ref: "#275",
+    }]);
+    assert.equal(closeMilestone("Batch 4", execFile), 1);
+
+    assert.deepEqual(calls.map((call) => call.args), [
+      ["api", "repos/{owner}/{repo}/milestones", "--jq", '.[] | select(.title==env.MS) | .due_on'],
+      ["issue", "list", "--milestone", "Batch 4", "--state", "open", "--json", "number,title,labels"],
+      ["api", "repos/{owner}/{repo}/milestones", "--jq", '.[] | select(.title==env.MS) | .number'],
+      ["api", "-X", "PATCH", "repos/{owner}/{repo}/milestones/9", "-f", "state=closed"],
+    ]);
+    assert.equal(calls[0].options.env.MS, "Batch 4");
+    assert.equal(calls[2].options.env.MS, "Batch 4");
+  });
+
+  it("preserves mirror find/create/update argv and legacy results", () => {
+    const marker = "<!-- dev-backlog:sprint-mirror sprint=batch-4 -->";
+    const { calls, execFile } = makeExec([
+      JSON.stringify([{ number: 8, body: marker }]),
+      "https://github.com/acme/widgets/issues/9\n",
+      "",
+    ]);
+
+    assert.deepEqual(findMirrorIssue(marker, execFile), { number: 8, body: marker });
+    assert.deepEqual(createMirrorIssue("Sprint mirror: batch-4", marker, execFile), { number: 9 });
+    assert.equal(updateMirrorIssue(9, marker, execFile), undefined);
+    assert.deepEqual(calls.map((call) => call.args), [
+      ["issue", "list", "--state", "all", "--search", "dev-backlog:sprint-mirror in:body", "--json", "number,body", "--limit", "50"],
+      ["issue", "create", "--title", "Sprint mirror: batch-4", "--body", marker],
+      ["issue", "edit", "9", "--body", marker],
+    ]);
+  });
+
+  it("preserves the human status list argv and row bytes through configured resolution", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "github-status-list-"));
+    const backlogDir = path.join(root, "backlog");
+    fs.mkdirSync(backlogDir);
+    const { calls, execFile } = makeExec([JSON.stringify([{
+      number: 275,
+      title: "GitHub adapter",
+      labels: [{ name: "priority:high" }],
+      milestone: { title: "Batch 4" },
+    }])]);
+
+    assert.deepEqual(listStatusRows(backlogDir, { execFile }), [
+      "275\tBatch 4\tGitHub adapter\tpriority:high",
+    ]);
+    assert.deepEqual(calls[0].args, [
+      "issue", "list", "--state", "open", "--limit", "20",
+      "--json", "number,title,labels,milestone",
+    ]);
+  });
+});
+
+describe("configured-only failure before effects", () => {
+  it("never executes GitHub or writes sprint state for explicit local", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "github-capability-gate-"));
+    const backlogDir = path.join(root, "backlog");
+    fs.mkdirSync(backlogDir);
+    fs.writeFileSync(path.join(backlogDir, "config.yml"), "tracker: local\n");
+    let executions = 0;
+    const execFile = () => {
+      executions += 1;
+      throw new Error("must not execute");
+    };
+
+    assert.throws(() => loadOpenIssues({ config: { tracker: "local" }, execFile }), /local/);
+    assert.throws(() => syncMirror({ backlogDir, execFile }), /local/);
+    assert.throws(() => syncProgress({ month: "2026-07", backlogDir, execFile }), /local/);
+    assert.throws(() => createSprintFile({
+      topic: "blocked",
+      milestone: "blocked",
+      dryRun: false,
+      sprintsDir: path.join(backlogDir, "sprints"),
+    }), /local/);
+    await assert.rejects(
+      collectSnapshot({ repo: "acme/widgets", trackerConfig: { tracker: "local" }, execFile }),
+      /local/
+    );
+
+    const report = path.join(root, "report.md");
+    fs.writeFileSync(report, [
+      "---", "generated: 2026-07-11", "---", "",
+      '<!-- triage:revisit issue=275 reason="check" -->',
+      "- [x] revisit", "",
+    ].join("\n"));
+    const applied = applyTriage([report, "--apply", "--yes"], {
+      cwd: root,
+      trackerConfig: { tracker: "local" },
+      runGh: () => {
+        executions += 1;
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    });
+    assert.equal(applied.exitCode, 1);
+    assert.match(applied.error, /local/);
+    assert.equal(executions, 0);
+    assert.equal(fs.existsSync(path.join(backlogDir, "sprints")), false);
+    assert.equal(fs.existsSync(path.join(backlogDir, "triage", "2026-07-11-apply.log")), false);
+  });
+
+  it("gates milestone close before doctor or sprint-file mutation", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "github-close-gate-"));
+    const backlogDir = path.join(root, "backlog");
+    const sprintsDir = path.join(backlogDir, "sprints");
+    fs.mkdirSync(sprintsDir, { recursive: true });
+    fs.writeFileSync(path.join(backlogDir, "config.yml"), "tracker: local\n");
+    const sprintPath = path.join(sprintsDir, "active.md");
+    fs.writeFileSync(sprintPath, [
+      "---", "milestone: Batch 4", "status: active", "---", "",
+      "## Plan", "- [x] #275 Adapter", "", "## Running Context", "", "## Progress", "",
+    ].join("\n"));
+
+    const result = spawnSync("bash", [
+      path.join(__dirname, "sprint-close.sh"),
+      backlogDir,
+      "--close-milestone",
+    ], { encoding: "utf8" });
+
+    assert.equal(result.status, 1);
+    assert.match(`${result.stdout}${result.stderr}`, /local/);
+    assert.match(fs.readFileSync(sprintPath, "utf8"), /^status: active$/m);
+    assert.doesNotMatch(fs.readFileSync(sprintPath, "utf8"), /Sprint closed/);
+  });
+
+  it("refuses to overwrite an exact-title progress issue without the owned marker", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "github-progress-marker-"));
+    const backlogDir = path.join(root, "backlog");
+    fs.mkdirSync(backlogDir);
+    let searches = 0;
+    const calls = [];
+    const execFile = (_command, args) => {
+      calls.push(args);
+      if (args[0] === "pr") return "[]";
+      if (args[0] === "issue" && args[1] === "list") {
+        searches += 1;
+        return searches === 1
+          ? JSON.stringify([{ number: 88, title: "Progress: July 2026", body: "Human notes" }])
+          : "[]";
+      }
+      throw new Error(`unexpected mutation: ${args.join(" ")}`);
+    };
+
+    assert.throws(
+      () => syncProgress({ month: "2026-07", backlogDir, execFile }),
+      /missing managed progress marker/
+    );
+    assert.equal(calls.some((args) => ["create", "edit", "comment"].includes(args[1])), false);
+  });
+});

--- a/skills/dev-backlog/scripts/github-milestones.js
+++ b/skills/dev-backlog/scripts/github-milestones.js
@@ -1,0 +1,51 @@
+/** Explicit GitHub implementation of the optional milestones capability. */
+
+const { execFileSync } = require("child_process");
+const { GH_EXEC_DEFAULTS, normalizeGithubTask } = require("./github-tracker.js");
+
+function getMilestoneDue(milestone, execFile = execFileSync) {
+  try {
+    const output = execFile("gh", [
+      "api", "repos/{owner}/{repo}/milestones",
+      "--jq", '.[] | select(.title==env.MS) | .due_on',
+    ], { ...GH_EXEC_DEFAULTS, env: { ...process.env, MS: milestone } }).trim();
+    return output ? output.slice(0, 10) : "TBD";
+  } catch {
+    return "TBD";
+  }
+}
+
+function getMilestoneIssues(milestone, execFile = execFileSync) {
+  try {
+    const output = execFile("gh", [
+      "issue", "list", "--milestone", milestone,
+      "--state", "open", "--json", "number,title,labels",
+    ], GH_EXEC_DEFAULTS);
+    return JSON.parse(output).map(normalizeGithubTask);
+  } catch {
+    return [];
+  }
+}
+
+function closeMilestone(milestone, execFile = execFileSync, onPatchError = () => {}) {
+  const output = execFile("gh", [
+    "api", "repos/{owner}/{repo}/milestones",
+    "--jq", '.[] | select(.title==env.MS) | .number',
+  ], { ...GH_EXEC_DEFAULTS, env: { ...process.env, MS: milestone } });
+  const numbers = String(output).split(/\r?\n/).map((value) => value.trim()).filter(Boolean);
+  let closed = 0;
+  for (const number of numbers) {
+    try {
+      execFile("gh", [
+        "api", "-X", "PATCH", `repos/{owner}/{repo}/milestones/${number}`,
+        "-f", "state=closed",
+      ], GH_EXEC_DEFAULTS);
+      closed += 1;
+    } catch (error) {
+      onPatchError(number, error);
+    }
+  }
+  return closed;
+}
+
+module.exports = { getMilestoneDue, getMilestoneIssues, closeMilestone };

--- a/skills/dev-backlog/scripts/github-mirrors.js
+++ b/skills/dev-backlog/scripts/github-mirrors.js
@@ -1,0 +1,32 @@
+/** Explicit GitHub implementation of the optional sprint-mirror capability. */
+
+const { GH_EXEC_DEFAULTS } = require("./github-tracker.js");
+
+function findMirrorIssue(marker, execFile) {
+  const output = execFile("gh", [
+    "issue", "list", "--state", "all",
+    "--search", "dev-backlog:sprint-mirror in:body",
+    "--json", "number,body", "--limit", "50",
+  ], GH_EXEC_DEFAULTS);
+  const issues = JSON.parse(output);
+  return issues.find((issue) => issue.body && issue.body.includes(marker)) || null;
+}
+
+function createMirrorIssue(title, body, execFile) {
+  const output = execFile(
+    "gh",
+    ["issue", "create", "--title", title, "--body", body],
+    GH_EXEC_DEFAULTS
+  );
+  const match = String(output).trim().match(/\/issues\/(\d+)\s*$/);
+  if (!match) {
+    throw new Error(`Failed to parse issue number from gh output: ${String(output).trim()}`);
+  }
+  return { number: Number(match[1]) };
+}
+
+function updateMirrorIssue(number, body, execFile) {
+  execFile("gh", ["issue", "edit", String(number), "--body", body], GH_EXEC_DEFAULTS);
+}
+
+module.exports = { findMirrorIssue, createMirrorIssue, updateMirrorIssue };

--- a/skills/dev-backlog/scripts/github-ownership.test.js
+++ b/skills/dev-backlog/scripts/github-ownership.test.js
@@ -1,0 +1,56 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const ROOT = path.resolve(__dirname, "../../..");
+const SCRIPT_ROOTS = [
+  path.join(ROOT, "skills", "dev-backlog", "scripts"),
+  path.join(ROOT, "skills", "backlog-triage", "scripts"),
+];
+const ALLOWED_DIRECT_GH = new Set([
+  "skills/dev-backlog/scripts/github-tracker.js",
+  "skills/dev-backlog/scripts/github-milestones.js",
+  "skills/dev-backlog/scripts/github-mirrors.js",
+  "skills/dev-backlog/scripts/progress-sync-github.js",
+  "skills/backlog-triage/scripts/triage-github.js",
+]);
+
+function productionJavascriptFiles(directory) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const file = path.join(directory, entry.name);
+    if (entry.isDirectory()) return productionJavascriptFiles(file);
+    if (!entry.name.endsWith(".js") || entry.name.endsWith(".test.js")) return [];
+    return [file];
+  });
+}
+
+describe("direct gh production ownership", () => {
+  it("confines execution to the required adapter and explicit GitHub capability transports", () => {
+    const directPattern = /execFile(?:Sync)?\(\s*["']gh["']|^[ \t]*["']gh["'][ \t]*,/m;
+    const directFiles = SCRIPT_ROOTS
+      .flatMap(productionJavascriptFiles)
+      .filter((file) => directPattern.test(fs.readFileSync(file, "utf8")))
+      .map((file) => path.relative(ROOT, file))
+      .sort();
+
+    assert.deepEqual(directFiles, [...ALLOWED_DIRECT_GH].sort());
+  });
+
+  it("removes direct task lifecycle ownership from every migrated generic caller", () => {
+    const migrated = [
+      "skills/dev-backlog/scripts/lib.js",
+      "skills/dev-backlog/scripts/sync-pull.js",
+      "skills/dev-backlog/scripts/sprint-init.js",
+      "skills/dev-backlog/scripts/status.sh",
+      "skills/dev-backlog/scripts/sprint-close.sh",
+      "skills/dev-backlog/scripts/sprint-mirror.js",
+      "skills/backlog-triage/scripts/triage-collect.js",
+      "skills/backlog-triage/scripts/triage-apply.js",
+    ];
+    const directPattern = /execFile(?:Sync)?\(\s*["']gh["']|^[ \t]*(?:MS="\$MILESTONE" )?gh (?:api|issue|pr)\b|^[ \t]*["']gh["'][ \t]*,/m;
+    for (const relative of migrated) {
+      assert.doesNotMatch(fs.readFileSync(path.join(ROOT, relative), "utf8"), directPattern, relative);
+    }
+  });
+});

--- a/skills/dev-backlog/scripts/github-tracker.js
+++ b/skills/dev-backlog/scripts/github-tracker.js
@@ -1,0 +1,172 @@
+/** GitHub implementation of the required seven-operation tracker lifecycle. */
+
+const { execFileSync } = require("child_process");
+
+const GH_EXEC_DEFAULTS = {
+  encoding: "utf-8",
+  maxBuffer: 50 * 1024 * 1024,
+};
+const OPEN_ISSUE_COUNT_QUERY =
+  "query($owner: String!, $name: String!) { repository(owner: $owner, name: $name) { issues(states: OPEN) { totalCount } } }";
+const OPEN_ISSUE_JSON_FIELDS =
+  "number,title,body,labels,milestone,assignees,createdAt,updatedAt";
+
+function buildIssueCountArgs(repo) {
+  if (!repo) {
+    return [
+      "api", "graphql", "-F", "owner={owner}", "-F", "name={repo}",
+      "-f", `query=${OPEN_ISSUE_COUNT_QUERY}`,
+      "--jq", ".data.repository.issues.totalCount",
+    ];
+  }
+  const [owner, name] = repo.split("/");
+  if (!owner || !name) {
+    throw new Error(`Invalid repo value: ${repo}. Expected OWNER/REPO.`);
+  }
+  return [
+    "api", "graphql", "-F", `owner=${owner}`, "-F", `name=${name}`,
+    "-f", `query=${OPEN_ISSUE_COUNT_QUERY}`,
+    "--jq", ".data.repository.issues.totalCount",
+  ];
+}
+
+function getOpenIssueCount({ repo, execFile = execFileSync } = {}) {
+  const output = execFile("gh", buildIssueCountArgs(repo), GH_EXEC_DEFAULTS).trim();
+  const count = Number.parseInt(output, 10);
+  if (!Number.isInteger(count) || count < 0) {
+    throw new Error(`Invalid issue count from gh: ${output}`);
+  }
+  return count;
+}
+
+function githubIdentity(number, url) {
+  const id = String(number);
+  if (!/^\d+$/.test(id) || Number(id) < 1) {
+    throw new Error(`Invalid GitHub issue number: ${number}`);
+  }
+  const identity = { tracker: "github", id, ref: `#${id}` };
+  if (url !== undefined && url !== null && url !== "") {
+    let parsed;
+    try {
+      parsed = new URL(String(url));
+    } catch {
+      throw new Error(`Invalid GitHub issue URL: ${url}`);
+    }
+    if (!["http:", "https:"].includes(parsed.protocol)) {
+      throw new Error(`Invalid GitHub issue URL: ${url}`);
+    }
+    identity.url = String(url);
+  }
+  return identity;
+}
+
+function normalizeGithubTask(issue) {
+  if (issue === null || typeof issue !== "object" || Array.isArray(issue)) {
+    throw new Error("Invalid GitHub issue result: expected an object.");
+  }
+  return { ...issue, ...githubIdentity(issue.number, issue.url) };
+}
+
+function identityFrom(value) {
+  if (typeof value === "number" || (typeof value === "string" && /^#?\d+$/.test(value))) {
+    return githubIdentity(String(value).replace(/^#/, ""));
+  }
+  if (value === null || typeof value !== "object" || value.tracker !== "github") {
+    throw new Error("GitHub lifecycle operation requires a GitHub task identity.");
+  }
+  const identity = githubIdentity(value.id, value.url);
+  if (value.ref !== identity.ref) throw new Error(`Invalid GitHub task ref: ${value.ref}`);
+  return identity;
+}
+
+function parseCreatedIssue(output) {
+  const url = String(output).trim();
+  const match = url.match(/\/issues\/(\d+)\s*$/);
+  if (!match) throw new Error(`Failed to parse issue number from gh output: ${url}`);
+  return githubIdentity(match[1], url);
+}
+
+function createGithubAdapter({ execFile = execFileSync, listTransport } = {}) {
+  return Object.freeze({
+    availability: () => ({ available: true }),
+    capabilities: () => [
+      "milestones",
+      "pull-request-relationships",
+      "mirrors",
+      "progress-issues",
+      "comments",
+      "closing-semantics",
+    ],
+    list({ state = "open", limit, defaultLimit, repo, fields = OPEN_ISSUE_JSON_FIELDS } = {}) {
+      if (listTransport) {
+        const transported = listTransport({ state, limit, defaultLimit, repo, fields });
+        if (!Array.isArray(transported)) {
+          throw new Error("Invalid GitHub issue list result: expected an array.");
+        }
+        return transported.map(normalizeGithubTask);
+      }
+      const resolvedLimit = limit ?? defaultLimit ?? getOpenIssueCount({ repo, execFile });
+      if (resolvedLimit === 0) return [];
+      const args = ["issue", "list", "--state", state, "--limit", String(resolvedLimit)];
+      if (repo) args.push("--repo", repo);
+      args.push("--json", fields);
+      const issues = JSON.parse(execFile("gh", args, GH_EXEC_DEFAULTS));
+      if (!Array.isArray(issues)) throw new Error("Invalid GitHub issue list result: expected an array.");
+      return issues.map(normalizeGithubTask);
+    },
+    read(taskIdentity, { repo, fields = OPEN_ISSUE_JSON_FIELDS } = {}) {
+      const identity = identityFrom(taskIdentity);
+      const args = ["issue", "view", identity.id];
+      if (repo) args.push("--repo", repo);
+      args.push("--json", fields);
+      const issue = JSON.parse(execFile("gh", args, GH_EXEC_DEFAULTS));
+      return normalizeGithubTask({ ...issue, number: issue.number ?? Number(identity.id) });
+    },
+    create({ title, body, repo } = {}) {
+      if (typeof title !== "string" || !title.trim()) {
+        throw new Error("GitHub task creation requires a non-empty title.");
+      }
+      const args = ["issue", "create", "--title", title];
+      if (body !== undefined) args.push("--body", String(body));
+      if (repo) args.push("--repo", repo);
+      return parseCreatedIssue(execFile("gh", args, GH_EXEC_DEFAULTS));
+    },
+    update(taskIdentity, changes = {}) {
+      const identity = identityFrom(taskIdentity);
+      const args = ["issue", "edit", identity.id];
+      if (changes.title !== undefined) args.push("--title", String(changes.title));
+      if (changes.body !== undefined) args.push("--body", String(changes.body));
+      for (const label of changes.addLabels || []) args.push("--add-label", String(label));
+      for (const label of changes.removeLabels || []) args.push("--remove-label", String(label));
+      if (changes.milestone !== undefined) args.push("--milestone", String(changes.milestone));
+      if (changes.repo) args.push("--repo", changes.repo);
+      if (args.length > 3) execFile("gh", args, GH_EXEC_DEFAULTS);
+      return identity;
+    },
+    close(taskIdentity, { repo, reason } = {}) {
+      const identity = identityFrom(taskIdentity);
+      const args = ["issue", "close", identity.id];
+      if (reason) args.push("-r", String(reason));
+      if (repo) args.push("--repo", repo);
+      execFile("gh", args, GH_EXEC_DEFAULTS);
+      return identity;
+    },
+  });
+}
+
+function stripNormalizedIdentity(task) {
+  const { tracker: _tracker, id: _id, ref: _ref, ...legacy } = task;
+  return legacy;
+}
+
+module.exports = {
+  GH_EXEC_DEFAULTS,
+  OPEN_ISSUE_COUNT_QUERY,
+  OPEN_ISSUE_JSON_FIELDS,
+  buildIssueCountArgs,
+  createGithubAdapter,
+  getOpenIssueCount,
+  githubIdentity,
+  normalizeGithubTask,
+  stripNormalizedIdentity,
+};

--- a/skills/dev-backlog/scripts/github-tracker.test.js
+++ b/skills/dev-backlog/scripts/github-tracker.test.js
@@ -207,4 +207,12 @@ describe("GitHub required lifecycle adapter", () => {
     );
     assert.equal(mutations, 0);
   });
+
+  it("rejects malformed provider identities instead of leaking them to core callers", () => {
+    const { execFile } = recordingExec([
+      JSON.stringify([{ number: 7, title: "bad URL", url: "not-a-url" }]),
+    ]);
+    const adapter = createGithubAdapter({ execFile });
+    assert.throws(() => adapter.list({ limit: 1 }), /Invalid GitHub issue URL/);
+  });
 });

--- a/skills/dev-backlog/scripts/github-tracker.test.js
+++ b/skills/dev-backlog/scripts/github-tracker.test.js
@@ -1,0 +1,210 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  CAPABILITY_NAMES,
+  TRACKER_ADAPTERS,
+  UnsupportedTrackerCapabilityError,
+  createGithubAdapter,
+  invokeCapability,
+  resolveTracker,
+} = require("./tracker.js");
+const { GH_EXEC_DEFAULTS, OPEN_ISSUE_JSON_FIELDS } = require("./lib.js");
+
+function recordingExec(responses) {
+  const calls = [];
+  const execFile = (command, args, options) => {
+    calls.push({ command, args, options });
+    const response = responses.shift();
+    if (response instanceof Error) throw response;
+    return response;
+  };
+  return { calls, execFile };
+}
+
+function identityOf(task) {
+  const identity = {
+    tracker: task.tracker,
+    id: task.id,
+    ref: task.ref,
+  };
+  if (task.url !== undefined) identity.url = task.url;
+  return identity;
+}
+
+describe("GitHub required lifecycle adapter", () => {
+  it("has exactly the required shape and reports the frozen capabilities", () => {
+    const adapter = createGithubAdapter({ execFile: () => "" });
+
+    assert.deepEqual(Object.keys(adapter), [
+      "availability",
+      "capabilities",
+      "list",
+      "read",
+      "create",
+      "update",
+      "close",
+    ]);
+    assert.deepEqual(adapter.availability(), { available: true });
+    assert.deepEqual(adapter.capabilities(), CAPABILITY_NAMES);
+  });
+
+  it("lists open tasks with legacy argv and additive normalized identities", () => {
+    const github = [{
+      number: 7,
+      title: "Adapter boundary",
+      body: "body",
+      labels: [{ name: "feature" }],
+      milestone: null,
+      assignees: [],
+      createdAt: "2026-07-10T00:00:00Z",
+      updatedAt: "2026-07-11T00:00:00Z",
+      url: "https://github.com/acme/widgets/issues/7",
+    }];
+    const { calls, execFile } = recordingExec([JSON.stringify(github)]);
+    const adapter = createGithubAdapter({ execFile });
+
+    const tasks = adapter.list({ state: "open", limit: 12, repo: "acme/widgets" });
+
+    assert.deepEqual(calls, [{
+      command: "gh",
+      args: [
+        "issue", "list", "--state", "open", "--limit", "12",
+        "--repo", "acme/widgets", "--json", OPEN_ISSUE_JSON_FIELDS,
+      ],
+      options: GH_EXEC_DEFAULTS,
+    }]);
+    assert.deepEqual(tasks[0], {
+      ...github[0],
+      tracker: "github",
+      id: "7",
+      ref: "#7",
+    });
+    assert.deepEqual(identityOf(tasks[0]), {
+      tracker: "github",
+      id: "7",
+      ref: "#7",
+      url: github[0].url,
+    });
+  });
+
+  it("reads one task with exact argv and normalized identity", () => {
+    const issue = {
+      number: 7,
+      title: "Adapter boundary",
+      body: "body",
+      labels: [],
+      milestone: null,
+      assignees: [],
+      createdAt: "2026-07-10T00:00:00Z",
+      updatedAt: "2026-07-11T00:00:00Z",
+      url: "https://github.com/acme/widgets/issues/7",
+    };
+    const { calls, execFile } = recordingExec([JSON.stringify(issue)]);
+    const adapter = createGithubAdapter({ execFile });
+
+    const task = adapter.read(
+      { tracker: "github", id: "7", ref: "#7" },
+      { repo: "acme/widgets" }
+    );
+
+    assert.deepEqual(calls, [{
+      command: "gh",
+      args: [
+        "issue", "view", "7", "--repo", "acme/widgets",
+        "--json", OPEN_ISSUE_JSON_FIELDS,
+      ],
+      options: GH_EXEC_DEFAULTS,
+    }]);
+    assert.deepEqual(task, {
+      ...issue,
+      tracker: "github",
+      id: "7",
+      ref: "#7",
+    });
+  });
+
+  it("creates, updates, and closes through injected execution with stable results", () => {
+    const url = "https://github.com/acme/widgets/issues/42";
+    const { calls, execFile } = recordingExec([`${url}\n`, "", ""]);
+    const adapter = createGithubAdapter({ execFile });
+
+    const created = adapter.create({
+      title: "Ship adapter",
+      body: "Compatibility first",
+      repo: "acme/widgets",
+    });
+    const updated = adapter.update(created, {
+      title: "Ship GitHub adapter",
+      body: "Compatibility preserved",
+      repo: "acme/widgets",
+    });
+    const closed = adapter.close(updated, { repo: "acme/widgets" });
+
+    assert.deepEqual(calls, [
+      {
+        command: "gh",
+        args: [
+          "issue", "create", "--title", "Ship adapter", "--body", "Compatibility first",
+          "--repo", "acme/widgets",
+        ],
+        options: GH_EXEC_DEFAULTS,
+      },
+      {
+        command: "gh",
+        args: [
+          "issue", "edit", "42", "--title", "Ship GitHub adapter",
+          "--body", "Compatibility preserved", "--repo", "acme/widgets",
+        ],
+        options: GH_EXEC_DEFAULTS,
+      },
+      {
+        command: "gh",
+        args: ["issue", "close", "42", "--repo", "acme/widgets"],
+        options: GH_EXEC_DEFAULTS,
+      },
+    ]);
+    const identity = { tracker: "github", id: "42", ref: "#42", url };
+    assert.deepEqual(created, identity);
+    assert.deepEqual(updated, identity);
+    assert.deepEqual(closed, identity);
+  });
+
+  it("resolves only the configured adapter and never falls back after transport failure", () => {
+    let localReads = 0;
+    const { execFile } = recordingExec([new Error("gh transport failed")]);
+    const github = createGithubAdapter({ execFile });
+    const local = {
+      ...TRACKER_ADAPTERS.local,
+      availability: () => {
+        localReads += 1;
+        return { available: true };
+      },
+    };
+    const resolved = resolveTracker({ tracker: "github" }, { adapters: { github, local } });
+
+    assert.throws(() => resolved.adapter.list({ limit: 1 }), /gh transport failed/);
+    assert.equal(localReads, 0);
+  });
+
+  it("fails an unsupported capability before the supplied mutation", () => {
+    let mutations = 0;
+    const resolved = {
+      tracker: "local",
+      adapter: TRACKER_ADAPTERS.local,
+    };
+
+    assert.throws(
+      () => invokeCapability(resolved, "mirrors", () => {
+        mutations += 1;
+      }),
+      (error) => {
+        assert.ok(error instanceof UnsupportedTrackerCapabilityError);
+        assert.equal(error.tracker, "local");
+        assert.equal(error.capability, "mirrors");
+        return true;
+      }
+    );
+    assert.equal(mutations, 0);
+  });
+});

--- a/skills/dev-backlog/scripts/lib.js
+++ b/skills/dev-backlog/scripts/lib.js
@@ -5,6 +5,14 @@
 const { execFileSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
+const {
+  GH_EXEC_DEFAULTS,
+  OPEN_ISSUE_COUNT_QUERY,
+  OPEN_ISSUE_JSON_FIELDS,
+  createGithubAdapter,
+  getOpenIssueCount: getGithubOpenIssueCount,
+  stripNormalizedIdentity,
+} = require("./github-tracker.js");
 
 function slugify(text) {
   return text
@@ -20,12 +28,6 @@ function escapeYaml(text) {
   }
   return text;
 }
-
-/** Default options for gh CLI execFileSync calls (prevents silent truncation). */
-const GH_EXEC_DEFAULTS = {
-  encoding: "utf-8",
-  maxBuffer: 50 * 1024 * 1024,
-};
 
 const CONFIG_DEFAULTS = {
   tracker: "github",
@@ -43,10 +45,6 @@ const TRIAGE_CONFIG_DEFAULTS = {
   stale_days: 60,
   duplicate_threshold: 0.75,
 };
-
-const OPEN_ISSUE_COUNT_QUERY =
-  "query($owner: String!, $name: String!) { repository(owner: $owner, name: $name) { issues(states: OPEN) { totalCount } } }";
-const OPEN_ISSUE_JSON_FIELDS = "number,title,body,labels,milestone,assignees,createdAt,updatedAt";
 
 function stripQuotes(text) {
   if (
@@ -156,50 +154,8 @@ function readTriageConfig(backlogDir) {
   );
 }
 
-function buildIssueCountArgs(repo) {
-  if (!repo) {
-    return [
-      "api",
-      "graphql",
-      "-F",
-      "owner={owner}",
-      "-F",
-      "name={repo}",
-      "-f",
-      `query=${OPEN_ISSUE_COUNT_QUERY}`,
-      "--jq",
-      ".data.repository.issues.totalCount",
-    ];
-  }
-
-  const [owner, name] = repo.split("/");
-  if (!owner || !name) {
-    throw new Error(`Invalid repo value: ${repo}. Expected OWNER/REPO.`);
-  }
-
-  return [
-    "api",
-    "graphql",
-    "-F",
-    `owner=${owner}`,
-    "-F",
-    `name=${name}`,
-    "-f",
-    `query=${OPEN_ISSUE_COUNT_QUERY}`,
-    "--jq",
-    ".data.repository.issues.totalCount",
-  ];
-}
-
 function getOpenIssueCount({ repo, execFile = execFileSync } = {}) {
-  const out = execFile("gh", buildIssueCountArgs(repo), GH_EXEC_DEFAULTS).trim();
-  const count = Number.parseInt(out, 10);
-
-  if (!Number.isInteger(count) || count < 0) {
-    throw new Error(`Invalid issue count from gh: ${out}`);
-  }
-
-  return count;
+  return getGithubOpenIssueCount({ repo, execFile });
 }
 
 /**
@@ -212,14 +168,9 @@ function getOpenIssueCount({ repo, execFile = execFileSync } = {}) {
  * spawning a process.
  */
 function fetchOpenIssues({ repo, limit, defaultLimit, execFile = execFileSync } = {}) {
-  const resolvedLimit = limit ?? defaultLimit ?? getOpenIssueCount({ repo, execFile });
-  if (resolvedLimit === 0) return [];
-
-  const args = ["issue", "list", "--state", "open", "--limit", String(resolvedLimit)];
-  if (repo) args.push("--repo", repo);
-  args.push("--json", OPEN_ISSUE_JSON_FIELDS);
-
-  return JSON.parse(execFile("gh", args, GH_EXEC_DEFAULTS));
+  return createGithubAdapter({ execFile })
+    .list({ repo, limit, defaultLimit })
+    .map(stripNormalizedIdentity);
 }
 
 /**

--- a/skills/dev-backlog/scripts/progress-sync.cli.test.js
+++ b/skills/dev-backlog/scripts/progress-sync.cli.test.js
@@ -32,15 +32,16 @@ function makeWorkspace() {
   return dir;
 }
 
-function writeMockGh(binDir) {
+function writeMockGh(binDir, issues = []) {
   const ghPath = path.join(binDir, "gh");
   fs.mkdirSync(binDir, { recursive: true });
   fs.writeFileSync(ghPath, `#!/usr/bin/env node
 const args = process.argv.slice(2);
 const joined = args.join(" ");
+const issues = ${JSON.stringify(issues)};
 
 if (joined.includes("issue list")) {
-  process.stdout.write("[]");
+  process.stdout.write(JSON.stringify(issues));
   process.exit(0);
 }
 
@@ -97,5 +98,68 @@ describe("progress-sync CLI", () => {
     assert.equal(payload.summary.sprint.file, "2026-04-maintenance.md");
     assert.equal(payload.comments.created, 0);
     assert.ok(payload.body.includes("| Merged PRs (month) | 1 |"));
+  });
+
+  it("refuses an exact-title issue without the managed marker in dry-run", () => {
+    const workspaceDir = makeWorkspace();
+    const binDir = path.join(workspaceDir, "bin");
+    writeMockGh(binDir, [{
+      number: 50,
+      title: "Progress: April 2026",
+      body: "Human-owned issue without a marker",
+    }]);
+
+    const result = spawnSync(
+      process.execPath,
+      [SCRIPT_PATH, "--dry-run", "--month", "2026-04"],
+      {
+        cwd: workspaceDir,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH || ""}`,
+        },
+      }
+    );
+
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, "");
+    assert.equal(
+      result.stderr,
+      "Error: Refusing to update GitHub issue #50: missing managed progress marker for 2026-04.\n"
+    );
+    assert.doesNotMatch(result.stdout, /Would update|#50/);
+  });
+
+  it("keeps marker-owned dry-run update output compatible", () => {
+    const workspaceDir = makeWorkspace();
+    const binDir = path.join(workspaceDir, "bin");
+    writeMockGh(binDir, [{
+      number: 50,
+      title: "Progress: April 2026",
+      body: "<!-- dev-backlog:progress-issue month=2026-04 -->\nOld body",
+    }]);
+
+    const result = spawnSync(
+      process.execPath,
+      [SCRIPT_PATH, "--dry-run", "--month", "2026-04"],
+      {
+        cwd: workspaceDir,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH || ""}`,
+        },
+      }
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stderr, "");
+    assert.equal(result.stdout, `[dry-run] Would update #50: Progress: April 2026
+  merged PRs (month): 1, in-flight: 1, stuck candidates: 1
+  sprint: 2026-04-maintenance.md (1/3 done)
+  comments: 2 created, 0 updated, 0 skipped, 0 repaired
+Done.
+`);
   });
 });

--- a/skills/dev-backlog/scripts/progress-sync.js
+++ b/skills/dev-backlog/scripts/progress-sync.js
@@ -257,7 +257,7 @@ function sync({
   });
   const title = monthTitle(month);
 
-  if (existing && parseMarkerMonth(existing.body) !== month && !dryRun) {
+  if (existing && parseMarkerMonth(existing.body) !== month) {
     throw new Error(
       `Refusing to update GitHub issue #${existing.number}: missing managed progress marker for ${month}.`
     );

--- a/skills/dev-backlog/scripts/progress-sync.js
+++ b/skills/dev-backlog/scripts/progress-sync.js
@@ -18,6 +18,7 @@ const { execFileSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const { readConfig } = require("./lib.js");
+const { invokeCapability, resolveConfiguredTracker } = require("./tracker.js");
 const {
   githubIssueNumber,
   parsePlanCheckbox,
@@ -212,6 +213,16 @@ function sync({
   readFs = { readTaskFiles, readActiveSprintSummary },
   fetchComments = fetchIssueComments,
 }) {
+  const resolved = resolveConfiguredTracker(readConfig(backlogDir), { execFile });
+  const requiredCapabilities = [
+    "progress-issues",
+    "pull-request-relationships",
+    "comments",
+    ...(finalize ? ["closing-semantics"] : []),
+  ];
+  for (const capability of requiredCapabilities) {
+    invokeCapability(resolved, capability, () => undefined);
+  }
   const tasksDir = path.join(backlogDir, "tasks");
   const sprintsDir = path.join(backlogDir, "sprints");
 
@@ -245,6 +256,12 @@ function sync({
     nextIssueNumber,
   });
   const title = monthTitle(month);
+
+  if (existing && parseMarkerMonth(existing.body) !== month && !dryRun) {
+    throw new Error(
+      `Refusing to update GitHub issue #${existing.number}: missing managed progress marker for ${month}.`
+    );
+  }
 
   const result = {
     action: "progress-sync",

--- a/skills/dev-backlog/scripts/smoke-test.sh
+++ b/skills/dev-backlog/scripts/smoke-test.sh
@@ -648,6 +648,34 @@ assert_contains "status: todo count" "$OUT" "1 To Do"
 assert_contains "status: inprog count" "$OUT" "1 In Progress"
 assert_contains "status: completed count" "$OUT" "Completed: 1"
 
+# A missing formatter must be detected before starting the Node producer. This
+# keeps the compatibility fallback and prevents a closed pipe from surfacing as
+# an unhandled EPIPE in tracker-status-list.js.
+NO_COLUMN_BIN="$TEST_DIR/no-column-bin"
+NO_COLUMN_BACKLOG="$TEST_DIR/no-column-backlog"
+NODE_CALLED="$TEST_DIR/no-column-node-called"
+mkdir -p "$NO_COLUMN_BIN" "$NO_COLUMN_BACKLOG"
+ln -s "$(command -v dirname)" "$NO_COLUMN_BIN/dirname"
+ln -s "$(command -v git)" "$NO_COLUMN_BIN/git"
+cat > "$NO_COLUMN_BIN/node" << 'EOF'
+#!/bin/bash
+: > "$NODE_CALLED"
+exit 99
+EOF
+chmod +x "$NO_COLUMN_BIN/node"
+
+set +e
+OUT=$(NODE_CALLED="$NODE_CALLED" PATH="$NO_COLUMN_BIN" RELAY_HOME="$TEST_DIR/no-relay" \
+  /bin/bash "$SCRIPT_DIR/status.sh" "$NO_COLUMN_BACKLOG" 2>&1)
+STATUS=$?
+set -e
+assert_equals "status no-column: exit code" "$STATUS" "0"
+assert_contains "status no-column: compatibility fallback" "$OUT" "(gh not available)"
+NODE_WAS_CALLED=0
+[ -e "$NODE_CALLED" ] && NODE_WAS_CALLED=1
+assert_equals "status no-column: skips Node producer" "$NODE_WAS_CALLED" "0"
+assert_not_contains "status no-column: no EPIPE" "$OUT" "EPIPE"
+
 # ============================================================
 # context-hook.sh tests
 # ============================================================

--- a/skills/dev-backlog/scripts/sprint-close.sh
+++ b/skills/dev-backlog/scripts/sprint-close.sh
@@ -38,6 +38,13 @@ for arg in "$@"; do
   esac
 done
 
+# Optional provider mutations must be authorized before local sprint mutation.
+if $CLOSE_MILESTONE; then
+  if ! node "$SCRIPT_DIR/tracker-capability.js" require milestones "$BACKLOG_DIR"; then
+    exit 1
+  fi
+fi
+
 SPRINTS_DIR="$BACKLOG_DIR/sprints"
 TASKS_DIR="$BACKLOG_DIR/tasks"
 COMPLETED_DIR="$BACKLOG_DIR/completed"
@@ -137,13 +144,7 @@ if $CLOSE_MILESTONE; then
     if $DRY_RUN; then
       echo "[dry-run] Would close milestone: $MILESTONE"
     else
-      MS="$MILESTONE" gh api repos/{owner}/{repo}/milestones \
-        --jq '.[] | select(.title==env.MS) | .number' 2>/dev/null | \
-        while IFS= read -r ms_num; do
-          gh api -X PATCH "repos/{owner}/{repo}/milestones/$ms_num" -f state=closed 2>/dev/null && \
-            echo "Closed milestone: $MILESTONE" || \
-            echo "Warning: Could not close milestone: $MILESTONE"
-        done
+      node "$SCRIPT_DIR/tracker-capability.js" close-milestone milestones "$BACKLOG_DIR" "$MILESTONE" 2>/dev/null
     fi
   fi
 fi

--- a/skills/dev-backlog/scripts/sprint-init.js
+++ b/skills/dev-backlog/scripts/sprint-init.js
@@ -11,11 +11,12 @@
  * Filename: YYYY-MM-<topic>.md
  */
 
-const { execFileSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const { renderTaskRef } = require("./task-ref.js");
-const { slugify, estimateSize, GH_EXEC_DEFAULTS } = require("./lib");
+const { slugify, estimateSize, readConfig } = require("./lib");
+const { getMilestoneDue, getMilestoneIssues } = require("./github-milestones.js");
+const { invokeCapability, resolveConfiguredTracker } = require("./tracker.js");
 const { resolveCharterPath } = require("./spec-paths.js");
 
 function parseArgs(args) {
@@ -141,30 +142,6 @@ function createSprintResult({
   };
 }
 
-function getMilestoneDue(milestone) {
-  try {
-    const out = execFileSync("gh", [
-      "api", "repos/{owner}/{repo}/milestones",
-      "--jq", '.[] | select(.title==env.MS) | .due_on'
-    ], { ...GH_EXEC_DEFAULTS, env: { ...process.env, MS: milestone } }).trim();
-    return out ? out.slice(0, 10) : "TBD";
-  } catch {
-    return "TBD";
-  }
-}
-
-function getMilestoneIssues(milestone) {
-  try {
-    const out = execFileSync("gh", [
-      "issue", "list", "--milestone", milestone,
-      "--state", "open", "--json", "number,title,labels"
-    ], GH_EXEC_DEFAULTS);
-    return JSON.parse(out);
-  } catch {
-    return [];
-  }
-}
-
 // Detect whether the spec axis backs each field. Charter resolves canonical
 // spec/charter.md or legacy root CHARTER.md; capabilities is spec/capabilities.md.
 function detectSpecPresence({ repoRoot = process.cwd(), fileExists = fs.existsSync } = {}) {
@@ -186,12 +163,18 @@ function createSprintFile({
   fileExists = fs.existsSync,
   mkdir = (dir) => fs.mkdirSync(dir, { recursive: true }),
   writeFile = fs.writeFileSync,
-  getDue = getMilestoneDue,
-  getIssues = getMilestoneIssues,
+  getDue,
+  getIssues,
   // Optional overrides; when omitted, detected from repoRoot's spec/ files.
   hasCharter,
   hasCapabilities,
 }) {
+  if (!getDue || !getIssues) {
+    const resolved = resolveConfiguredTracker(readConfig(path.dirname(sprintsDir)));
+    invokeCapability(resolved, "milestones", () => undefined);
+    getDue = getDue || getMilestoneDue;
+    getIssues = getIssues || getMilestoneIssues;
+  }
   if (!dryRun) mkdir(sprintsDir);
 
   const datePrefix = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}`;

--- a/skills/dev-backlog/scripts/sprint-mirror.js
+++ b/skills/dev-backlog/scripts/sprint-mirror.js
@@ -19,8 +19,14 @@
 
 const { execFileSync } = require("child_process");
 const path = require("path");
-const { GH_EXEC_DEFAULTS } = require("./lib.js");
+const { readConfig } = require("./lib.js");
 const { parseTaskRef, renderTaskRef } = require("./task-ref.js");
+const { invokeCapability, resolveConfiguredTracker } = require("./tracker.js");
+const {
+  findMirrorIssue,
+  createMirrorIssue,
+  updateMirrorIssue,
+} = require("./github-mirrors.js");
 
 const MARKER_PREFIX = "<!-- dev-backlog:sprint-mirror sprint=";
 const MARKER_SUFFIX = " -->";
@@ -166,39 +172,6 @@ function renderMirrorBody({ state, slug, now = new Date() }) {
   return lines.join("\n");
 }
 
-// --- GitHub I/O ---
-
-function findMirrorIssue(marker, execFile) {
-  const out = execFile(
-    "gh",
-    [
-      "issue", "list", "--state", "all",
-      "--search", "dev-backlog:sprint-mirror in:body",
-      "--json", "number,body", "--limit", "50",
-    ],
-    GH_EXEC_DEFAULTS
-  );
-  const issues = JSON.parse(out);
-  return issues.find((issue) => issue.body && issue.body.includes(marker)) || null;
-}
-
-function createMirrorIssue(title, body, execFile) {
-  const out = execFile(
-    "gh",
-    ["issue", "create", "--title", title, "--body", body],
-    GH_EXEC_DEFAULTS
-  );
-  const match = String(out).trim().match(/\/issues\/(\d+)\s*$/);
-  if (!match) {
-    throw new Error(`Failed to parse issue number from gh output: ${String(out).trim()}`);
-  }
-  return { number: Number(match[1]) };
-}
-
-function updateMirrorIssue(number, body, execFile) {
-  execFile("gh", ["issue", "edit", String(number), "--body", body], GH_EXEC_DEFAULTS);
-}
-
 // --- Core sync ---
 
 function sync({
@@ -208,6 +181,8 @@ function sync({
   execFile = execFileSync,
   sprintStatePath = SPRINT_STATE_PATH,
 } = {}) {
+  const resolved = resolveConfiguredTracker(readConfig(backlogDir), { execFile });
+  invokeCapability(resolved, "mirrors", () => undefined);
   const state = resolveSprintState({ backlogDir, execFile, sprintStatePath });
   const slug = path.basename(state.active_sprint.path, ".md");
   const marker = makeMarker(slug);

--- a/skills/dev-backlog/scripts/status.sh
+++ b/skills/dev-backlog/scripts/status.sh
@@ -76,7 +76,12 @@ fi
 # --- GitHub Issues ---
 echo ""
 echo "=== GitHub Issues ==="
-node "$SCRIPT_DIR/tracker-status-list.js" "$BACKLOG_DIR" | column -t -s $'\t'
+if command -v column >/dev/null 2>&1; then
+  node "$SCRIPT_DIR/tracker-status-list.js" "$BACKLOG_DIR" | column -t -s $'\t' \
+    || echo "(gh not available)"
+else
+  echo "(gh not available)"
+fi
 
 # --- Local Files ---
 echo ""

--- a/skills/dev-backlog/scripts/status.sh
+++ b/skills/dev-backlog/scripts/status.sh
@@ -76,9 +76,7 @@ fi
 # --- GitHub Issues ---
 echo ""
 echo "=== GitHub Issues ==="
-gh issue list --state open --limit 20 --json number,title,labels,milestone --jq '
-  .[] | "\(.number)\t\(.milestone.title // "-")\t\(.title)\t\([.labels[].name] | join(","))"
-' 2>/dev/null | column -t -s $'\t' || echo "(gh not available)"
+node "$SCRIPT_DIR/tracker-status-list.js" "$BACKLOG_DIR" | column -t -s $'\t'
 
 # --- Local Files ---
 echo ""

--- a/skills/dev-backlog/scripts/sync-pull.js
+++ b/skills/dev-backlog/scripts/sync-pull.js
@@ -19,9 +19,13 @@ const {
   slugify,
   escapeYaml,
   readConfig,
-  GH_EXEC_DEFAULTS,
   getOpenIssueCount: getSharedOpenIssueCount,
 } = require("./lib");
+const {
+  createGithubAdapter,
+  stripNormalizedIdentity,
+} = require("./github-tracker.js");
+const { resolveConfiguredTracker } = require("./tracker.js");
 const { parseMarkerMonth } = require("./progress-sync-render");
 const {
   parseTaskFileName,
@@ -282,18 +286,16 @@ function getOpenIssueCount(execFile = execFileSync) {
 }
 
 function fetchOpenIssues(limit, execFile = execFileSync) {
-  const out = execFile("gh", [
-    "issue", "list", "--state", "open", "--limit", String(limit),
-    "--json", ISSUE_JSON_FIELDS,
-  ], GH_EXEC_DEFAULTS);
-
-  return JSON.parse(out);
+  return createGithubAdapter({ execFile })
+    .list({ limit, fields: ISSUE_JSON_FIELDS })
+    .map(stripNormalizedIdentity);
 }
 
-function loadOpenIssues({ limit, execFile = execFileSync } = {}) {
-  const resolvedLimit = limit ?? getOpenIssueCount(execFile);
-  if (resolvedLimit === 0) return [];
-  return fetchOpenIssues(resolvedLimit, execFile);
+function loadOpenIssues({ limit, execFile = execFileSync, config = {} } = {}) {
+  const resolved = resolveConfiguredTracker(config, { execFile });
+  return resolved.adapter
+    .list({ limit, fields: ISSUE_JSON_FIELDS })
+    .map(stripNormalizedIdentity);
 }
 
 function main() {
@@ -307,9 +309,10 @@ function main() {
 
   let issues;
   try {
-    issues = loadOpenIssues({ limit: options.limit });
+    issues = loadOpenIssues({ limit: options.limit, config });
   } catch (e) {
-    console.error(`gh error: ${e.message}`);
+    const prefix = e?.tracker ? "tracker error" : "gh error";
+    console.error(`${prefix}: ${e.message}`);
     process.exit(1);
   }
 

--- a/skills/dev-backlog/scripts/tracker-capability.js
+++ b/skills/dev-backlog/scripts/tracker-capability.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+const { readConfig } = require("./lib.js");
+const { invokeCapability, resolveConfiguredTracker } = require("./tracker.js");
+const { closeMilestone } = require("./github-milestones.js");
+
+function requireCapability(capability, backlogDir = "backlog") {
+  const resolved = resolveConfiguredTracker(readConfig(backlogDir));
+  return invokeCapability(resolved, capability, () => resolved);
+}
+
+function main() {
+  const [operation, capability, backlogDir = "backlog", value] = process.argv.slice(2);
+  try {
+    const resolved = requireCapability(capability, backlogDir);
+    if (operation === "require") return;
+    if (operation === "close-milestone") {
+      const count = invokeCapability(resolved, "milestones", () => closeMilestone(
+        value,
+        undefined,
+        () => console.log(`Warning: Could not close milestone: ${value}`)
+      ));
+      if (count > 0) console.log(`Closed milestone: ${value}`);
+      return;
+    }
+    throw new Error(`Unknown tracker capability operation: ${operation}`);
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) main();
+
+module.exports = { requireCapability };

--- a/skills/dev-backlog/scripts/tracker-status-list.js
+++ b/skills/dev-backlog/scripts/tracker-status-list.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+const { readConfig } = require("./lib.js");
+const { resolveConfiguredTracker } = require("./tracker.js");
+
+function listStatusRows(backlogDir = "backlog", { execFile } = {}) {
+  const resolved = resolveConfiguredTracker(readConfig(backlogDir), { execFile });
+  return resolved.adapter.list({
+    state: "open",
+    limit: 20,
+    fields: "number,title,labels,milestone",
+  }).map((task) => [
+    task.number,
+    task.milestone?.title || "-",
+    task.title,
+    (task.labels || []).map((label) => typeof label === "string" ? label : label.name).join(","),
+  ].join("\t"));
+}
+
+function main() {
+  try {
+    process.stdout.write(`${listStatusRows(process.argv[2]).join("\n")}\n`);
+  } catch (error) {
+    const message = error?.tracker
+      ? `(tracker unavailable: ${error.message})`
+      : "(gh not available)";
+    process.stdout.write(`${message}\n`);
+  }
+}
+
+if (require.main === module) main();
+
+module.exports = { listStatusRows };

--- a/skills/dev-backlog/scripts/tracker.js
+++ b/skills/dev-backlog/scripts/tracker.js
@@ -5,6 +5,8 @@
  * adapter, but it can never choose a different one.
  */
 
+const { createGithubAdapter } = require("./github-tracker.js");
+
 const TRACKER_KEYS = Object.freeze(["github", "local"]);
 const REQUIRED_ADAPTER_OPERATIONS = Object.freeze([
   "availability",
@@ -26,8 +28,6 @@ const CAPABILITY_NAMES = Object.freeze([
 
 const LOCAL_UNAVAILABLE_REASON =
   "local tracker persistence is not implemented; issue #276 adds it";
-const GITHUB_LIFECYCLE_REASON =
-  "GitHub lifecycle transport remains on compatibility callers until issue #275";
 
 class TrackerConfigurationError extends Error {
   constructor(value) {
@@ -171,6 +171,13 @@ function resolveTracker(config, { adapters = TRACKER_ADAPTERS } = {}) {
   return Object.freeze({ tracker, adapter, availability });
 }
 
+function resolveConfiguredTracker(config, { execFile, adapters } = {}) {
+  const registered = adapters || (execFile
+    ? { ...TRACKER_ADAPTERS, github: createGithubAdapter({ execFile }) }
+    : TRACKER_ADAPTERS);
+  return resolveTracker(config, { adapters: registered });
+}
+
 function validateIdentity(identity) {
   if (
     identity === null ||
@@ -268,20 +275,8 @@ function unavailableLocalOperation() {
   throw new TrackerUnavailableError("local", LOCAL_UNAVAILABLE_REASON);
 }
 
-function githubCompatibilityBoundary() {
-  throw new TrackerContractError(GITHUB_LIFECYCLE_REASON);
-}
-
 const TRACKER_ADAPTERS = Object.freeze({
-  github: Object.freeze({
-    availability: () => ({ available: true }),
-    capabilities: () => [...CAPABILITY_NAMES],
-    list: githubCompatibilityBoundary,
-    read: githubCompatibilityBoundary,
-    create: githubCompatibilityBoundary,
-    update: githubCompatibilityBoundary,
-    close: githubCompatibilityBoundary,
-  }),
+  github: createGithubAdapter(),
   local: Object.freeze({
     availability: () => ({ available: false, reason: LOCAL_UNAVAILABLE_REASON }),
     capabilities: () => [],
@@ -308,5 +303,7 @@ module.exports = {
   validateIdentity,
   readCapabilities,
   resolveTracker,
+  resolveConfiguredTracker,
   invokeCapability,
+  createGithubAdapter,
 };


### PR DESCRIPTION
## Dispatch Summary

```text
구현 완료 및 커밋했습니다. 작업트리는 깨끗하며 push/PR 생성은 하지 않았습니다.

커밋:

- `1f00963 tdd: red — pin GitHub tracker lifecycle compatibility`
- `fc08876 feat: move GitHub behavior behind tracker adapter (#275)`

### Direct `gh` 소유권 감사

| 기존 파일 | 최종 소유 경로 |
|---|---|
| `lib.js` | 호환 shim → `github-tracker.js` |
| `sync-pull.js` | configured adapter `list` |
| `sprint-init.js` | milestones gate → `github-milestones.js` |
| `status.sh` | `tracker-status-list.js` → adapter `list` |
| `sprint-close.sh` | 선행 capability ga
```

## Score Log

- Run: issue-275-20260711082621276-276a96e6
- Executor: codex
- Branch: relay/issue-275-github-adapter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 설정된 트래커를 통해 이슈 조회·생성·수정·종료 및 스프린트 관련 작업을 처리합니다.
  - 상태 화면에서 트래커의 열린 작업을 정렬된 목록으로 확인할 수 있습니다.
  - GitHub 마일스톤과 스프린트 미러 동기화를 지원합니다.

- **버그 수정**
  - 관리 마커가 없거나 월 정보가 맞지 않는 진행 이슈의 덮어쓰기를 방지합니다.
  - 로컬 트래커 설정에서는 지원되지 않는 외부 변경 작업이 실행되지 않습니다.
  - GitHub CLI가 없어도 상태 확인이 안전하게 완료됩니다.

- **문서**
  - 트래커 선택, 기능 지원 범위 및 로컬 트래커 동작 기준을 명확히 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->