### PR TITLE
fix: atomically capture lock before release (#276)

### DIFF
--- a/docs/tracker-adapter-design.md
+++ b/docs/tracker-adapter-design.md
@@ -29,9 +29,15 @@ configured-only resolution. Milestone, mirror, progress/PR/comment, and triage
 GitHub transports live in explicitly named provider modules and are reached only
 after their declared capability gates. Legacy helper exports remain compatibility
 shims over those owners, including their injected execution seams. The local slot
-still reports one implementation-pending reason and fails all lifecycle calls
-consistently until #276 adds persistence. This runtime does not make local task
-files canonical.
+is now implemented by `local-tracker.js` (#276): it owns the seven required
+operations over `backlog/tasks/` and `backlog/completed/` as the canonical local
+task store, allocates collision-safe parent IDs under an exclusive lock with
+atomic same-filesystem publication, preserves human body/AC bytes on
+metadata-only updates, archives on close without overwrite, reports no optional
+capabilities, and never invokes `gh` or falls back. In local mode these task
+files are canonical; GitHub mode continues to treat them as mirrors. Wiring the
+existing GitHub-oriented orchestration flows (sync, mirror, progress, triage,
+setup) onto local and the dual-mode documentation sweep remain #277/#278 work.
 
 ## Current Runtime Evidence
 

--- a/skills/dev-backlog/references/file-format.md
+++ b/skills/dev-backlog/references/file-format.md
@@ -111,9 +111,40 @@ statuses: ["To Do", "In Progress", "Done"]
 
 `tracker` accepts only `github` or `local`. A missing key deterministically
 defaults to `github`; runtime availability never changes that selection or
-falls back to the other adapter. The `local` adapter is intentionally
-unavailable until #276 implements persistence, and existing GitHub callers are
-not moved behind the seam until #275.
+falls back to the other adapter.
+
+## Local Canonical Storage (`tracker: local`)
+
+In local mode the `backlog/tasks/` and `backlog/completed/` files are the
+**canonical** task store, not GitHub mirrors. `local-tracker.js` owns every
+filesystem rule behind the seven required operations; callers only ever see the
+normalized identity `{ tracker: "local", id, ref: "{PREFIX}-{N}[.M]" }` — there
+is no fabricated `url`.
+
+- **Allocation.** `create` allocates the next positive **parent** integer by
+  scanning the exact configured-prefix IDs across both `tasks/` and
+  `completed/` (so a closed `BACK-7` still reserves `7`). `BACK-1` and `BACK-11`
+  are kept distinct by exact-match parsing. An explicit decimal `id` (e.g.
+  `1.2`) creates a subtask only when that exact ID is free; decimals never
+  shift parent allocation and are not auto-created.
+- **Atomic publication.** Allocation runs inside an exclusive lock
+  (`backlog/.local-tracker.lock`); the new file is written to a same-directory
+  temp and hard-linked into place, so a colliding destination fails instead of
+  overwriting. The lock and temp are always released, including on error.
+- **Body preservation.** A metadata/state-only `update` rewrites only the
+  requested frontmatter keys and leaves the human-authored description,
+  headings, and `AC:BEGIN/END` checkbox bytes untouched. Filenames stay stable
+  even when the frontmatter `title` changes. The body is replaced only when the
+  caller supplies one explicitly.
+- **Archive on close.** `close` moves exactly one active task into
+  `backlog/completed/`, writes `status: Done`, and refuses an existing
+  destination rather than overwriting; a task that is already archived returns a
+  clear already-closed result without data loss.
+- **No provider features.** Local reports **no** optional capabilities. Any
+  milestone, PR relationship, mirror, progress-issue, comment, or
+  closing-semantics attempt fails with the existing tracker+capability error
+  before any filesystem mutation, and the runtime never invokes `gh` or falls
+  back to GitHub for explicit local.
 
 dev-backlog also reads `task_prefix`, `default_status`, and `statuses`;
 `project_name` is retained as metadata. Other Backlog.md config fields are not

--- a/skills/dev-backlog/scripts/github-capabilities.test.js
+++ b/skills/dev-backlog/scripts/github-capabilities.test.js
@@ -115,7 +115,8 @@ describe("configured-only failure before effects", () => {
       throw new Error("must not execute");
     };
 
-    assert.throws(() => loadOpenIssues({ config: { tracker: "local" }, execFile }), /local/);
+    // Optional-capability GitHub flows stay fail-closed for explicit local:
+    // they raise the tracker+capability error before any GitHub execution.
     assert.throws(() => syncMirror({ backlogDir, execFile }), /local/);
     assert.throws(() => syncProgress({ month: "2026-07", backlogDir, execFile }), /local/);
     assert.throws(() => createSprintFile({
@@ -128,6 +129,10 @@ describe("configured-only failure before effects", () => {
       collectSnapshot({ repo: "acme/widgets", trackerConfig: { tracker: "local" }, execFile }),
       /local/
     );
+
+    // Required-op flows resolve the local adapter (post-#276) rather than
+    // GitHub. They must never execute gh or fall back to the GitHub transport.
+    loadOpenIssues({ config: { tracker: "local" }, execFile });
 
     const report = path.join(root, "report.md");
     fs.writeFileSync(report, [
@@ -143,8 +148,7 @@ describe("configured-only failure before effects", () => {
         return { status: 0, stdout: "", stderr: "" };
       },
     });
-    assert.equal(applied.exitCode, 1);
-    assert.match(applied.error, /local/);
+    assert.equal(applied.exitCode, 0);
     assert.equal(executions, 0);
     assert.equal(fs.existsSync(path.join(backlogDir, "sprints")), false);
     assert.equal(fs.existsSync(path.join(backlogDir, "triage", "2026-07-11-apply.log")), false);

--- a/skills/dev-backlog/scripts/local-tracker.integration.test.js
+++ b/skills/dev-backlog/scripts/local-tracker.integration.test.js
@@ -167,6 +167,50 @@ describe("offline local core sprint cycle", () => {
   });
 });
 
+describe("offline local close survives a process crash", () => {
+  it("recovers duplicate copies and a stale lock left by a crash mid-close", (t) => {
+    const { root, backlogDir } = makeOfflineStore(t);
+    fs.writeFileSync(
+      path.join(backlogDir, "tasks", "BACK-1 - one.md"),
+      "---\nid: BACK-1\ntitle: One\nstatus: To Do\nlabels: []\npriority: medium\ncreated_date: '2026-07-01'\n---\n## Description\nkeep me\n"
+    );
+
+    // A worker that dies after the completed copy is published but before the
+    // active source is unlinked — the exact window that used to strand the store
+    // with duplicate canonical copies and a held lock.
+    const workerPath = path.join(root, "crash-worker.js");
+    fs.writeFileSync(
+      workerPath,
+      `const { createLocalAdapter } = require(${JSON.stringify(LOCAL_TRACKER_PATH)});\n` +
+        "const [backlogDir] = process.argv.slice(2);\n" +
+        "const adapter = createLocalAdapter({ backlogDir, testHooks: { beforeUnlinkSource() { process.exit(99); } } });\n" +
+        "adapter.close('BACK-1');\n"
+    );
+    const crashed = spawnSync(process.execPath, [workerPath, backlogDir], { encoding: "utf8" });
+    assert.equal(crashed.status, 99, "worker crashed mid-close after publishing the completed copy");
+
+    // The crash left both canonical copies, a durable marker, and a stale lock.
+    assert.ok(fs.existsSync(path.join(backlogDir, "tasks", "BACK-1 - one.md")), "active source survived the crash");
+    assert.ok(fs.existsSync(path.join(backlogDir, "completed", "BACK-1 - one.md")), "completed copy was published before the crash");
+    assert.ok(fs.existsSync(path.join(backlogDir, ".local-tracker.close")), "recovery marker remains");
+    assert.ok(fs.existsSync(path.join(backlogDir, ".local-tracker.lock")), "the crashed process left a stale lock");
+
+    // Next open reclaims the stale lock, heals to a single authority, clears the marker.
+    const { adapter } = localAdapter(backlogDir);
+    const result = adapter.close("BACK-1");
+    assert.deepEqual(result, { tracker: "local", id: "1", ref: "BACK-1" });
+    assert.equal(fs.existsSync(path.join(backlogDir, "tasks", "BACK-1 - one.md")), false, "duplicate active source retired");
+    assert.deepEqual(adapter.list().map((task) => task.ref), []);
+    assert.deepEqual(adapter.list({ state: "closed" }).map((task) => task.ref), ["BACK-1"]);
+    assert.equal(fs.existsSync(path.join(backlogDir, ".local-tracker.lock")), false, "stale lock reclaimed and released");
+    assert.equal(fs.existsSync(path.join(backlogDir, ".local-tracker.close")), false, "marker cleared after recovery");
+
+    const archived = fs.readFileSync(path.join(backlogDir, "completed", "BACK-1 - one.md"), "utf-8");
+    assert.match(archived, /^status: Done$/m);
+    assert.ok(archived.includes("keep me"), "the archived body is preserved");
+  });
+});
+
 describe("offline concurrent allocation is atomic", () => {
   it("assigns distinct ids to parallel allocators with no overwrite or leaked lock/temp", async (t) => {
     const { root, backlogDir } = makeOfflineStore(t);

--- a/skills/dev-backlog/scripts/local-tracker.integration.test.js
+++ b/skills/dev-backlog/scripts/local-tracker.integration.test.js
@@ -1,0 +1,219 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawn, spawnSync } = require("node:child_process");
+
+const { resolveConfiguredTracker, invokeCapability, CAPABILITY_NAMES } = require("./tracker.js");
+const { LocalStoreError } = require("./local-tracker.js");
+const { readSprintState, findNextBatch } = require("./sprint-state.js");
+
+const SCRIPTS_DIR = __dirname;
+const LOCAL_TRACKER_PATH = path.join(SCRIPTS_DIR, "local-tracker.js");
+
+function makeOfflineStore(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "local-integration-"));
+  const backlogDir = path.join(root, "backlog");
+  fs.mkdirSync(path.join(backlogDir, "tasks"), { recursive: true });
+  fs.mkdirSync(path.join(backlogDir, "completed"), { recursive: true });
+  fs.mkdirSync(path.join(backlogDir, "sprints"), { recursive: true });
+  fs.writeFileSync(
+    path.join(backlogDir, "config.yml"),
+    'tracker: local\ntask_prefix: "BACK"\ndefault_status: "To Do"\nstatuses: ["To Do", "In Progress", "Done"]\n'
+  );
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return { root, backlogDir };
+}
+
+/** Install a `gh` that records any invocation and fails, proving no-gh paths. */
+function installFailingGh(t, root) {
+  const binDir = path.join(root, "bin");
+  fs.mkdirSync(binDir, { recursive: true });
+  const marker = path.join(root, "gh-invoked");
+  fs.writeFileSync(
+    path.join(binDir, "gh"),
+    `#!/bin/sh\necho "gh $*" >> "${marker}"\nexit 97\n`
+  );
+  fs.chmodSync(path.join(binDir, "gh"), 0o755);
+  const savedPath = process.env.PATH;
+  process.env.PATH = `${binDir}:${savedPath}`;
+  t.after(() => {
+    process.env.PATH = savedPath;
+  });
+  return { binDir, marker, envPath: `${binDir}:${savedPath}` };
+}
+
+function localAdapter(backlogDir) {
+  return resolveConfiguredTracker({ tracker: "local" }, { backlogDir });
+}
+
+describe("offline local core sprint cycle", () => {
+  it("runs create → Plan → status/next → read → work-state update → close/archive with no gh", (t) => {
+    const { root, backlogDir } = makeOfflineStore(t);
+    const { marker, envPath } = installFailingGh(t, root);
+    const { adapter } = localAdapter(backlogDir);
+
+    // create three canonical local tasks, offline
+    const first = adapter.create({ title: "Design offline adapter" });
+    const second = adapter.create({ title: "Prove core cycle" });
+    const third = adapter.create({ title: "Archive on close" });
+    assert.deepEqual([first, second, third].map((task) => task.ref), ["BACK-1", "BACK-2", "BACK-3"]);
+    assert.equal([first, second, third].every((task) => !("url" in task)), true);
+
+    // Plan them into an active sprint using their normalized refs
+    fs.writeFileSync(
+      path.join(backlogDir, "sprints", "cycle.md"),
+      [
+        "---", "milestone: local cycle", "status: active", "started: 2026-07-11", "---", "",
+        "# Offline Local Cycle", "",
+        "## Goal", "Prove the offline local core cycle.", "",
+        "## Plan", "",
+        "### Batch 1 - core",
+        `- [ ] ${first.ref} Design offline adapter`,
+        `- [ ] ${second.ref} Prove core cycle`,
+        `- [ ] ${third.ref} Archive on close`,
+        "", "## Running Context", "", "## Progress", "",
+      ].join("\n")
+    );
+
+    // status orientation: the active sprint reads back normalized local plan items
+    const state = readSprintState({ backlogDir });
+    assert.equal(state.active_sprint.frontmatter.milestone, "local cycle");
+    assert.deepEqual(state.plan_items.map((item) => item.ref), ["BACK-1", "BACK-2", "BACK-3"]);
+    assert.equal(state.plan_items.every((item) => item.tracker === "local" && item.issue_number === null), true);
+
+    // next orientation: the first todo batch is the local batch we planned
+    const nextBatch = findNextBatch(state.plan_items);
+    assert.equal(nextBatch.heading, "### Batch 1 - core");
+    assert.deepEqual(nextBatch.items.map((item) => item.ref), ["BACK-1", "BACK-2", "BACK-3"]);
+
+    // the whole orientation path is gh-free when driven as a subprocess
+    const oriented = spawnSync(process.execPath, [
+      path.join(SCRIPTS_DIR, "sprint-state.js"), "--mode", "next", backlogDir, "--json",
+    ], { encoding: "utf8", env: { ...process.env, PATH: envPath } });
+    assert.equal(oriented.status, 0);
+    const orientedState = JSON.parse(oriented.stdout);
+    assert.deepEqual(orientedState.plan_items.map((item) => item.ref), ["BACK-1", "BACK-2", "BACK-3"]);
+
+    // read one task by its normalized ref
+    const readBack = adapter.read(second.ref);
+    assert.equal(readBack.title, "Prove core cycle");
+    assert.equal(readBack.status, "To Do");
+    assert.equal(readBack.state, "open");
+
+    // work-state update preserves the human body byte-for-byte
+    const secondFile = path.join(backlogDir, "tasks", "BACK-2 - prove-core-cycle.md");
+    const bodyBefore = fs.readFileSync(secondFile, "utf-8");
+    const humanBody = bodyBefore.slice(bodyBefore.indexOf("\n## Description"));
+    adapter.update(second.ref, { status: "In Progress" });
+    const bodyAfter = fs.readFileSync(secondFile, "utf-8");
+    assert.equal(bodyAfter.slice(bodyAfter.indexOf("\n## Description")), humanBody);
+    assert.match(bodyAfter, /^status: In Progress$/m);
+
+    // checked close archives exactly that task into completed/ as Done
+    adapter.close(second.ref);
+    assert.equal(fs.existsSync(secondFile), false);
+    const archived = fs.readFileSync(path.join(backlogDir, "completed", "BACK-2 - prove-core-cycle.md"), "utf-8");
+    assert.match(archived, /^status: Done$/m);
+    assert.deepEqual(adapter.list().map((task) => task.ref), ["BACK-1", "BACK-3"]);
+    assert.deepEqual(adapter.list({ state: "closed" }).map((task) => task.ref), ["BACK-2"]);
+
+    // the entire cycle never touched gh
+    assert.equal(fs.existsSync(marker), false, `gh must never run offline; invocations: ${fs.existsSync(marker) ? fs.readFileSync(marker, "utf-8") : ""}`);
+  });
+
+  it("fails every optional capability before mutation and never falls back", (t) => {
+    const { backlogDir } = makeOfflineStore(t);
+    const resolved = localAdapter(backlogDir);
+    assert.deepEqual(resolved.adapter.capabilities(), []);
+    for (const capability of CAPABILITY_NAMES) {
+      let mutated = false;
+      assert.throws(
+        () => invokeCapability(resolved, capability, () => {
+          mutated = true;
+        }),
+        (error) => {
+          assert.equal(error.tracker, "local");
+          assert.equal(error.capability, capability);
+          return true;
+        }
+      );
+      assert.equal(mutated, false);
+    }
+  });
+
+  it("handles malformed input, exact collisions, and decimal identities", (t) => {
+    const { backlogDir } = makeOfflineStore(t);
+    const { adapter } = localAdapter(backlogDir);
+
+    assert.throws(() => adapter.create({ title: "" }), LocalStoreError);
+    assert.throws(() => adapter.create({}), LocalStoreError);
+
+    // seed a BACK-1/BACK-11 collision boundary directly
+    for (const [id, name] of [[1, "one"], [11, "eleven"]]) {
+      fs.writeFileSync(
+        path.join(backlogDir, "tasks", `BACK-${id} - ${name}.md`),
+        `---\nid: BACK-${id}\ntitle: ${name}\nstatus: To Do\nlabels: []\npriority: medium\ncreated_date: '2026-07-01'\n---\n## Description\n${name}\n`
+      );
+    }
+    assert.equal(adapter.read("BACK-1").id, "1");
+    assert.equal(adapter.read("BACK-11").id, "11");
+    assert.equal(adapter.create({ title: "next parent" }).id, "12");
+
+    const sub = adapter.create({ title: "decimal child", id: "1.2" });
+    assert.deepEqual(sub, { tracker: "local", id: "1.2", ref: "BACK-1.2" });
+    assert.throws(() => adapter.create({ title: "dup decimal", id: "1.2" }), LocalStoreError);
+  });
+});
+
+describe("offline concurrent allocation is atomic", () => {
+  it("assigns distinct ids to parallel allocators with no overwrite or leaked lock/temp", async (t) => {
+    const { root, backlogDir } = makeOfflineStore(t);
+    const workerPath = path.join(root, "alloc-worker.js");
+    fs.writeFileSync(
+      workerPath,
+      `const { createLocalAdapter } = require(${JSON.stringify(LOCAL_TRACKER_PATH)});\n` +
+        "const [backlogDir, title] = process.argv.slice(2);\n" +
+        "try {\n" +
+        "  const id = createLocalAdapter({ backlogDir }).create({ title });\n" +
+        "  process.stdout.write(JSON.stringify(id));\n" +
+        "  process.exit(0);\n" +
+        "} catch (error) {\n" +
+        "  process.stderr.write(String(error && error.message));\n" +
+        "  process.exit(3);\n" +
+        "}\n"
+    );
+
+    const WORKERS = 8;
+    const results = await Promise.all(
+      Array.from({ length: WORKERS }, (_unused, index) =>
+        new Promise((resolve, reject) => {
+          const child = spawn(process.execPath, [workerPath, backlogDir, `Parallel task ${index}`], {
+            stdio: ["ignore", "pipe", "pipe"],
+          });
+          let out = "";
+          let err = "";
+          child.stdout.on("data", (chunk) => { out += chunk; });
+          child.stderr.on("data", (chunk) => { err += chunk; });
+          child.on("close", (code) => {
+            if (code === 0) resolve(JSON.parse(out));
+            else reject(new Error(`worker ${index} exited ${code}: ${err}`));
+          });
+        })
+      )
+    );
+
+    const ids = results.map((identity) => Number(identity.id)).sort((a, b) => a - b);
+    assert.deepEqual(ids, Array.from({ length: WORKERS }, (_unused, index) => index + 1), "ids must be distinct 1..N");
+
+    const files = fs.readdirSync(path.join(backlogDir, "tasks")).filter((name) => name.endsWith(".md"));
+    assert.equal(files.length, WORKERS, "one file per allocation, none overwritten");
+    assert.equal(new Set(files.map((name) => name.split(" - ")[0])).size, WORKERS);
+
+    // no leaked lock or temp files remain
+    assert.equal(fs.existsSync(path.join(backlogDir, ".local-tracker.lock")), false);
+    const strays = fs.readdirSync(path.join(backlogDir, "tasks")).filter((name) => name.includes(".tmp"));
+    assert.deepEqual(strays, []);
+  });
+});

--- a/skills/dev-backlog/scripts/local-tracker.integration.test.js
+++ b/skills/dev-backlog/scripts/local-tracker.integration.test.js
@@ -168,7 +168,7 @@ describe("offline local core sprint cycle", () => {
 });
 
 describe("offline local close survives a process crash", () => {
-  it("recovers duplicate copies and a stale lock left by a crash mid-close", (t) => {
+  it("fails closed on the stale lock, then heals to one authority once it is cleared", (t) => {
     const { root, backlogDir } = makeOfflineStore(t);
     fs.writeFileSync(
       path.join(backlogDir, "tasks", "BACK-1 - one.md"),
@@ -176,8 +176,8 @@ describe("offline local close survives a process crash", () => {
     );
 
     // A worker that dies after the completed copy is published but before the
-    // active source is unlinked — the exact window that used to strand the store
-    // with duplicate canonical copies and a held lock.
+    // active source is unlinked — the exact window that strands the store with
+    // duplicate canonical copies and a held lock.
     const workerPath = path.join(root, "crash-worker.js");
     fs.writeFileSync(
       workerPath,
@@ -193,16 +193,32 @@ describe("offline local close survives a process crash", () => {
     assert.ok(fs.existsSync(path.join(backlogDir, "tasks", "BACK-1 - one.md")), "active source survived the crash");
     assert.ok(fs.existsSync(path.join(backlogDir, "completed", "BACK-1 - one.md")), "completed copy was published before the crash");
     assert.ok(fs.existsSync(path.join(backlogDir, ".local-tracker.close")), "recovery marker remains");
-    assert.ok(fs.existsSync(path.join(backlogDir, ".local-tracker.lock")), "the crashed process left a stale lock");
+    const lockPath = path.join(backlogDir, ".local-tracker.lock");
+    assert.ok(fs.existsSync(lockPath), "the crashed process left a stale lock");
+    const staleLockBytes = fs.readFileSync(lockPath, "utf-8");
 
-    // Next open reclaims the stale lock, heals to a single authority, clears the marker.
+    // Next open must NOT auto-reclaim the dead-PID lock: a path-based reclaim
+    // cannot avoid racing a replacement holder. It fails closed with an actionable
+    // manual-cleanup error and leaves the stale lock byte-for-byte untouched.
     const { adapter } = localAdapter(backlogDir);
+    assert.throws(
+      () => adapter.close("BACK-1"),
+      (error) => error instanceof LocalStoreError && /stale lock|no longer running|manually/i.test(error.message)
+    );
+    assert.equal(fs.readFileSync(lockPath, "utf-8"), staleLockBytes, "the stale lock is never auto-reclaimed");
+    assert.ok(fs.existsSync(path.join(backlogDir, "tasks", "BACK-1 - one.md")), "no roll-forward while the lock is held");
+    assert.ok(fs.existsSync(path.join(backlogDir, ".local-tracker.close")), "the marker survives the fail-closed attempt");
+
+    // The operator confirms no allocator is running and removes the stale lock.
+    // Recovery then derives the exact Done bytes from the active source, sees the
+    // published copy match, retires the source, and clears the marker.
+    fs.unlinkSync(lockPath);
     const result = adapter.close("BACK-1");
     assert.deepEqual(result, { tracker: "local", id: "1", ref: "BACK-1" });
     assert.equal(fs.existsSync(path.join(backlogDir, "tasks", "BACK-1 - one.md")), false, "duplicate active source retired");
     assert.deepEqual(adapter.list().map((task) => task.ref), []);
     assert.deepEqual(adapter.list({ state: "closed" }).map((task) => task.ref), ["BACK-1"]);
-    assert.equal(fs.existsSync(path.join(backlogDir, ".local-tracker.lock")), false, "stale lock reclaimed and released");
+    assert.equal(fs.existsSync(lockPath), false, "the healing close releases its own lock");
     assert.equal(fs.existsSync(path.join(backlogDir, ".local-tracker.close")), false, "marker cleared after recovery");
 
     const archived = fs.readFileSync(path.join(backlogDir, "completed", "BACK-1 - one.md"), "utf-8");

--- a/skills/dev-backlog/scripts/local-tracker.js
+++ b/skills/dev-backlog/scripts/local-tracker.js
@@ -1,0 +1,517 @@
+/**
+ * Local filesystem implementation of the required seven-operation tracker
+ * lifecycle.
+ *
+ * This module is the single owner of every local-store rule: task filenames,
+ * frontmatter grammar, body preservation, ID allocation, and the atomic
+ * publication primitives. Callers only ever see the seven operations and the
+ * normalized `{ tracker: "local", id, ref }` identity — no URL, no filename,
+ * and no frontmatter leak across the seam.
+ *
+ * Canonical tasks live in `backlog/tasks/` (open) and `backlog/completed/`
+ * (closed) as Backlog.md-compatible `{PREFIX}-{N}[.M] - {slug}.md` files. The
+ * adapter never invokes `gh`, opens a network socket, reads GitHub state, or
+ * falls back to another tracker: local selection is authoritative.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
+
+const { readConfig, slugify, escapeYaml, parseSimpleYaml } = require("./lib.js");
+const {
+  parseTaskRef,
+  parseTaskFileName,
+} = require("./task-ref.js");
+
+const TASKS_DIR = "tasks";
+const COMPLETED_DIR = "completed";
+const LOCK_FILE = ".local-tracker.lock";
+const DONE_STATUS = "Done";
+const DEFAULT_LOCK = Object.freeze({ retries: 100, delayMs: 20 });
+
+/** Every recoverable local-store failure surfaces as this actionable type. */
+class LocalStoreError extends Error {
+  constructor(message, options) {
+    super(message, options);
+    this.name = "LocalStoreError";
+    this.tracker = "local";
+  }
+}
+
+// --- synchronous timing primitive (no busy spin) ---
+
+function sleepSync(ms) {
+  if (!(ms > 0)) return;
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+// --- frontmatter / body split, preserving human bytes verbatim ---
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---(\r?\n[\s\S]*|$)/;
+
+function splitDocument(content) {
+  const match = content.match(FRONTMATTER_RE);
+  if (!match) return null;
+  return { frontmatter: match[1], body: match[2] };
+}
+
+/**
+ * Parse a frontmatter block into ordered entries. Each entry keeps its raw
+ * source lines so untouched keys are re-emitted byte-for-byte on update.
+ */
+function parseFrontmatterEntries(frontmatter) {
+  const entries = [];
+  let current = null;
+  for (const line of frontmatter.split("\n")) {
+    const isKey = /^[A-Za-z0-9_-]+:/.test(line) && !/^\s/.test(line);
+    if (isKey) {
+      if (current) entries.push(current);
+      current = { key: line.slice(0, line.indexOf(":")), lines: [line] };
+    } else if (current) {
+      current.lines.push(line);
+    }
+  }
+  if (current) entries.push(current);
+  return entries;
+}
+
+function entryValue(entry) {
+  return parseSimpleYaml(entry.lines.join("\n"))[entry.key];
+}
+
+function frontmatterObject(entries) {
+  const object = {};
+  for (const entry of entries) object[entry.key] = entryValue(entry);
+  return object;
+}
+
+const DATE_KEYS = new Set(["created_date", "updated_date"]);
+
+function renderScalar(key, value) {
+  const text = String(value);
+  if (DATE_KEYS.has(key)) return `${key}: '${text}'`;
+  return `${key}: ${escapeYaml(text)}`;
+}
+
+function renderFieldLines(key, value) {
+  if (Array.isArray(value)) {
+    if (value.length === 0) return [`${key}: []`];
+    return [`${key}:`, ...value.map((item) => `  - ${item}`)];
+  }
+  return [renderScalar(key, value)];
+}
+
+/**
+ * Replace only the requested keys; append new keys at the end. Every other
+ * entry is emitted from its raw source lines, so unrelated frontmatter and the
+ * human body are never re-rendered or reordered.
+ */
+function applyFrontmatterChanges(entries, changes) {
+  const next = entries.map((entry) => ({ ...entry, lines: [...entry.lines] }));
+  for (const [key, value] of Object.entries(changes)) {
+    if (value === undefined) continue;
+    const lines = renderFieldLines(key, value);
+    const existing = next.find((entry) => entry.key === key);
+    if (existing) existing.lines = lines;
+    else next.push({ key, lines });
+  }
+  return next;
+}
+
+function stringifyFrontmatter(entries) {
+  const inner = entries.flatMap((entry) => entry.lines).join("\n");
+  return `---\n${inner}\n---`;
+}
+
+// --- normalized task shape ---
+
+function normalizeTask({ identity, object, body, state }) {
+  const labels = Array.isArray(object.labels)
+    ? object.labels
+    : object.labels
+      ? [object.labels]
+      : [];
+  const dependencies = Array.isArray(object.dependencies)
+    ? object.dependencies
+    : object.dependencies
+      ? [object.dependencies]
+      : [];
+  return {
+    tracker: "local",
+    id: identity.id,
+    ref: identity.ref,
+    title: object.title === undefined ? "" : String(object.title),
+    status: object.status === undefined ? "" : String(object.status),
+    labels,
+    priority: object.priority === undefined ? "" : String(object.priority),
+    dependencies,
+    created_date: object.created_date === undefined ? "" : String(object.created_date),
+    updated_date: object.updated_date === undefined ? "" : String(object.updated_date),
+    body,
+    state,
+  };
+}
+
+function createLocalAdapter(options = {}) {
+  const backlogDir = options.backlogDir;
+  const now = options.now || (() => new Date());
+  const config = options.config || readConfig(backlogDir);
+  const taskPrefix = config.task_prefix || "BACK";
+  const defaultStatus = config.default_status || "To Do";
+  const lockConfig = { ...DEFAULT_LOCK, ...(options.lock || {}) };
+  const testHooks = options.testHooks || {};
+  const refOptions = { taskPrefix };
+
+  function dirPath(kind) {
+    return path.join(backlogDir, kind);
+  }
+
+  function today() {
+    return now().toISOString().slice(0, 10);
+  }
+
+  // --- identity resolution (no foreign-prefix inference) ---
+
+  function resolveIdentity(selector) {
+    if (selector && typeof selector === "object") {
+      if (selector.tracker !== "local") {
+        throw new LocalStoreError("local read/update/close requires a local task identity");
+      }
+      const bare = parseTaskRef(`${taskPrefix}-${selector.id}`, refOptions);
+      if (!bare) throw new LocalStoreError(`invalid local task id: ${String(selector.id)}`);
+      if (selector.ref !== undefined && selector.ref !== bare.ref) {
+        throw new LocalStoreError(`local task ref ${selector.ref} does not match ${bare.ref}`);
+      }
+      return bare;
+    }
+    if (typeof selector === "string") {
+      const asRef = parseTaskRef(selector, refOptions);
+      if (asRef && asRef.tracker === "local") return asRef;
+      const asId = parseTaskRef(`${taskPrefix}-${selector}`, refOptions);
+      if (asId) return asId;
+    }
+    throw new LocalStoreError(`unresolved local task selector: ${String(selector)}`);
+  }
+
+  // --- directory scanning ---
+
+  function listDir(kind) {
+    const dir = dirPath(kind);
+    let names;
+    try {
+      names = fs.readdirSync(dir);
+    } catch (error) {
+      if (error.code === "ENOENT") return [];
+      throw new LocalStoreError(`cannot read local ${kind} directory: ${error.message}`, { cause: error });
+    }
+    const found = [];
+    for (const name of names) {
+      if (!name.endsWith(".md")) continue;
+      const identity = parseTaskFileName(name, { taskPrefix, tracker: "local" });
+      if (identity) found.push({ identity, file: name });
+    }
+    return found;
+  }
+
+  function findEntry(kind, identity) {
+    return listDir(kind).find((entry) => entry.identity.id === identity.id);
+  }
+
+  function readTask(kind, entry) {
+    const full = path.join(dirPath(kind), entry.file);
+    const content = fs.readFileSync(full, "utf-8");
+    const split = splitDocument(content);
+    if (!split) return null;
+    const object = frontmatterObject(parseFrontmatterEntries(split.frontmatter));
+    const state = kind === COMPLETED_DIR ? "closed" : "open";
+    return normalizeTask({ identity: entry.identity, object, body: split.body, state });
+  }
+
+  // --- allocation critical section ---
+
+  function tempPath(dir, id) {
+    const token = crypto.randomBytes(6).toString("hex");
+    return path.join(dir, `.local-tracker.${process.pid}.${id}.${token}.tmp`);
+  }
+
+  function acquireLock() {
+    fs.mkdirSync(backlogDir, { recursive: true });
+    const lockPath = path.join(backlogDir, LOCK_FILE);
+    for (let attempt = 0; attempt <= lockConfig.retries; attempt += 1) {
+      try {
+        return fs.openSync(lockPath, "wx");
+      } catch (error) {
+        if (error.code !== "EEXIST") {
+          throw new LocalStoreError(`cannot acquire local allocation lock: ${error.message}`, { cause: error });
+        }
+        if (attempt < lockConfig.retries) sleepSync(lockConfig.delayMs);
+      }
+    }
+    throw new LocalStoreError(
+      "another local allocation holds the store lock; retry once it releases " +
+        `(remove ${path.join(backlogDir, LOCK_FILE)} only if you are certain no allocator is running)`
+    );
+  }
+
+  function releaseLock(fd) {
+    const lockPath = path.join(backlogDir, LOCK_FILE);
+    try {
+      fs.closeSync(fd);
+    } catch {
+      /* fd already closed */
+    }
+    try {
+      fs.unlinkSync(lockPath);
+    } catch {
+      /* lock already gone */
+    }
+  }
+
+  function withAllocationLock(fn) {
+    const fd = acquireLock();
+    try {
+      return fn();
+    } finally {
+      releaseLock(fd);
+    }
+  }
+
+  function allocateParentId() {
+    let max = 0;
+    for (const kind of [TASKS_DIR, COMPLETED_DIR]) {
+      for (const { identity } of listDir(kind)) {
+        const parent = Number.parseInt(identity.id.split(".")[0], 10);
+        if (Number.isInteger(parent) && parent > max) max = parent;
+      }
+    }
+    return String(max + 1);
+  }
+
+  function idExists(id) {
+    return [TASKS_DIR, COMPLETED_DIR].some((kind) =>
+      listDir(kind).some((entry) => entry.identity.id === id)
+    );
+  }
+
+  // --- atomic publication: temp on same fs, hard-link (no overwrite), unlink ---
+
+  function publishNewFile(dir, fileName, content) {
+    fs.mkdirSync(dir, { recursive: true });
+    const dest = path.join(dir, fileName);
+    const tmp = tempPath(dir, path.basename(fileName));
+    fs.writeFileSync(tmp, content);
+    try {
+      if (testHooks.beforePublish) testHooks.beforePublish(dest);
+      fs.linkSync(tmp, dest);
+    } catch (error) {
+      if (error.code === "EEXIST") {
+        throw new LocalStoreError(`local task file already exists: ${fileName}`, { cause: error });
+      }
+      throw error;
+    } finally {
+      try {
+        fs.unlinkSync(tmp);
+      } catch {
+        /* temp already gone */
+      }
+    }
+    return dest;
+  }
+
+  function replaceFileAtomic(dir, fileName, content) {
+    const dest = path.join(dir, fileName);
+    const tmp = tempPath(dir, path.basename(fileName));
+    fs.writeFileSync(tmp, content);
+    try {
+      fs.renameSync(tmp, dest);
+    } catch (error) {
+      try {
+        fs.unlinkSync(tmp);
+      } catch {
+        /* temp already gone */
+      }
+      throw error;
+    }
+    return dest;
+  }
+
+  // --- rendered content builders ---
+
+  function buildFilename(identity, title) {
+    const slug = slugify(title) || identity.id;
+    return `${identity.ref} - ${slug}.md`;
+  }
+
+  function buildNewContent({ identity, title, status, labels, priority, dependencies, body }) {
+    const entries = [
+      { key: "id", lines: [`id: ${identity.ref}`] },
+      { key: "title", lines: renderFieldLines("title", title) },
+      { key: "status", lines: renderFieldLines("status", status) },
+      { key: "labels", lines: renderFieldLines("labels", labels) },
+      { key: "priority", lines: renderFieldLines("priority", priority) },
+    ];
+    if (dependencies.length) entries.push({ key: "dependencies", lines: renderFieldLines("dependencies", dependencies) });
+    entries.push({ key: "created_date", lines: [renderScalar("created_date", today())] });
+    return `${stringifyFrontmatter(entries)}${body}`;
+  }
+
+  // --- the seven required operations ---
+
+  function availability() {
+    if (typeof backlogDir !== "string" || !backlogDir.trim()) {
+      return { available: false, reason: "local tracker backlogDir is not configured" };
+    }
+    for (const probe of [backlogDir, dirPath(TASKS_DIR), dirPath(COMPLETED_DIR)]) {
+      let stat;
+      try {
+        stat = fs.statSync(probe);
+      } catch (error) {
+        if (error.code === "ENOENT") continue; // created lazily on first write
+        return { available: false, reason: `local store path ${probe} is unusable: ${error.message}` };
+      }
+      if (!stat.isDirectory()) {
+        return { available: false, reason: `local store path ${probe} is not a directory` };
+      }
+    }
+    return { available: true };
+  }
+
+  function capabilities() {
+    return [];
+  }
+
+  function list({ state = "open" } = {}) {
+    const kinds = state === "all"
+      ? [TASKS_DIR, COMPLETED_DIR]
+      : state === "closed"
+        ? [COMPLETED_DIR]
+        : [TASKS_DIR];
+    const tasks = [];
+    for (const kind of kinds) {
+      for (const entry of listDir(kind)) {
+        const task = readTask(kind, entry);
+        if (task) tasks.push(task);
+      }
+    }
+    return tasks.sort(compareByParentThenSub);
+  }
+
+  function read(selector) {
+    const identity = resolveIdentity(selector);
+    for (const kind of [TASKS_DIR, COMPLETED_DIR]) {
+      const entry = findEntry(kind, identity);
+      if (entry) {
+        const task = readTask(kind, entry);
+        if (task) return task;
+        throw new LocalStoreError(`local task file for ${identity.ref} is malformed`);
+      }
+    }
+    throw new LocalStoreError(`local task not found: ${identity.ref}`);
+  }
+
+  function create(input = {}) {
+    const title = input.title;
+    if (typeof title !== "string" || !title.trim()) {
+      throw new LocalStoreError("local task creation requires a non-empty title");
+    }
+    let requestedId = null;
+    if (input.id !== undefined && input.id !== null) {
+      const parsed = parseTaskRef(`${taskPrefix}-${input.id}`, refOptions);
+      if (!parsed) throw new LocalStoreError(`invalid explicit local task id: ${String(input.id)}`);
+      requestedId = parsed.id;
+    }
+
+    return withAllocationLock(() => {
+      const id = requestedId ?? allocateParentId();
+      if (idExists(id)) {
+        throw new LocalStoreError(`local task ${taskPrefix}-${id} already exists`);
+      }
+      const identity = parseTaskRef(`${taskPrefix}-${id}`, refOptions);
+      const body = input.body !== undefined ? String(input.body) : "\n## Description\n(No description provided)\n";
+      const content = buildNewContent({
+        identity,
+        title,
+        status: input.status ? String(input.status) : defaultStatus,
+        labels: Array.isArray(input.labels) ? input.labels : [],
+        priority: input.priority ? String(input.priority) : "medium",
+        dependencies: Array.isArray(input.dependencies) ? input.dependencies : [],
+        body,
+      });
+      publishNewFile(dirPath(TASKS_DIR), buildFilename(identity, title), content);
+      return { tracker: "local", id: identity.id, ref: identity.ref };
+    });
+  }
+
+  const NEUTRAL_FIELDS = ["title", "status", "priority"];
+  const NEUTRAL_LIST_FIELDS = ["labels", "dependencies"];
+
+  function update(selector, changes = {}) {
+    const identity = resolveIdentity(selector);
+    const entry = findEntry(TASKS_DIR, identity);
+    if (!entry) {
+      throw new LocalStoreError(`no active local task to update: ${identity.ref}`);
+    }
+    const full = path.join(dirPath(TASKS_DIR), entry.file);
+    const content = fs.readFileSync(full, "utf-8");
+    const split = splitDocument(content);
+    if (!split) throw new LocalStoreError(`local task file for ${identity.ref} is malformed`);
+
+    const fieldChanges = {};
+    for (const field of NEUTRAL_FIELDS) {
+      if (changes[field] !== undefined) fieldChanges[field] = String(changes[field]);
+    }
+    for (const field of NEUTRAL_LIST_FIELDS) {
+      if (changes[field] !== undefined) {
+        if (!Array.isArray(changes[field])) {
+          throw new LocalStoreError(`local update ${field} must be an array`);
+        }
+        fieldChanges[field] = changes[field].map(String);
+      }
+    }
+    if (changes.updated_date !== undefined) fieldChanges.updated_date = String(changes.updated_date);
+
+    const entries = applyFrontmatterChanges(parseFrontmatterEntries(split.frontmatter), fieldChanges);
+    const body = changes.body !== undefined ? String(changes.body) : split.body;
+    const nextContent = `${stringifyFrontmatter(entries)}${body}`;
+    replaceFileAtomic(dirPath(TASKS_DIR), entry.file, nextContent);
+    return { tracker: "local", id: identity.id, ref: identity.ref };
+  }
+
+  function close(selector) {
+    const identity = resolveIdentity(selector);
+    const activeEntry = findEntry(TASKS_DIR, identity);
+    if (!activeEntry) {
+      if (findEntry(COMPLETED_DIR, identity)) {
+        return { tracker: "local", id: identity.id, ref: identity.ref };
+      }
+      throw new LocalStoreError(`local task not found: ${identity.ref}`);
+    }
+
+    const src = path.join(dirPath(TASKS_DIR), activeEntry.file);
+    const content = fs.readFileSync(src, "utf-8");
+    const split = splitDocument(content);
+    if (!split) throw new LocalStoreError(`local task file for ${identity.ref} is malformed`);
+
+    const entries = applyFrontmatterChanges(parseFrontmatterEntries(split.frontmatter), {
+      status: DONE_STATUS,
+    });
+    const doneContent = `${stringifyFrontmatter(entries)}${split.body}`;
+    publishNewFile(dirPath(COMPLETED_DIR), activeEntry.file, doneContent);
+    fs.unlinkSync(src);
+    return { tracker: "local", id: identity.id, ref: identity.ref };
+  }
+
+  return Object.freeze({ availability, capabilities, list, read, create, update, close });
+}
+
+function compareByParentThenSub(left, right) {
+  const [lp, ls = -1] = left.id.split(".").map(Number);
+  const [rp, rs = -1] = right.id.split(".").map(Number);
+  return lp === rp ? ls - rs : lp - rp;
+}
+
+module.exports = {
+  createLocalAdapter,
+  LocalStoreError,
+};

--- a/skills/dev-backlog/scripts/local-tracker.js
+++ b/skills/dev-backlog/scripts/local-tracker.js
@@ -94,13 +94,19 @@ function sleepSync(ms) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
-// --- stale-lock reclamation (crash recovery) ---
+// --- lock stamp inspection (crash detection, no reclamation) ---
 
-// The lock file stamps `${pid}:${token}`: the pid decides staleness, while the
-// token is a per-acquisition nonce so reclaim and release can bind their unlink
-// to the exact file instance they inspected and never evict a different live
-// holder that replaced the one they saw.
+// The lock file stamps `${pid}:${token}`: the pid lets a later process tell a
+// crashed holder from a live one, while the token is a per-acquisition nonce so
+// release can bind its unlink to the exact file instance it created. Reclamation
+// is intentionally NOT automatic: a path-based rename/unlink cannot reclaim a
+// stale lock without racing a replacement holder, so a dead-PID lock is surfaced
+// as an actionable manual-cleanup error and left untouched.
 function readLockStamp(lockPath) {
+  // The lock must be a regular, non-symlink file; never follow a symlink planted
+  // at the lock path when judging ownership.
+  const stat = lstatSafe(lockPath);
+  if (!stat || !stat.isFile()) return null;
   let raw;
   try {
     raw = fs.readFileSync(lockPath, "utf-8").trim();
@@ -113,11 +119,6 @@ function readLockStamp(lockPath) {
   return { pid, token: colon === -1 ? "" : raw.slice(colon + 1) };
 }
 
-function readLockOwner(lockPath) {
-  const stamp = readLockStamp(lockPath);
-  return stamp ? stamp.pid : null;
-}
-
 function processAlive(pid) {
   try {
     process.kill(pid, 0);
@@ -125,42 +126,6 @@ function processAlive(pid) {
   } catch (error) {
     return error.code === "EPERM"; // exists but not signalable by us
   }
-}
-
-// Reclaim a lock whose stamped owner is provably gone. Two reclaimers must never
-// both remove "the same" stale lock and then race each other's fresh lock, so
-// removal is bound to a specific file instance: capture the lock by an atomic
-// rename (only one racer wins it; the loser gets ENOENT and retries), then judge
-// the captured file. If a live owner had replaced the stale lock between our read
-// and the capture, restore it and bow out rather than evict a running holder.
-function reclaimStaleLock(lockPath, stagePath) {
-  const owner = readLockOwner(lockPath);
-  if (owner === null || owner === process.pid || processAlive(owner)) return false;
-  try {
-    fs.renameSync(lockPath, stagePath);
-  } catch {
-    return false; // vanished or another reclaimer captured it first
-  }
-  const captured = readLockOwner(stagePath);
-  if (captured !== null && captured !== process.pid && !processAlive(captured)) {
-    try {
-      fs.unlinkSync(stagePath); // provably dead: drop it so the acquire loop recreates
-    } catch {
-      /* already gone */
-    }
-    return true;
-  }
-  // Captured a live/ambiguous lock — restore it so its owner keeps exclusivity.
-  try {
-    fs.renameSync(stagePath, lockPath);
-  } catch {
-    try {
-      fs.unlinkSync(stagePath);
-    } catch {
-      /* nothing to restore */
-    }
-  }
-  return false;
 }
 
 // --- frontmatter / body split, preserving human bytes verbatim ---
@@ -428,6 +393,24 @@ function withinDir(dir, dest) {
   return path.resolve(path.dirname(dest)) === path.resolve(dir);
 }
 
+// A canonical store directory is sound only when the path is absent (created
+// lazily on first write) or a real, non-symlink directory. A symlink or plain
+// file here would let a lifecycle operation read or write outside the backlog,
+// so it is refused. Returns an actionable reason, or null when the path is safe.
+function realDirIssue(dir) {
+  let stat;
+  try {
+    // lstat, not stat: a symlinked directory must be refused, not resolved.
+    stat = fs.lstatSync(dir);
+  } catch (error) {
+    if (error.code === "ENOENT") return null; // created lazily on first write
+    return `local store path ${dir} is unusable: ${error.message}`;
+  }
+  if (stat.isSymbolicLink()) return `local store path ${dir} must not be a symlink`;
+  if (!stat.isDirectory()) return `local store path ${dir} is not a directory`;
+  return null;
+}
+
 // --- close compensation: identity-checked rollback of a published copy ---
 
 function fileIdentity(target) {
@@ -515,6 +498,34 @@ function createLocalAdapter(options = {}) {
         `refusing to write a local task outside its canonical directory: ${dest}`
       );
     }
+  }
+
+  // Report the first canonical directory (backlog root, tasks/, completed/) that
+  // is not a real non-symlink directory. Powers both the structured availability
+  // probe and the per-operation integrity guards below.
+  function canonicalDirIssue() {
+    for (const probe of [backlogDir, dirPath(TASKS_DIR), dirPath(COMPLETED_DIR)]) {
+      const issue = realDirIssue(probe);
+      if (issue) return issue;
+    }
+    return null;
+  }
+
+  // Enforce canonical-directory integrity at every lifecycle boundary — not just
+  // in availability(). Called at the entry of list/read/create/update/close and
+  // again under the store lock, so a directory swapped for a symlink or a plain
+  // file after the initial probe can never route a read or write outside the
+  // backlog. Absent directories are allowed (create materializes them).
+  function assertCanonicalDirs() {
+    const issue = canonicalDirIssue();
+    if (issue) throw new LocalStoreError(issue);
+  }
+
+  // The tightest boundary check: a single directory must be absent or a real
+  // non-symlink directory immediately before we mkdir/link/rename into it.
+  function assertRealDir(dir) {
+    const issue = realDirIssue(dir);
+    if (issue) throw new LocalStoreError(issue);
   }
 
   function today() {
@@ -620,16 +631,16 @@ function createLocalAdapter(options = {}) {
   }
 
   function acquireLock() {
+    assertRealDir(backlogDir); // never create the lock through a symlinked root
     fs.mkdirSync(backlogDir, { recursive: true });
     const lockPath = path.join(backlogDir, LOCK_FILE);
     const token = crypto.randomBytes(12).toString("hex");
-    let reclaimed = false;
     for (let attempt = 0; attempt <= lockConfig.retries; attempt += 1) {
       try {
         const fd = fs.openSync(lockPath, "wx");
         // Stamp `${pid}:${token}` so a later process can tell a crashed holder
-        // from a live one (pid) and bind reclaim/release to this exact lock
-        // instance (token) rather than to the path alone.
+        // from a live one (pid) and bind release to this exact lock instance
+        // (token + file identity) rather than to the path alone.
         try {
           fs.writeSync(fd, `${process.pid}:${token}`);
         } catch {
@@ -640,40 +651,80 @@ function createLocalAdapter(options = {}) {
         if (error.code !== "EEXIST") {
           throw new LocalStoreError(`cannot acquire local allocation lock: ${error.message}`, { cause: error });
         }
-        // Reclaim a crashed holder's lock exactly once, and only when its owner
-        // is provably gone, so a live allocator is never evicted. The stage path
-        // is unique to us so concurrent reclaimers cannot collide on it.
-        const stagePath = `${lockPath}.${process.pid}.${token}.reclaiming`;
-        if (!reclaimed && reclaimStaleLock(lockPath, stagePath)) {
-          reclaimed = true;
-          continue;
-        }
         if (attempt < lockConfig.retries) sleepSync(lockConfig.delayMs);
       }
     }
-    throw new LocalStoreError(
-      "another local allocation holds the store lock; retry once it releases " +
-        `(remove ${path.join(backlogDir, LOCK_FILE)} only if you are certain no allocator is running)`
+    // Exhausted: never reclaim automatically. A path-based rename/unlink cannot
+    // evict a stale lock without racing a replacement holder, so a dead-PID lock
+    // is surfaced as an actionable manual-cleanup error and left untouched.
+    throw lockContentionError(path.join(backlogDir, LOCK_FILE));
+  }
+
+  // Distinguish a provably-dead holder (stale lock, needs manual cleanup) from
+  // live contention. Neither case touches the lock: reclamation is deliberately
+  // manual because there is no race-free path-based way to reclaim it.
+  function lockContentionError(lockPath) {
+    const stamp = readLockStamp(lockPath);
+    if (stamp && !processAlive(stamp.pid)) {
+      return new LocalStoreError(
+        `the local allocation lock ${lockPath} is held by pid ${stamp.pid}, which is no longer ` +
+          "running (stale lock). It is not reclaimed automatically because a path-based reclaim " +
+          "cannot avoid racing a replacement holder. After confirming no allocator is running, " +
+          "remove the lock file manually to proceed."
+      );
+    }
+    return new LocalStoreError(
+      `another local allocation holds the store lock ${lockPath}; retry once it releases ` +
+        "(remove it manually only if you are certain no allocator is running)."
     );
   }
 
   function releaseLock(handle) {
     const lockPath = path.join(backlogDir, LOCK_FILE);
+    if (testHooks.beforeReleaseLock) testHooks.beforeReleaseLock(lockPath);
+    // Bind release to BOTH the token we stamped and the exact file instance we
+    // opened. Our fd keeps pointing at the file we created even after the path is
+    // unlinked or replaced, so comparing the fd's identity to whatever now sits
+    // at the path reveals a replacement owner. If ownership or file identity
+    // changed, preserve the replacement and fail clearly rather than evict a live
+    // holder — a normal release only removes the lock still proven to be ours.
+    let held = null;
+    try {
+      held = fs.fstatSync(handle.fd);
+    } catch {
+      /* fd already invalid */
+    }
+    const atPath = lstatSafe(lockPath);
+    const stamp = readLockStamp(lockPath);
     try {
       fs.closeSync(handle.fd);
     } catch {
       /* fd already closed */
     }
-    // Only unlink the lock if it is still ours: a token mismatch means another
-    // process already reclaimed it (having judged us dead) and may now hold it,
-    // so unlinking would evict a live holder. Bind the removal to our token.
-    const stamp = readLockStamp(lockPath);
-    if (stamp && stamp.token === handle.token) {
-      try {
-        fs.unlinkSync(lockPath);
-      } catch {
-        /* lock already gone */
-      }
+    if (atPath === null) return; // lock already gone: nothing of ours to release
+    // File identity is definitive while our fd is open: the inode we created
+    // cannot be recycled under the path, so a matching dev/ino proves it is our
+    // instance. The token is the second binding — a present stamp must be ours
+    // (it catches an inode-number reuse after our fd closes), but a stamp lost to
+    // a failed write does not veto an identity we can still prove by the fd.
+    const identityMatch =
+      held !== null &&
+      atPath.isFile() &&
+      atPath.dev === held.dev &&
+      atPath.ino === held.ino;
+    const tokenOk = stamp === null || stamp.token === handle.token;
+    const stillOurs = identityMatch && tokenOk;
+    if (!stillOurs) {
+      throw new LocalStoreError(
+        `local allocation lock ${lockPath} changed owner before release and was left ` +
+          "untouched to protect the replacement holder; a concurrent allocator may be running. " +
+          "Resolve the contention and remove the lock manually only if you are certain none is."
+      );
+    }
+    try {
+      fs.unlinkSync(lockPath);
+    } catch {
+      /* lock already gone */
     }
   }
 
@@ -748,25 +799,58 @@ function createLocalAdapter(options = {}) {
     return !!info && info.hash === destHash && info.id === ref;
   }
 
-  function activeSourceMatches(src, ref) {
-    const info = readIdentityAndHash(src);
-    return !!info && info.id === ref;
+  // Independently recompute the exact Done bytes a faithful close of the active
+  // source would publish, so roll-forward is verified against the real
+  // authoritative content instead of the untrusted marker hash. The source is
+  // fully validated first (regular file, well-formed frontmatter, id === ref);
+  // returns the derived bytes and their hash, or null when it cannot be derived.
+  function deriveExpectedDone(src, ref) {
+    const stat = lstatSafe(src);
+    if (!stat || !stat.isFile()) return null;
+    let content;
+    try {
+      content = fs.readFileSync(src, "utf-8");
+    } catch {
+      return null;
+    }
+    const split = splitDocument(content);
+    if (!split) return null;
+    const entries = parseFrontmatterEntries(split.frontmatter);
+    try {
+      requireValidFrontmatter(entries, ref);
+    } catch {
+      return null; // an unvalidatable source is not authoritative to derive from
+    }
+    const doneEntries = applyFrontmatterChanges(entries, { status: DONE_STATUS });
+    const doneContent = `${stringifyFrontmatter(doneEntries, split.eol)}${split.body}`;
+    return { content: doneContent, hash: contentHash(doneContent) };
   }
 
   // Finish or discard a close a previous process left half-applied. MUST run
-  // under the store lock. The journal records only the intent to publish;
-  // recovery derives the actual phase from evidence on disk rather than trusting
-  // the marker:
-  //   dest proves it is our publication (bytes + id) -> retire a matching active
-  //                                                     source (roll the move forward)
-  //   dest absent / unverified (external, partial)   -> publish never landed; the
-  //                                                     active source stays authority
-  // Nothing outside the canonical stores, and nothing whose identity we cannot
-  // confirm, is ever deleted or promoted; the marker is then cleared.
+  // under the store lock. The journal records only the intent to publish; every
+  // field — including destHash — is untrusted. Recovery derives the exact Done
+  // bytes independently from the fully validated active source and rolls the move
+  // forward ONLY when the derived hash, the journaled hash, and the destination's
+  // actual bytes+id ALL agree:
+  //   - all three agree -> the destination is a faithful publication of this
+  //     source; retire the active source (roll the move forward).
+  //   - any disagreement (including a valid, self-consistent marker/destination
+  //     pair whose bytes differ from the active body) -> roll-forward is refused
+  //     and every file is preserved (fail closed). A surviving duplicate then
+  //     fails closed on the next read/list via the exact-id guard.
+  // Nothing outside the canonical stores, and nothing whose derived identity we
+  // cannot confirm, is ever deleted or promoted; the spent marker is then cleared.
   function recover() {
+    const markerPath = closeMarkerPath();
+    const markerStat = lstatSafe(markerPath);
+    if (markerStat === null) return; // no interrupted close to reconcile
+    if (!markerStat.isFile()) {
+      removeCloseMarker(); // a symlink/dir at the marker path is untrusted
+      return;
+    }
     let raw;
     try {
-      raw = fs.readFileSync(closeMarkerPath(), "utf-8");
+      raw = fs.readFileSync(markerPath, "utf-8");
     } catch (error) {
       if (error.code === "ENOENT") return;
       throw new LocalStoreError(`cannot read local recovery marker: ${error.message}`, { cause: error });
@@ -791,13 +875,27 @@ function createLocalAdapter(options = {}) {
       removeCloseMarker();
       return;
     }
-    if (publishedMatches(dest, plan.ref, plan.destHash) && activeSourceMatches(src, plan.ref)) {
+    // Derive the expected Done bytes from the active source itself, then require
+    // derived === journaled === destination (bytes and id). A marker that merely
+    // matches the destination is not enough: without this the destination could
+    // be self-consistent completed bytes for the same ref that were never the
+    // publication of THIS active body, and rolling forward would delete
+    // authoritative content.
+    const derived = deriveExpectedDone(src, plan.ref);
+    const rollForward =
+      derived !== null &&
+      derived.hash === plan.destHash &&
+      publishedMatches(dest, plan.ref, derived.hash);
+    if (rollForward) {
       try {
         fs.unlinkSync(src);
       } catch {
-        return; // keep the marker; retry once the stale source is writable
+        return; // roll-forward proven but the source is not yet writable; retry later
       }
     }
+    // Proven-and-completed, or refused-and-every-file-preserved: the untrusted
+    // intent is spent either way, so clear it. A refused roll-forward leaves the
+    // active source intact and any duplicate to the exact-id guard.
     removeCloseMarker();
   }
 
@@ -809,6 +907,10 @@ function createLocalAdapter(options = {}) {
   function withStoreLock(fn) {
     const handle = acquireLock();
     try {
+      // Re-verify canonical-directory integrity under the lock (the mutation
+      // boundary) so a directory swapped for a symlink between the entry probe and
+      // now cannot route recovery or the mutation outside the backlog.
+      assertCanonicalDirs();
       recover();
       return fn();
     } finally {
@@ -839,15 +941,18 @@ function createLocalAdapter(options = {}) {
   // --- atomic publication: temp on same fs, hard-link (no overwrite), unlink ---
 
   // Route temp writes through an injectable writer so a test can reproduce a
-  // partial-write ENOSPC that leaves bytes on disk.
+  // partial-write ENOSPC that leaves bytes on disk. The `wx` flag makes the temp
+  // a fresh regular file: a symlink (or any entry) pre-planted at the temp path
+  // fails the create instead of being followed or overwritten.
   function writeTemp(tmp, content) {
     if (testHooks.writeFile) return testHooks.writeFile(tmp, content);
-    return fs.writeFileSync(tmp, content);
+    return fs.writeFileSync(tmp, content, { flag: "wx" });
   }
 
   function publishNewFile(dir, fileName, content) {
     const dest = path.join(dir, fileName);
     assertWithin(dir, dest);
+    assertRealDir(dir); // final boundary: never link into a symlinked target dir
     fs.mkdirSync(dir, { recursive: true });
     const tmp = tempPath(dir, path.basename(fileName));
     // The temp write is inside the try so a partial write (e.g. ENOSPC) is
@@ -874,6 +979,7 @@ function createLocalAdapter(options = {}) {
   function replaceFileAtomic(dir, fileName, content) {
     const dest = path.join(dir, fileName);
     assertWithin(dir, dest);
+    assertRealDir(dir); // final boundary: never rename into a symlinked target dir
     const tmp = tempPath(dir, path.basename(fileName));
     // A successful rename consumes the temp; any earlier failure (partial write
     // or failed rename) is cleaned here so no stray `.tmp` survives.
@@ -956,23 +1062,11 @@ function createLocalAdapter(options = {}) {
     if (prefixIssue) {
       return { available: false, reason: `local tracker ${prefixIssue}` };
     }
-    for (const probe of [backlogDir, dirPath(TASKS_DIR), dirPath(COMPLETED_DIR)]) {
-      let stat;
-      try {
-        // lstat, not stat: a symlinked canonical directory must be refused, not
-        // resolved, or create/read/close could escape the backlog through it.
-        stat = fs.lstatSync(probe);
-      } catch (error) {
-        if (error.code === "ENOENT") continue; // created lazily on first write
-        return { available: false, reason: `local store path ${probe} is unusable: ${error.message}` };
-      }
-      if (stat.isSymbolicLink()) {
-        return { available: false, reason: `local store path ${probe} must not be a symlink` };
-      }
-      if (!stat.isDirectory()) {
-        return { available: false, reason: `local store path ${probe} is not a directory` };
-      }
-    }
+    // The same canonical-directory integrity the lifecycle operations enforce on
+    // every call: a symlinked or non-directory backlog root, tasks/, or completed/
+    // is refused (an absent one is created lazily on first write).
+    const issue = canonicalDirIssue();
+    if (issue) return { available: false, reason: issue };
     return { available: true };
   }
 
@@ -986,6 +1080,7 @@ function createLocalAdapter(options = {}) {
         `invalid local list state ${JSON.stringify(state)}; expected one of open, closed, all`
       );
     }
+    assertCanonicalDirs(); // refuse a symlinked/foreign store before reading it
     // list never mutates: an interrupted close is healed on the next mutation,
     // not here. Duplicate copies from a crash surface as a fail-closed error.
     const kinds = LIST_STATE_KINDS[state];
@@ -1008,6 +1103,7 @@ function createLocalAdapter(options = {}) {
   }
 
   function read(selector) {
+    assertCanonicalDirs(); // refuse a symlinked/foreign store before reading it
     const identity = resolveIdentity(selector);
     // read never mutates; recovery of an interrupted close is deferred to the
     // next create/update/close under the store lock.
@@ -1021,6 +1117,7 @@ function createLocalAdapter(options = {}) {
   function create(input = {}) {
     rejectUnsupportedOptions("create", input, CREATE_OPTIONS);
     assertUsablePrefix();
+    assertCanonicalDirs(); // refuse a symlinked/foreign store before any mutation
     const title = input.title;
     if (typeof title !== "string" || !title.trim()) {
       throw new LocalStoreError("local task creation requires a non-empty title");
@@ -1065,6 +1162,7 @@ function createLocalAdapter(options = {}) {
   function update(selector, changes = {}) {
     rejectUnsupportedOptions("update", changes, UPDATE_OPTIONS);
     assertUsablePrefix();
+    assertCanonicalDirs(); // refuse a symlinked/foreign store before any mutation
     const identity = resolveIdentity(selector);
     // Validate and coerce every field before the lock so a rejected injection or
     // wrong-typed list never triggers an mkdir/lock/temp/mtime mutation.
@@ -1098,6 +1196,7 @@ function createLocalAdapter(options = {}) {
   function close(selector, options = {}) {
     rejectUnsupportedOptions("close", options, CLOSE_OPTIONS);
     assertUsablePrefix();
+    assertCanonicalDirs(); // refuse a symlinked/foreign store before any mutation
     const identity = resolveIdentity(selector);
 
     return withStoreLock(() => {

--- a/skills/dev-backlog/scripts/local-tracker.js
+++ b/skills/dev-backlog/scripts/local-tracker.js
@@ -696,36 +696,117 @@ function createLocalAdapter(options = {}) {
     }
     const atPath = lstatSafe(lockPath);
     const stamp = readLockStamp(lockPath);
-    try {
-      fs.closeSync(handle.fd);
-    } catch {
-      /* fd already closed */
+    if (atPath === null) {
+      try {
+        fs.closeSync(handle.fd);
+      } catch {
+        /* fd already closed */
+      }
+      return; // lock already gone: nothing of ours to release
     }
-    if (atPath === null) return; // lock already gone: nothing of ours to release
     // File identity is definitive while our fd is open: the inode we created
     // cannot be recycled under the path, so a matching dev/ino proves it is our
-    // instance. The token is the second binding — a present stamp must be ours
-    // (it catches an inode-number reuse after our fd closes), but a stamp lost to
-    // a failed write does not veto an identity we can still prove by the fd.
+    // instance. The token is the second binding and must also match; a missing or
+    // malformed stamp cannot be treated as authority to remove a lock.
     const identityMatch =
       held !== null &&
       atPath.isFile() &&
       atPath.dev === held.dev &&
       atPath.ino === held.ino;
-    const tokenOk = stamp === null || stamp.token === handle.token;
+    const tokenOk = stamp !== null && stamp.token === handle.token;
     const stillOurs = identityMatch && tokenOk;
     if (!stillOurs) {
+      try {
+        fs.closeSync(handle.fd);
+      } catch {
+        /* fd already closed */
+      }
       throw new LocalStoreError(
         `local allocation lock ${lockPath} changed owner before release and was left ` +
           "untouched to protect the replacement holder; a concurrent allocator may be running. " +
           "Resolve the contention and remove the lock manually only if you are certain none is."
       );
     }
+
+    // A check followed by unlink(lockPath) is still racy: another owner can
+    // replace the canonical pathname after the check and before the unlink. Move
+    // exactly what is at the pathname to an unguessable private capture first.
+    // The rename is the atomic ownership boundary; we only unlink the capture
+    // after proving that the captured inode/token are the lock represented by our
+    // still-open fd.
+    if (testHooks.afterReleaseLockValidation) testHooks.afterReleaseLockValidation(lockPath);
+    const capturePath = path.join(
+      backlogDir,
+      `${LOCK_FILE}.release.${process.pid}.${crypto.randomBytes(12).toString("hex")}`
+    );
     try {
-      fs.unlinkSync(lockPath);
-    } catch {
-      /* lock already gone */
+      fs.renameSync(lockPath, capturePath);
+    } catch (error) {
+      try {
+        fs.closeSync(handle.fd);
+      } catch {
+        /* fd already closed */
+      }
+      if (error.code === "ENOENT") return; // removed by someone else; never chase a replacement
+      throw new LocalStoreError(`cannot capture local allocation lock for safe release: ${error.message}`, {
+        cause: error,
+      });
     }
+
+    const captured = lstatSafe(capturePath);
+    const capturedStamp = readLockStamp(capturePath);
+    const capturedIdentityMatch =
+      held !== null &&
+      captured !== null &&
+      captured.isFile() &&
+      captured.dev === held.dev &&
+      captured.ino === held.ino;
+    const capturedTokenOk = capturedStamp !== null && capturedStamp.token === handle.token;
+    const capturedOurs = capturedIdentityMatch && capturedTokenOk;
+    try {
+      fs.closeSync(handle.fd);
+    } catch {
+      /* fd already closed */
+    }
+
+    if (capturedOurs) {
+      try {
+        fs.unlinkSync(capturePath);
+      } catch (error) {
+        if (error.code !== "ENOENT") {
+          throw new LocalStoreError(
+            `captured local allocation lock could not be removed safely: ${error.message}`,
+            { cause: error }
+          );
+        }
+      }
+      return;
+    }
+
+    // The pathname was replaced after validation, so the capture belongs to a
+    // foreign owner. Restore it without overwriting a newer canonical owner:
+    // link() is atomic and fails with EEXIST. Deliberately retain the capture in
+    // every outcome, including successful restoration, so release never deletes
+    // the foreign inode and an operator can inspect/reconcile both authorities.
+    let restoration;
+    if (testHooks.beforeForeignLockRestore) {
+      testHooks.beforeForeignLockRestore(capturePath, lockPath);
+    }
+    try {
+      fs.linkSync(capturePath, lockPath);
+      restoration = `restored without overwrite at ${lockPath}`;
+    } catch (error) {
+      if (error.code === "EEXIST") {
+        restoration = `a newer owner already occupies ${lockPath}; both locks were preserved`;
+      } else {
+        restoration = `could not restore ${lockPath} without overwrite (${error.message})`;
+      }
+    }
+    throw new LocalStoreError(
+      `local allocation lock changed owner during release; the foreign lock was preserved at ` +
+        `${capturePath} and ${restoration}. Stop concurrent allocators and reconcile these lock ` +
+        "files manually before retrying."
+    );
   }
 
   // --- crash-recoverable close journal ---

--- a/skills/dev-backlog/scripts/local-tracker.js
+++ b/skills/dev-backlog/scripts/local-tracker.js
@@ -30,6 +30,42 @@ const LOCK_FILE = ".local-tracker.lock";
 const DONE_STATUS = "Done";
 const DEFAULT_LOCK = Object.freeze({ retries: 100, delayMs: 20 });
 
+// Only provider-neutral fields are accepted; every other option (milestone,
+// pull-request relationship, mirror, progress issue, comment, closing reason,
+// …) maps to an optional capability the local store does not have and must be
+// rejected before any mutation rather than silently ignored.
+const CREATE_OPTIONS = Object.freeze([
+  "title",
+  "id",
+  "body",
+  "status",
+  "labels",
+  "priority",
+  "dependencies",
+]);
+const UPDATE_OPTIONS = Object.freeze([
+  "title",
+  "status",
+  "priority",
+  "labels",
+  "dependencies",
+  "body",
+  "updated_date",
+]);
+const CLOSE_OPTIONS = Object.freeze([]);
+
+function rejectUnsupportedOptions(operation, options, allowed) {
+  if (options === null || typeof options !== "object") return;
+  const extra = Object.keys(options).filter((key) => !allowed.includes(key));
+  if (extra.length) {
+    throw new LocalStoreError(
+      `local ${operation} does not support option${extra.length === 1 ? "" : "s"}: ` +
+        `${extra.join(", ")}. The local tracker reports no optional capabilities, so ` +
+        "provider-specific fields must be handled before dispatch."
+    );
+  }
+}
+
 /** Every recoverable local-store failure surfaces as this actionable type. */
 class LocalStoreError extends Error {
   constructor(message, options) {
@@ -76,8 +112,36 @@ function parseFrontmatterEntries(frontmatter) {
   return entries;
 }
 
+/**
+ * Resolve one entry to its value. Block sequences (`key:` followed by `  - x`
+ * lines) are decoded here because the shared simple YAML parser only consumes
+ * `key: value` lines and would otherwise return a malformed object for the
+ * exact block syntax we render on create/update.
+ */
 function entryValue(entry) {
+  const head = entry.lines[0] || "";
+  const colon = head.indexOf(":");
+  const inline = colon === -1 ? "" : head.slice(colon + 1).trim();
+  if (!inline) {
+    const items = [];
+    for (const line of entry.lines.slice(1)) {
+      const item = line.match(/^\s*-\s+(.*)$/);
+      if (item) items.push(unquoteBlockItem(item[1].trim()));
+    }
+    if (items.length) return items;
+  }
   return parseSimpleYaml(entry.lines.join("\n"))[entry.key];
+}
+
+function unquoteBlockItem(text) {
+  if (
+    text.length >= 2 &&
+    ((text.startsWith('"') && text.endsWith('"')) ||
+      (text.startsWith("'") && text.endsWith("'")))
+  ) {
+    return text.slice(1, -1).replace(/''/g, "'");
+  }
+  return text;
 }
 
 function frontmatterObject(entries) {
@@ -124,6 +188,35 @@ function stringifyFrontmatter(entries) {
   return `---\n${inner}\n---`;
 }
 
+/**
+ * A task body must be separated from the closing `---` by a newline; otherwise
+ * `---body` collapses into the frontmatter fence and the file reads back as
+ * malformed. Callers may pass a body without the leading newline, so normalize
+ * it here rather than trusting the caller's byte layout.
+ */
+function normalizeBody(body) {
+  return body.startsWith("\n") ? body : `\n${body}`;
+}
+
+/**
+ * The configured task prefix flows into filenames and identity refs, so it must
+ * never carry path separators, traversal, NUL, or whitespace that could steer a
+ * write outside the canonical `tasks/` and `completed/` directories. Returns an
+ * actionable reason string when the prefix is unusable, or null when it is safe.
+ */
+function taskPrefixIssue(prefix) {
+  if (typeof prefix !== "string" || !prefix.length) {
+    return "task_prefix must be a non-empty string";
+  }
+  if (/[\s/\\\0]/.test(prefix)) {
+    return `task_prefix ${JSON.stringify(prefix)} must not contain whitespace, path separators, or NUL`;
+  }
+  if (prefix.includes("..")) {
+    return `task_prefix ${JSON.stringify(prefix)} must not contain traversal segments`;
+  }
+  return null;
+}
+
 // --- normalized task shape ---
 
 function normalizeTask({ identity, object, body, state }) {
@@ -162,9 +255,23 @@ function createLocalAdapter(options = {}) {
   const lockConfig = { ...DEFAULT_LOCK, ...(options.lock || {}) };
   const testHooks = options.testHooks || {};
   const refOptions = { taskPrefix };
+  const prefixIssue = taskPrefixIssue(taskPrefix);
+
+  function assertUsablePrefix() {
+    if (prefixIssue) throw new LocalStoreError(`local tracker ${prefixIssue}`);
+  }
 
   function dirPath(kind) {
     return path.join(backlogDir, kind);
+  }
+
+  /** Refuse any write whose resolved parent is not exactly the target dir. */
+  function assertWithin(dir, dest) {
+    if (path.resolve(path.dirname(dest)) !== path.resolve(dir)) {
+      throw new LocalStoreError(
+        `refusing to write a local task outside its canonical directory: ${dest}`
+      );
+    }
   }
 
   function today() {
@@ -206,10 +313,20 @@ function createLocalAdapter(options = {}) {
       throw new LocalStoreError(`cannot read local ${kind} directory: ${error.message}`, { cause: error });
     }
     const found = [];
+    const byId = new Map();
     for (const name of names) {
       if (!name.endsWith(".md")) continue;
       const identity = parseTaskFileName(name, { taskPrefix, tracker: "local" });
-      if (identity) found.push({ identity, file: name });
+      if (!identity) continue;
+      const seen = byId.get(identity.id);
+      if (seen) {
+        throw new LocalStoreError(
+          `local ${kind} store is corrupt: ${identity.ref} is claimed by multiple files ` +
+            `(${seen}, ${name}); resolve the duplicate before continuing`
+        );
+      }
+      byId.set(identity.id, name);
+      found.push({ identity, file: name });
     }
     return found;
   }
@@ -218,12 +335,35 @@ function createLocalAdapter(options = {}) {
     return listDir(kind).find((entry) => entry.identity.id === identity.id);
   }
 
+  /**
+   * Locate one identity across both stores. Presence in both stores is
+   * canonical-store corruption (an exact id must be unique store-wide), so the
+   * caller decides how to fail rather than silently first-matching.
+   */
+  function locateEntry(identity) {
+    const active = findEntry(TASKS_DIR, identity);
+    const completed = findEntry(COMPLETED_DIR, identity);
+    if (active && completed) {
+      throw new LocalStoreError(
+        `local task ${identity.ref} exists in both active and completed stores; ` +
+          "an exact id must be unique across the canonical stores"
+      );
+    }
+    return { active, completed };
+  }
+
   function readTask(kind, entry) {
     const full = path.join(dirPath(kind), entry.file);
     const content = fs.readFileSync(full, "utf-8");
     const split = splitDocument(content);
     if (!split) return null;
     const object = frontmatterObject(parseFrontmatterEntries(split.frontmatter));
+    if (object.id !== undefined && String(object.id) !== entry.identity.ref) {
+      throw new LocalStoreError(
+        `local task ${entry.identity.ref} is corrupt: frontmatter id ` +
+          `${JSON.stringify(String(object.id))} does not match its filename`
+      );
+    }
     const state = kind === COMPLETED_DIR ? "closed" : "open";
     return normalizeTask({ identity: entry.identity, object, body: split.body, state });
   }
@@ -268,7 +408,10 @@ function createLocalAdapter(options = {}) {
     }
   }
 
-  function withAllocationLock(fn) {
+  // Every create/update/close mutation runs inside this single exclusive
+  // section so reads and writes across the two stores are serializable; a close
+  // can never race an update into archiving stale bytes.
+  function withStoreLock(fn) {
     const fd = acquireLock();
     try {
       return fn();
@@ -297,8 +440,9 @@ function createLocalAdapter(options = {}) {
   // --- atomic publication: temp on same fs, hard-link (no overwrite), unlink ---
 
   function publishNewFile(dir, fileName, content) {
-    fs.mkdirSync(dir, { recursive: true });
     const dest = path.join(dir, fileName);
+    assertWithin(dir, dest);
+    fs.mkdirSync(dir, { recursive: true });
     const tmp = tempPath(dir, path.basename(fileName));
     fs.writeFileSync(tmp, content);
     try {
@@ -321,6 +465,7 @@ function createLocalAdapter(options = {}) {
 
   function replaceFileAtomic(dir, fileName, content) {
     const dest = path.join(dir, fileName);
+    assertWithin(dir, dest);
     const tmp = tempPath(dir, path.basename(fileName));
     fs.writeFileSync(tmp, content);
     try {
@@ -353,7 +498,7 @@ function createLocalAdapter(options = {}) {
     ];
     if (dependencies.length) entries.push({ key: "dependencies", lines: renderFieldLines("dependencies", dependencies) });
     entries.push({ key: "created_date", lines: [renderScalar("created_date", today())] });
-    return `${stringifyFrontmatter(entries)}${body}`;
+    return `${stringifyFrontmatter(entries)}${normalizeBody(body)}`;
   }
 
   // --- the seven required operations ---
@@ -361,6 +506,9 @@ function createLocalAdapter(options = {}) {
   function availability() {
     if (typeof backlogDir !== "string" || !backlogDir.trim()) {
       return { available: false, reason: "local tracker backlogDir is not configured" };
+    }
+    if (prefixIssue) {
+      return { available: false, reason: `local tracker ${prefixIssue}` };
     }
     for (const probe of [backlogDir, dirPath(TASKS_DIR), dirPath(COMPLETED_DIR)]) {
       let stat;
@@ -388,8 +536,17 @@ function createLocalAdapter(options = {}) {
         ? [COMPLETED_DIR]
         : [TASKS_DIR];
     const tasks = [];
+    const seen = new Map();
     for (const kind of kinds) {
       for (const entry of listDir(kind)) {
+        const prior = seen.get(entry.identity.id);
+        if (prior && prior !== kind) {
+          throw new LocalStoreError(
+            `local task ${entry.identity.ref} exists in both active and completed stores; ` +
+              "an exact id must be unique across the canonical stores"
+          );
+        }
+        seen.set(entry.identity.id, kind);
         const task = readTask(kind, entry);
         if (task) tasks.push(task);
       }
@@ -399,18 +556,18 @@ function createLocalAdapter(options = {}) {
 
   function read(selector) {
     const identity = resolveIdentity(selector);
-    for (const kind of [TASKS_DIR, COMPLETED_DIR]) {
-      const entry = findEntry(kind, identity);
-      if (entry) {
-        const task = readTask(kind, entry);
-        if (task) return task;
-        throw new LocalStoreError(`local task file for ${identity.ref} is malformed`);
-      }
-    }
-    throw new LocalStoreError(`local task not found: ${identity.ref}`);
+    const { active, completed } = locateEntry(identity);
+    const kind = active ? TASKS_DIR : COMPLETED_DIR;
+    const entry = active || completed;
+    if (!entry) throw new LocalStoreError(`local task not found: ${identity.ref}`);
+    const task = readTask(kind, entry);
+    if (!task) throw new LocalStoreError(`local task file for ${identity.ref} is malformed`);
+    return task;
   }
 
   function create(input = {}) {
+    rejectUnsupportedOptions("create", input, CREATE_OPTIONS);
+    assertUsablePrefix();
     const title = input.title;
     if (typeof title !== "string" || !title.trim()) {
       throw new LocalStoreError("local task creation requires a non-empty title");
@@ -422,7 +579,7 @@ function createLocalAdapter(options = {}) {
       requestedId = parsed.id;
     }
 
-    return withAllocationLock(() => {
+    return withStoreLock(() => {
       const id = requestedId ?? allocateParentId();
       if (idExists(id)) {
         throw new LocalStoreError(`local task ${taskPrefix}-${id} already exists`);
@@ -447,59 +604,72 @@ function createLocalAdapter(options = {}) {
   const NEUTRAL_LIST_FIELDS = ["labels", "dependencies"];
 
   function update(selector, changes = {}) {
+    rejectUnsupportedOptions("update", changes, UPDATE_OPTIONS);
+    assertUsablePrefix();
     const identity = resolveIdentity(selector);
-    const entry = findEntry(TASKS_DIR, identity);
-    if (!entry) {
-      throw new LocalStoreError(`no active local task to update: ${identity.ref}`);
-    }
-    const full = path.join(dirPath(TASKS_DIR), entry.file);
-    const content = fs.readFileSync(full, "utf-8");
-    const split = splitDocument(content);
-    if (!split) throw new LocalStoreError(`local task file for ${identity.ref} is malformed`);
 
-    const fieldChanges = {};
-    for (const field of NEUTRAL_FIELDS) {
-      if (changes[field] !== undefined) fieldChanges[field] = String(changes[field]);
-    }
-    for (const field of NEUTRAL_LIST_FIELDS) {
-      if (changes[field] !== undefined) {
-        if (!Array.isArray(changes[field])) {
-          throw new LocalStoreError(`local update ${field} must be an array`);
-        }
-        fieldChanges[field] = changes[field].map(String);
+    return withStoreLock(() => {
+      const { active: entry } = locateEntry(identity);
+      if (!entry) {
+        throw new LocalStoreError(`no active local task to update: ${identity.ref}`);
       }
-    }
-    if (changes.updated_date !== undefined) fieldChanges.updated_date = String(changes.updated_date);
+      const full = path.join(dirPath(TASKS_DIR), entry.file);
+      const content = fs.readFileSync(full, "utf-8");
+      const split = splitDocument(content);
+      if (!split) throw new LocalStoreError(`local task file for ${identity.ref} is malformed`);
 
-    const entries = applyFrontmatterChanges(parseFrontmatterEntries(split.frontmatter), fieldChanges);
-    const body = changes.body !== undefined ? String(changes.body) : split.body;
-    const nextContent = `${stringifyFrontmatter(entries)}${body}`;
-    replaceFileAtomic(dirPath(TASKS_DIR), entry.file, nextContent);
-    return { tracker: "local", id: identity.id, ref: identity.ref };
+      const fieldChanges = {};
+      for (const field of NEUTRAL_FIELDS) {
+        if (changes[field] !== undefined) fieldChanges[field] = String(changes[field]);
+      }
+      for (const field of NEUTRAL_LIST_FIELDS) {
+        if (changes[field] !== undefined) {
+          if (!Array.isArray(changes[field])) {
+            throw new LocalStoreError(`local update ${field} must be an array`);
+          }
+          fieldChanges[field] = changes[field].map(String);
+        }
+      }
+      if (changes.updated_date !== undefined) fieldChanges.updated_date = String(changes.updated_date);
+
+      const entries = applyFrontmatterChanges(parseFrontmatterEntries(split.frontmatter), fieldChanges);
+      const body = changes.body !== undefined ? normalizeBody(String(changes.body)) : split.body;
+      const nextContent = `${stringifyFrontmatter(entries)}${body}`;
+      replaceFileAtomic(dirPath(TASKS_DIR), entry.file, nextContent);
+      return { tracker: "local", id: identity.id, ref: identity.ref };
+    });
   }
 
-  function close(selector) {
+  function close(selector, options = {}) {
+    rejectUnsupportedOptions("close", options, CLOSE_OPTIONS);
+    assertUsablePrefix();
     const identity = resolveIdentity(selector);
-    const activeEntry = findEntry(TASKS_DIR, identity);
-    if (!activeEntry) {
-      if (findEntry(COMPLETED_DIR, identity)) {
-        return { tracker: "local", id: identity.id, ref: identity.ref };
+
+    return withStoreLock(() => {
+      // locateEntry rejects the store-wide exact-id collision (active + a
+      // completed twin under a different slug) before any bytes are touched, so
+      // close can never publish a second completed twin over a duplicate id.
+      const { active: activeEntry, completed: completedEntry } = locateEntry(identity);
+      if (!activeEntry) {
+        if (completedEntry) {
+          return { tracker: "local", id: identity.id, ref: identity.ref };
+        }
+        throw new LocalStoreError(`local task not found: ${identity.ref}`);
       }
-      throw new LocalStoreError(`local task not found: ${identity.ref}`);
-    }
 
-    const src = path.join(dirPath(TASKS_DIR), activeEntry.file);
-    const content = fs.readFileSync(src, "utf-8");
-    const split = splitDocument(content);
-    if (!split) throw new LocalStoreError(`local task file for ${identity.ref} is malformed`);
+      const src = path.join(dirPath(TASKS_DIR), activeEntry.file);
+      const content = fs.readFileSync(src, "utf-8");
+      const split = splitDocument(content);
+      if (!split) throw new LocalStoreError(`local task file for ${identity.ref} is malformed`);
 
-    const entries = applyFrontmatterChanges(parseFrontmatterEntries(split.frontmatter), {
-      status: DONE_STATUS,
+      const entries = applyFrontmatterChanges(parseFrontmatterEntries(split.frontmatter), {
+        status: DONE_STATUS,
+      });
+      const doneContent = `${stringifyFrontmatter(entries)}${split.body}`;
+      publishNewFile(dirPath(COMPLETED_DIR), activeEntry.file, doneContent);
+      fs.unlinkSync(src);
+      return { tracker: "local", id: identity.id, ref: identity.ref };
     });
-    const doneContent = `${stringifyFrontmatter(entries)}${split.body}`;
-    publishNewFile(dirPath(COMPLETED_DIR), activeEntry.file, doneContent);
-    fs.unlinkSync(src);
-    return { tracker: "local", id: identity.id, ref: identity.ref };
   }
 
   return Object.freeze({ availability, capabilities, list, read, create, update, close });

--- a/skills/dev-backlog/scripts/local-tracker.js
+++ b/skills/dev-backlog/scripts/local-tracker.js
@@ -27,6 +27,10 @@ const {
 const TASKS_DIR = "tasks";
 const COMPLETED_DIR = "completed";
 const LOCK_FILE = ".local-tracker.lock";
+// Durable intent journal for close: written after the completed copy lands and
+// before the active source is removed, so a process that dies in that window is
+// finished (or discarded) on the next open instead of leaving two authorities.
+const CLOSE_MARKER_FILE = ".local-tracker.close";
 const DONE_STATUS = "Done";
 
 // The only accepted list scopes. Any other `state` fails closed rather than
@@ -90,14 +94,55 @@ function sleepSync(ms) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
+// --- stale-lock reclamation (crash recovery) ---
+
+function readLockOwner(lockPath) {
+  try {
+    const pid = Number.parseInt(fs.readFileSync(lockPath, "utf-8").trim(), 10);
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+function processAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error.code === "EPERM"; // exists but not signalable by us
+  }
+}
+
+// Reclaim a lock whose stamped owner is provably gone. Returns false (leaving
+// the lock untouched) for a live owner, our own pid, or an unstamped/racing
+// lock, so a running allocator is never evicted.
+function reclaimStaleLock(lockPath) {
+  const owner = readLockOwner(lockPath);
+  if (owner === null || owner === process.pid || processAlive(owner)) return false;
+  try {
+    fs.unlinkSync(lockPath);
+  } catch {
+    /* another process reclaimed it first */
+  }
+  return true;
+}
+
 // --- frontmatter / body split, preserving human bytes verbatim ---
 
-const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---(\r?\n[\s\S]*|$)/;
+const FRONTMATTER_RE = /^---(\r?\n)([\s\S]*?)\r?\n---(\r?\n[\s\S]*|$)/;
 
 function splitDocument(content) {
   const match = content.match(FRONTMATTER_RE);
   if (!match) return null;
-  return { frontmatter: match[1], body: match[2] };
+  // `eol` is the stored newline style, taken from the opening fence. The
+  // frontmatter is normalized to LF so value parsing sees clean logical lines
+  // (a trailing CR would otherwise make `id` read back as missing), while `eol`
+  // lets re-emission restore the original CRLF byte-for-byte. The body is kept
+  // verbatim so its own newline style is never rewritten.
+  const eol = match[1];
+  const frontmatter = match[2].replace(/\r\n/g, "\n");
+  return { frontmatter, body: match[3], eol };
 }
 
 /**
@@ -166,10 +211,27 @@ function renderScalar(key, value) {
   return `${key}: ${escapeYaml(text)}`;
 }
 
+// A block-sequence item is left bare only when it is unambiguously a plain
+// string. Anything else — indicators (`#`, `[`, `{`, `-`, …), a mapping colon,
+// leading/trailing space, an empty value, or a token a YAML tool would resolve
+// to a boolean/null/number — is single-quoted so it round-trips as the exact
+// string it was given and never changes meaning for Backlog.md or any reader.
+const SAFE_PLAIN_ITEM_RE = /^[A-Za-z0-9_][A-Za-z0-9_./-]*$/;
+const YAML_RESERVED_RE = /^(?:true|false|yes|no|on|off|null|none|~)$/i;
+const NUMBERLIKE_RE = /^[-+]?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?$/;
+
+function encodeListItem(value) {
+  const text = String(value);
+  if (SAFE_PLAIN_ITEM_RE.test(text) && !YAML_RESERVED_RE.test(text) && !NUMBERLIKE_RE.test(text)) {
+    return text;
+  }
+  return `'${text.replace(/'/g, "''")}'`;
+}
+
 function renderFieldLines(key, value) {
   if (Array.isArray(value)) {
     if (value.length === 0) return [`${key}: []`];
-    return [`${key}:`, ...value.map((item) => `  - ${item}`)];
+    return [`${key}:`, ...value.map((item) => `  - ${encodeListItem(item)}`)];
   }
   return [renderScalar(key, value)];
 }
@@ -191,9 +253,9 @@ function applyFrontmatterChanges(entries, changes) {
   return next;
 }
 
-function stringifyFrontmatter(entries) {
-  const inner = entries.flatMap((entry) => entry.lines).join("\n");
-  return `---\n${inner}\n---`;
+function stringifyFrontmatter(entries, eol = "\n") {
+  const inner = entries.flatMap((entry) => entry.lines).join(eol);
+  return `---${eol}${inner}${eol}---`;
 }
 
 /**
@@ -492,12 +554,27 @@ function createLocalAdapter(options = {}) {
   function acquireLock() {
     fs.mkdirSync(backlogDir, { recursive: true });
     const lockPath = path.join(backlogDir, LOCK_FILE);
+    let reclaimed = false;
     for (let attempt = 0; attempt <= lockConfig.retries; attempt += 1) {
       try {
-        return fs.openSync(lockPath, "wx");
+        const fd = fs.openSync(lockPath, "wx");
+        // Stamp the owner pid so a later process can tell a crashed holder from
+        // a live one and reclaim only a provably dead lock.
+        try {
+          fs.writeSync(fd, String(process.pid));
+        } catch {
+          /* the lock is held regardless of whether the stamp lands */
+        }
+        return fd;
       } catch (error) {
         if (error.code !== "EEXIST") {
           throw new LocalStoreError(`cannot acquire local allocation lock: ${error.message}`, { cause: error });
+        }
+        // Reclaim a crashed holder's lock exactly once, and only when its owner
+        // is provably gone, so a live allocator is never evicted.
+        if (!reclaimed && reclaimStaleLock(lockPath)) {
+          reclaimed = true;
+          continue;
         }
         if (attempt < lockConfig.retries) sleepSync(lockConfig.delayMs);
       }
@@ -522,27 +599,98 @@ function createLocalAdapter(options = {}) {
     }
   }
 
+  // --- crash-recoverable close journal ---
+
+  function closeMarkerPath() {
+    return path.join(backlogDir, CLOSE_MARKER_FILE);
+  }
+
+  function writeCloseMarker(marker) {
+    const fd = fs.openSync(closeMarkerPath(), "w");
+    try {
+      fs.writeSync(fd, JSON.stringify(marker));
+      fs.fsyncSync(fd); // durable so the intent survives a power loss / crash
+    } finally {
+      fs.closeSync(fd);
+    }
+  }
+
+  function removeCloseMarker() {
+    try {
+      fs.unlinkSync(closeMarkerPath());
+    } catch {
+      /* already gone */
+    }
+  }
+
+  // Finish or discard a close a previous process left half-applied. MUST run
+  // under the store lock. A durable marker means the completed copy was (about
+  // to be) published; reconcile so exactly one authoritative file remains:
+  //   dest present + source present -> roll the move forward (retire source)
+  //   dest absent                   -> publish never landed; source is authority
+  function recover() {
+    let raw;
+    try {
+      raw = fs.readFileSync(closeMarkerPath(), "utf-8");
+    } catch (error) {
+      if (error.code === "ENOENT") return;
+      throw new LocalStoreError(`cannot read local recovery marker: ${error.message}`, { cause: error });
+    }
+    let marker;
+    try {
+      marker = JSON.parse(raw);
+    } catch {
+      removeCloseMarker(); // an unreadable marker cannot be acted on
+      return;
+    }
+    const { src, dest } = marker;
+    if (typeof src !== "string" || typeof dest !== "string") {
+      removeCloseMarker();
+      return;
+    }
+    if (fs.existsSync(dest) && fs.existsSync(src)) {
+      try {
+        fs.unlinkSync(src);
+      } catch {
+        return; // keep the marker; retry once the stale source is writable
+      }
+    }
+    removeCloseMarker();
+  }
+
   // Every create/update/close mutation runs inside this single exclusive
   // section so reads and writes across the two stores are serializable; a close
-  // can never race an update into archiving stale bytes.
+  // can never race an update into archiving stale bytes. Recovery runs first so
+  // any interrupted close is healed before the next mutation observes the store.
   function withStoreLock(fn) {
     const fd = acquireLock();
     try {
+      recover();
       return fn();
     } finally {
       releaseLock(fd);
     }
   }
 
+  // Lock-free read paths (list/read) take the lock only when a marker exists, so
+  // a crashed close is healed before its duplicate copies would fail them closed.
+  function recoverIfNeeded() {
+    if (!fs.existsSync(closeMarkerPath())) return;
+    withStoreLock(() => {});
+  }
+
   function allocateParentId() {
-    let max = 0;
+    // Compare and increment as BigInt so an existing parent beyond
+    // Number.MAX_SAFE_INTEGER (e.g. BACK-9007199254740993) is not silently
+    // rounded down, which would allocate a colliding/backwards id.
+    let max = 0n;
     for (const kind of [TASKS_DIR, COMPLETED_DIR]) {
       for (const { identity } of listDir(kind)) {
-        const parent = Number.parseInt(identity.id.split(".")[0], 10);
-        if (Number.isInteger(parent) && parent > max) max = parent;
+        const parent = BigInt(identity.id.split(".")[0]);
+        if (parent > max) max = parent;
       }
     }
-    return String(max + 1);
+    return String(max + 1n);
   }
 
   function idExists(id) {
@@ -553,13 +701,22 @@ function createLocalAdapter(options = {}) {
 
   // --- atomic publication: temp on same fs, hard-link (no overwrite), unlink ---
 
+  // Route temp writes through an injectable writer so a test can reproduce a
+  // partial-write ENOSPC that leaves bytes on disk.
+  function writeTemp(tmp, content) {
+    if (testHooks.writeFile) return testHooks.writeFile(tmp, content);
+    return fs.writeFileSync(tmp, content);
+  }
+
   function publishNewFile(dir, fileName, content) {
     const dest = path.join(dir, fileName);
     assertWithin(dir, dest);
     fs.mkdirSync(dir, { recursive: true });
     const tmp = tempPath(dir, path.basename(fileName));
-    fs.writeFileSync(tmp, content);
+    // The temp write is inside the try so a partial write (e.g. ENOSPC) is
+    // cleaned by the finally instead of leaking a stray `.tmp`.
     try {
+      writeTemp(tmp, content);
       if (testHooks.beforePublish) testHooks.beforePublish(dest);
       fs.linkSync(tmp, dest);
     } catch (error) {
@@ -571,7 +728,7 @@ function createLocalAdapter(options = {}) {
       try {
         fs.unlinkSync(tmp);
       } catch {
-        /* temp already gone */
+        /* temp already gone or never created */
       }
     }
     return dest;
@@ -581,14 +738,16 @@ function createLocalAdapter(options = {}) {
     const dest = path.join(dir, fileName);
     assertWithin(dir, dest);
     const tmp = tempPath(dir, path.basename(fileName));
-    fs.writeFileSync(tmp, content);
+    // A successful rename consumes the temp; any earlier failure (partial write
+    // or failed rename) is cleaned here so no stray `.tmp` survives.
     try {
+      writeTemp(tmp, content);
       fs.renameSync(tmp, dest);
     } catch (error) {
       try {
         fs.unlinkSync(tmp);
       } catch {
-        /* temp already gone */
+        /* temp already gone or never created */
       }
       throw error;
     }
@@ -685,6 +844,7 @@ function createLocalAdapter(options = {}) {
         `invalid local list state ${JSON.stringify(state)}; expected one of open, closed, all`
       );
     }
+    recoverIfNeeded();
     const kinds = LIST_STATE_KINDS[state];
     const tasks = [];
     const seen = new Map();
@@ -706,6 +866,7 @@ function createLocalAdapter(options = {}) {
 
   function read(selector) {
     const identity = resolveIdentity(selector);
+    recoverIfNeeded();
     const { active, completed } = locateEntry(identity);
     const kind = active ? TASKS_DIR : COMPLETED_DIR;
     const entry = active || completed;
@@ -779,7 +940,7 @@ function createLocalAdapter(options = {}) {
 
       const entries = applyFrontmatterChanges(currentEntries, fieldChanges);
       const body = changes.body !== undefined ? normalizeBody(String(changes.body)) : split.body;
-      const nextContent = `${stringifyFrontmatter(entries)}${body}`;
+      const nextContent = `${stringifyFrontmatter(entries, split.eol)}${body}`;
       // A change-free update (or one that resolves to identical bytes) must not
       // rewrite the file, so the mtime and inode stay stable.
       if (nextContent !== content) {
@@ -814,9 +975,20 @@ function createLocalAdapter(options = {}) {
       requireValidFrontmatter(currentEntries, identity.ref);
 
       const entries = applyFrontmatterChanges(currentEntries, { status: DONE_STATUS });
-      const doneContent = `${stringifyFrontmatter(entries)}${split.body}`;
-      const dest = publishNewFile(dirPath(COMPLETED_DIR), activeEntry.file, doneContent);
-      retireSourceAfterPublish(identity, src, dest);
+      const doneContent = `${stringifyFrontmatter(entries, split.eol)}${split.body}`;
+      const dest = path.join(dirPath(COMPLETED_DIR), activeEntry.file);
+      // Journal the intent before publishing so a crash anywhere between here and
+      // the source unlink is reconciled to a single authority on the next open:
+      // no marker survives a fully successful move or a completed rollback.
+      writeCloseMarker({ id: identity.id, ref: identity.ref, src, dest });
+      try {
+        publishNewFile(dirPath(COMPLETED_DIR), activeEntry.file, doneContent);
+        retireSourceAfterPublish(identity, src, dest);
+      } catch (error) {
+        removeCloseMarker();
+        throw error;
+      }
+      removeCloseMarker();
       return { tracker: "local", id: identity.id, ref: identity.ref };
     });
   }
@@ -825,9 +997,17 @@ function createLocalAdapter(options = {}) {
 }
 
 function compareByParentThenSub(left, right) {
-  const [lp, ls = -1] = left.id.split(".").map(Number);
-  const [rp, rs = -1] = right.id.split(".").map(Number);
-  return lp === rp ? ls - rs : lp - rp;
+  // BigInt keys so large ids (past Number's safe range) still order correctly;
+  // a bare parent sorts before its decimal subtasks via the -1 sentinel.
+  const key = (id) => {
+    const [parent, sub] = id.split(".");
+    return [BigInt(parent), sub === undefined ? -1n : BigInt(sub)];
+  };
+  const [lp, ls] = key(left.id);
+  const [rp, rs] = key(right.id);
+  if (lp !== rp) return lp < rp ? -1 : 1;
+  if (ls !== rs) return ls < rs ? -1 : 1;
+  return 0;
 }
 
 module.exports = {

--- a/skills/dev-backlog/scripts/local-tracker.js
+++ b/skills/dev-backlog/scripts/local-tracker.js
@@ -1195,19 +1195,26 @@ function createLocalAdapter(options = {}) {
     assertCanonicalDirs(); // refuse a symlinked/foreign store before reading it
     // list never mutates: an interrupted close is healed on the next mutation,
     // not here. Duplicate copies from a crash surface as a fail-closed error.
+    // Integrity is store-wide, independent of the requested result state: an
+    // active/completed twin must make open, closed, and all views fail alike.
+    const entriesByKind = {
+      [TASKS_DIR]: listDir(TASKS_DIR),
+      [COMPLETED_DIR]: listDir(COMPLETED_DIR),
+    };
+    const activeIds = new Set(entriesByKind[TASKS_DIR].map((entry) => entry.identity.id));
+    for (const entry of entriesByKind[COMPLETED_DIR]) {
+      if (activeIds.has(entry.identity.id)) {
+        throw new LocalStoreError(
+          `local task ${entry.identity.ref} exists in both active and completed stores; ` +
+            "an exact id must be unique across the canonical stores"
+        );
+      }
+    }
+
     const kinds = LIST_STATE_KINDS[state];
     const tasks = [];
-    const seen = new Map();
     for (const kind of kinds) {
-      for (const entry of listDir(kind)) {
-        const prior = seen.get(entry.identity.id);
-        if (prior && prior !== kind) {
-          throw new LocalStoreError(
-            `local task ${entry.identity.ref} exists in both active and completed stores; ` +
-              "an exact id must be unique across the canonical stores"
-          );
-        }
-        seen.set(entry.identity.id, kind);
+      for (const entry of entriesByKind[kind]) {
         tasks.push(readTask(kind, entry));
       }
     }

--- a/skills/dev-backlog/scripts/local-tracker.js
+++ b/skills/dev-backlog/scripts/local-tracker.js
@@ -96,13 +96,26 @@ function sleepSync(ms) {
 
 // --- stale-lock reclamation (crash recovery) ---
 
-function readLockOwner(lockPath) {
+// The lock file stamps `${pid}:${token}`: the pid decides staleness, while the
+// token is a per-acquisition nonce so reclaim and release can bind their unlink
+// to the exact file instance they inspected and never evict a different live
+// holder that replaced the one they saw.
+function readLockStamp(lockPath) {
+  let raw;
   try {
-    const pid = Number.parseInt(fs.readFileSync(lockPath, "utf-8").trim(), 10);
-    return Number.isInteger(pid) && pid > 0 ? pid : null;
+    raw = fs.readFileSync(lockPath, "utf-8").trim();
   } catch {
     return null;
   }
+  const colon = raw.indexOf(":");
+  const pid = Number.parseInt(colon === -1 ? raw : raw.slice(0, colon), 10);
+  if (!(Number.isInteger(pid) && pid > 0)) return null;
+  return { pid, token: colon === -1 ? "" : raw.slice(colon + 1) };
+}
+
+function readLockOwner(lockPath) {
+  const stamp = readLockStamp(lockPath);
+  return stamp ? stamp.pid : null;
 }
 
 function processAlive(pid) {
@@ -114,18 +127,40 @@ function processAlive(pid) {
   }
 }
 
-// Reclaim a lock whose stamped owner is provably gone. Returns false (leaving
-// the lock untouched) for a live owner, our own pid, or an unstamped/racing
-// lock, so a running allocator is never evicted.
-function reclaimStaleLock(lockPath) {
+// Reclaim a lock whose stamped owner is provably gone. Two reclaimers must never
+// both remove "the same" stale lock and then race each other's fresh lock, so
+// removal is bound to a specific file instance: capture the lock by an atomic
+// rename (only one racer wins it; the loser gets ENOENT and retries), then judge
+// the captured file. If a live owner had replaced the stale lock between our read
+// and the capture, restore it and bow out rather than evict a running holder.
+function reclaimStaleLock(lockPath, stagePath) {
   const owner = readLockOwner(lockPath);
   if (owner === null || owner === process.pid || processAlive(owner)) return false;
   try {
-    fs.unlinkSync(lockPath);
+    fs.renameSync(lockPath, stagePath);
   } catch {
-    /* another process reclaimed it first */
+    return false; // vanished or another reclaimer captured it first
   }
-  return true;
+  const captured = readLockOwner(stagePath);
+  if (captured !== null && captured !== process.pid && !processAlive(captured)) {
+    try {
+      fs.unlinkSync(stagePath); // provably dead: drop it so the acquire loop recreates
+    } catch {
+      /* already gone */
+    }
+    return true;
+  }
+  // Captured a live/ambiguous lock — restore it so its owner keeps exclusivity.
+  try {
+    fs.renameSync(stagePath, lockPath);
+  } catch {
+    try {
+      fs.unlinkSync(stagePath);
+    } catch {
+      /* nothing to restore */
+    }
+  }
+  return false;
 }
 
 // --- frontmatter / body split, preserving human bytes verbatim ---
@@ -361,6 +396,38 @@ function buildUpdateFieldChanges(changes) {
   return fieldChanges;
 }
 
+// --- filesystem-boundary guards ---
+
+function contentHash(content) {
+  return crypto.createHash("sha256").update(content, "utf-8").digest("hex");
+}
+
+function lstatSafe(target) {
+  try {
+    return fs.lstatSync(target);
+  } catch {
+    return null;
+  }
+}
+
+// A canonical task must be a real file. A symlinked task file would let a read
+// or close follow the link and touch bytes outside the backlog, so reject any
+// non-regular file (symlink, directory, socket) before it is read or archived.
+function assertRegularFile(full, ref) {
+  const stat = lstatSafe(full);
+  if (!stat) {
+    throw new LocalStoreError(`cannot access local task ${ref}: file is missing or unreadable`);
+  }
+  if (!stat.isFile()) {
+    throw new LocalStoreError(`local task ${ref} is not a regular file; symlinked task files are refused`);
+  }
+}
+
+/** True only when `dest`'s resolved parent is exactly `dir` (no traversal). */
+function withinDir(dir, dest) {
+  return path.resolve(path.dirname(dest)) === path.resolve(dir);
+}
+
 // --- close compensation: identity-checked rollback of a published copy ---
 
 function fileIdentity(target) {
@@ -443,7 +510,7 @@ function createLocalAdapter(options = {}) {
 
   /** Refuse any write whose resolved parent is not exactly the target dir. */
   function assertWithin(dir, dest) {
-    if (path.resolve(path.dirname(dest)) !== path.resolve(dir)) {
+    if (!withinDir(dir, dest)) {
       throw new LocalStoreError(
         `refusing to write a local task outside its canonical directory: ${dest}`
       );
@@ -530,6 +597,7 @@ function createLocalAdapter(options = {}) {
 
   function readTask(kind, entry) {
     const full = path.join(dirPath(kind), entry.file);
+    assertRegularFile(full, entry.identity.ref);
     const content = fs.readFileSync(full, "utf-8");
     const split = splitDocument(content);
     if (!split) {
@@ -554,25 +622,29 @@ function createLocalAdapter(options = {}) {
   function acquireLock() {
     fs.mkdirSync(backlogDir, { recursive: true });
     const lockPath = path.join(backlogDir, LOCK_FILE);
+    const token = crypto.randomBytes(12).toString("hex");
     let reclaimed = false;
     for (let attempt = 0; attempt <= lockConfig.retries; attempt += 1) {
       try {
         const fd = fs.openSync(lockPath, "wx");
-        // Stamp the owner pid so a later process can tell a crashed holder from
-        // a live one and reclaim only a provably dead lock.
+        // Stamp `${pid}:${token}` so a later process can tell a crashed holder
+        // from a live one (pid) and bind reclaim/release to this exact lock
+        // instance (token) rather than to the path alone.
         try {
-          fs.writeSync(fd, String(process.pid));
+          fs.writeSync(fd, `${process.pid}:${token}`);
         } catch {
           /* the lock is held regardless of whether the stamp lands */
         }
-        return fd;
+        return { fd, token };
       } catch (error) {
         if (error.code !== "EEXIST") {
           throw new LocalStoreError(`cannot acquire local allocation lock: ${error.message}`, { cause: error });
         }
         // Reclaim a crashed holder's lock exactly once, and only when its owner
-        // is provably gone, so a live allocator is never evicted.
-        if (!reclaimed && reclaimStaleLock(lockPath)) {
+        // is provably gone, so a live allocator is never evicted. The stage path
+        // is unique to us so concurrent reclaimers cannot collide on it.
+        const stagePath = `${lockPath}.${process.pid}.${token}.reclaiming`;
+        if (!reclaimed && reclaimStaleLock(lockPath, stagePath)) {
           reclaimed = true;
           continue;
         }
@@ -585,17 +657,23 @@ function createLocalAdapter(options = {}) {
     );
   }
 
-  function releaseLock(fd) {
+  function releaseLock(handle) {
     const lockPath = path.join(backlogDir, LOCK_FILE);
     try {
-      fs.closeSync(fd);
+      fs.closeSync(handle.fd);
     } catch {
       /* fd already closed */
     }
-    try {
-      fs.unlinkSync(lockPath);
-    } catch {
-      /* lock already gone */
+    // Only unlink the lock if it is still ours: a token mismatch means another
+    // process already reclaimed it (having judged us dead) and may now hold it,
+    // so unlinking would evict a live holder. Bind the removal to our token.
+    const stamp = readLockStamp(lockPath);
+    if (stamp && stamp.token === handle.token) {
+      try {
+        fs.unlinkSync(lockPath);
+      } catch {
+        /* lock already gone */
+      }
     }
   }
 
@@ -623,11 +701,68 @@ function createLocalAdapter(options = {}) {
     }
   }
 
+  // The close journal is untrusted data. Accept only a marker whose filename is
+  // a safe basename that parses back to the journaled identity; a malformed or
+  // mismatched marker returns null so recovery fails closed instead of acting on
+  // an attacker-controlled path. Absolute src/dest strings are never trusted —
+  // the paths are reconstructed from the validated relative filename below.
+  function validateCloseMarker(marker) {
+    if (!marker || typeof marker !== "object") return null;
+    if (marker.v !== 1 || marker.phase !== "publish") return null;
+    const { id, ref, file, destHash } = marker;
+    if (typeof id !== "string" || typeof ref !== "string") return null;
+    if (typeof file !== "string" || typeof destHash !== "string") return null;
+    if (!/^[0-9a-f]{64}$/.test(destHash)) return null;
+    if (file !== path.basename(file) || /[\\/]/.test(file)) return null;
+    const parsed = parseTaskFileName(file, { taskPrefix, tracker: "local" });
+    if (!parsed || parsed.id !== id || parsed.ref !== ref) return null;
+    return { id, ref, file, destHash };
+  }
+
+  // Read a canonical file's frontmatter id and content hash without following a
+  // symlink. Returns null for anything that is not a regular file, so a
+  // symlinked src/dest can never be promoted or deleted by recovery.
+  function readIdentityAndHash(target) {
+    const stat = lstatSafe(target);
+    if (!stat || !stat.isFile()) return null;
+    let content;
+    try {
+      content = fs.readFileSync(target, "utf-8");
+    } catch {
+      return null;
+    }
+    const split = splitDocument(content);
+    let id = null;
+    if (split) {
+      const idEntry = parseFrontmatterEntries(split.frontmatter).find((entry) => entry.key === "id");
+      if (idEntry) id = String(entryValue(idEntry));
+    }
+    return { id, hash: contentHash(content) };
+  }
+
+  // The destination is this close's publication only if it is a regular file
+  // whose exact bytes (content evidence) and frontmatter id (identity evidence)
+  // match the journaled intent — never an external or partially written file.
+  function publishedMatches(dest, ref, destHash) {
+    const info = readIdentityAndHash(dest);
+    return !!info && info.hash === destHash && info.id === ref;
+  }
+
+  function activeSourceMatches(src, ref) {
+    const info = readIdentityAndHash(src);
+    return !!info && info.id === ref;
+  }
+
   // Finish or discard a close a previous process left half-applied. MUST run
-  // under the store lock. A durable marker means the completed copy was (about
-  // to be) published; reconcile so exactly one authoritative file remains:
-  //   dest present + source present -> roll the move forward (retire source)
-  //   dest absent                   -> publish never landed; source is authority
+  // under the store lock. The journal records only the intent to publish;
+  // recovery derives the actual phase from evidence on disk rather than trusting
+  // the marker:
+  //   dest proves it is our publication (bytes + id) -> retire a matching active
+  //                                                     source (roll the move forward)
+  //   dest absent / unverified (external, partial)   -> publish never landed; the
+  //                                                     active source stays authority
+  // Nothing outside the canonical stores, and nothing whose identity we cannot
+  // confirm, is ever deleted or promoted; the marker is then cleared.
   function recover() {
     let raw;
     try {
@@ -643,12 +778,20 @@ function createLocalAdapter(options = {}) {
       removeCloseMarker(); // an unreadable marker cannot be acted on
       return;
     }
-    const { src, dest } = marker;
-    if (typeof src !== "string" || typeof dest !== "string") {
+    const plan = validateCloseMarker(marker);
+    if (!plan) {
+      removeCloseMarker(); // malformed/untrusted marker: fail closed, touch nothing
+      return;
+    }
+    const src = path.join(dirPath(TASKS_DIR), plan.file);
+    const dest = path.join(dirPath(COMPLETED_DIR), plan.file);
+    // Containment: the reconstructed paths must resolve exactly into their
+    // canonical directories (validation guarantees this; verify defensively).
+    if (!withinDir(dirPath(TASKS_DIR), src) || !withinDir(dirPath(COMPLETED_DIR), dest)) {
       removeCloseMarker();
       return;
     }
-    if (fs.existsSync(dest) && fs.existsSync(src)) {
+    if (publishedMatches(dest, plan.ref, plan.destHash) && activeSourceMatches(src, plan.ref)) {
       try {
         fs.unlinkSync(src);
       } catch {
@@ -662,21 +805,15 @@ function createLocalAdapter(options = {}) {
   // section so reads and writes across the two stores are serializable; a close
   // can never race an update into archiving stale bytes. Recovery runs first so
   // any interrupted close is healed before the next mutation observes the store.
+  // Recovery never runs on the read paths (list/read), which stay non-mutating.
   function withStoreLock(fn) {
-    const fd = acquireLock();
+    const handle = acquireLock();
     try {
       recover();
       return fn();
     } finally {
-      releaseLock(fd);
+      releaseLock(handle);
     }
-  }
-
-  // Lock-free read paths (list/read) take the lock only when a marker exists, so
-  // a crashed close is healed before its duplicate copies would fail them closed.
-  function recoverIfNeeded() {
-    if (!fs.existsSync(closeMarkerPath())) return;
-    withStoreLock(() => {});
   }
 
   function allocateParentId() {
@@ -822,10 +959,15 @@ function createLocalAdapter(options = {}) {
     for (const probe of [backlogDir, dirPath(TASKS_DIR), dirPath(COMPLETED_DIR)]) {
       let stat;
       try {
-        stat = fs.statSync(probe);
+        // lstat, not stat: a symlinked canonical directory must be refused, not
+        // resolved, or create/read/close could escape the backlog through it.
+        stat = fs.lstatSync(probe);
       } catch (error) {
         if (error.code === "ENOENT") continue; // created lazily on first write
         return { available: false, reason: `local store path ${probe} is unusable: ${error.message}` };
+      }
+      if (stat.isSymbolicLink()) {
+        return { available: false, reason: `local store path ${probe} must not be a symlink` };
       }
       if (!stat.isDirectory()) {
         return { available: false, reason: `local store path ${probe} is not a directory` };
@@ -844,7 +986,8 @@ function createLocalAdapter(options = {}) {
         `invalid local list state ${JSON.stringify(state)}; expected one of open, closed, all`
       );
     }
-    recoverIfNeeded();
+    // list never mutates: an interrupted close is healed on the next mutation,
+    // not here. Duplicate copies from a crash surface as a fail-closed error.
     const kinds = LIST_STATE_KINDS[state];
     const tasks = [];
     const seen = new Map();
@@ -866,7 +1009,8 @@ function createLocalAdapter(options = {}) {
 
   function read(selector) {
     const identity = resolveIdentity(selector);
-    recoverIfNeeded();
+    // read never mutates; recovery of an interrupted close is deferred to the
+    // next create/update/close under the store lock.
     const { active, completed } = locateEntry(identity);
     const kind = active ? TASKS_DIR : COMPLETED_DIR;
     const entry = active || completed;
@@ -932,6 +1076,7 @@ function createLocalAdapter(options = {}) {
         throw new LocalStoreError(`no active local task to update: ${identity.ref}`);
       }
       const full = path.join(dirPath(TASKS_DIR), entry.file);
+      assertRegularFile(full, identity.ref);
       const content = fs.readFileSync(full, "utf-8");
       const split = splitDocument(content);
       if (!split) throw new LocalStoreError(`local task file for ${identity.ref} is malformed`);
@@ -968,6 +1113,7 @@ function createLocalAdapter(options = {}) {
       }
 
       const src = path.join(dirPath(TASKS_DIR), activeEntry.file);
+      assertRegularFile(src, identity.ref);
       const content = fs.readFileSync(src, "utf-8");
       const split = splitDocument(content);
       if (!split) throw new LocalStoreError(`local task file for ${identity.ref} is malformed`);
@@ -977,10 +1123,20 @@ function createLocalAdapter(options = {}) {
       const entries = applyFrontmatterChanges(currentEntries, { status: DONE_STATUS });
       const doneContent = `${stringifyFrontmatter(entries, split.eol)}${split.body}`;
       const dest = path.join(dirPath(COMPLETED_DIR), activeEntry.file);
-      // Journal the intent before publishing so a crash anywhere between here and
-      // the source unlink is reconciled to a single authority on the next open:
-      // no marker survives a fully successful move or a completed rollback.
-      writeCloseMarker({ id: identity.id, ref: identity.ref, src, dest });
+      // Journal only the validated relative identity/filename plus the exact
+      // bytes we intend to publish (destHash). A crash anywhere between here and
+      // the source unlink is reconciled to a single authority on the next
+      // mutation: recovery reconstructs src/dest inside the canonical dirs and
+      // rolls forward only when the destination proves it is this publication —
+      // never a raw path taken from the marker.
+      writeCloseMarker({
+        v: 1,
+        phase: "publish",
+        id: identity.id,
+        ref: identity.ref,
+        file: activeEntry.file,
+        destHash: contentHash(doneContent),
+      });
       try {
         publishNewFile(dirPath(COMPLETED_DIR), activeEntry.file, doneContent);
         retireSourceAfterPublish(identity, src, dest);

--- a/skills/dev-backlog/scripts/local-tracker.js
+++ b/skills/dev-backlog/scripts/local-tracker.js
@@ -28,6 +28,14 @@ const TASKS_DIR = "tasks";
 const COMPLETED_DIR = "completed";
 const LOCK_FILE = ".local-tracker.lock";
 const DONE_STATUS = "Done";
+
+// The only accepted list scopes. Any other `state` fails closed rather than
+// silently narrowing to the open store.
+const LIST_STATE_KINDS = Object.freeze({
+  open: [TASKS_DIR],
+  closed: [COMPLETED_DIR],
+  all: [TASKS_DIR, COMPLETED_DIR],
+});
 const DEFAULT_LOCK = Object.freeze({ retries: 100, delayMs: 20 });
 
 // Only provider-neutral fields are accepted; every other option (milestone,
@@ -217,6 +225,112 @@ function taskPrefixIssue(prefix) {
   return null;
 }
 
+// --- required-field and injection validation (fail closed) ---
+
+const REQUIRED_FRONTMATTER_KEYS = ["id", "title", "status"];
+const NEUTRAL_FIELDS = ["title", "status", "priority"];
+const NEUTRAL_LIST_FIELDS = ["labels", "dependencies"];
+
+// Control characters (the C0 set plus DEL) cannot survive the simple YAML
+// renderer: a raw newline in a scalar or list item re-parses as a fresh `key:`
+// line and injects arbitrary frontmatter. Reject them before any mutation.
+const CONTROL_CHAR_RE = /[\x00-\x1F\x7F]/;
+
+function assertNoControlChars(field, value) {
+  if (CONTROL_CHAR_RE.test(value)) {
+    throw new LocalStoreError(
+      `local ${field} must not contain newlines or control characters; ` +
+        "they would inject frontmatter keys and break the task round trip"
+    );
+  }
+}
+
+function cleanScalar(field, value) {
+  const text = String(value);
+  assertNoControlChars(field, text);
+  return text;
+}
+
+/**
+ * Require exactly one non-empty scalar `id`, `title`, and `status`, with the id
+ * equal to the filename ref. Runs before every list/read/update/close so
+ * missing, duplicate, wrong-typed, or empty required fields fail closed rather
+ * than flowing into a normalized task or a mutation.
+ */
+function requireValidFrontmatter(entries, ref) {
+  for (const key of REQUIRED_FRONTMATTER_KEYS) {
+    const matches = entries.filter((entry) => entry.key === key);
+    if (matches.length !== 1) {
+      const problem = matches.length === 0 ? "missing" : "duplicate";
+      throw new LocalStoreError(`local task ${ref} is malformed: ${problem} required '${key}' frontmatter`);
+    }
+    const value = entryValue(matches[0]);
+    // Arrays and mappings both report as objects; a required field must be scalar.
+    if (value !== null && typeof value === "object") {
+      throw new LocalStoreError(`local task ${ref} is malformed: '${key}' must be a single scalar value`);
+    }
+    const text = value === undefined || value === null ? "" : String(value).trim();
+    if (!text) {
+      throw new LocalStoreError(`local task ${ref} is malformed: '${key}' must be a non-empty scalar`);
+    }
+    if (key === "id" && String(value) !== ref) {
+      throw new LocalStoreError(
+        `local task ${ref} is corrupt: frontmatter id ${JSON.stringify(String(value))} does not match its filename`
+      );
+    }
+  }
+}
+
+function buildUpdateFieldChanges(changes) {
+  const fieldChanges = {};
+  for (const field of NEUTRAL_FIELDS) {
+    if (changes[field] !== undefined) fieldChanges[field] = cleanScalar(field, changes[field]);
+  }
+  for (const field of NEUTRAL_LIST_FIELDS) {
+    if (changes[field] === undefined) continue;
+    if (!Array.isArray(changes[field])) {
+      throw new LocalStoreError(`local update ${field} must be an array`);
+    }
+    fieldChanges[field] = changes[field].map((item) => cleanScalar(`${field} item`, item));
+  }
+  if (changes.updated_date !== undefined) {
+    fieldChanges.updated_date = cleanScalar("updated_date", changes.updated_date);
+  }
+  return fieldChanges;
+}
+
+// --- close compensation: identity-checked rollback of a published copy ---
+
+function fileIdentity(target) {
+  const stat = fs.statSync(target);
+  return { dev: stat.dev, ino: stat.ino };
+}
+
+function sameFileIdentity(a, b) {
+  return a.dev === b.dev && a.ino === b.ino;
+}
+
+function closeSourceRetained(identity, src, cause) {
+  return new LocalStoreError(
+    `local close of ${identity.ref} could not remove the active source ${src}, so the ` +
+      "completed copy was rolled back; the task is unchanged and still open. " +
+      `Retry once the source is writable. Cause: ${cause.message}`,
+    { cause }
+  );
+}
+
+function closeSplitStore(identity, src, dest, unlinkError, rollbackError) {
+  const note = rollbackError
+    ? `rolling the completed copy back also failed (${rollbackError.message})`
+    : "the completed copy was replaced by another writer and was left untouched";
+  return new LocalStoreError(
+    `local close of ${identity.ref} could not remove the active source ${src} ` +
+      `(${unlinkError.message}) and ${note}; both ${src} and ${dest} remain. ` +
+      "Resolve the duplicate manually before continuing.",
+    { cause: unlinkError }
+  );
+}
+
 // --- normalized task shape ---
 
 function normalizeTask({ identity, object, body, state }) {
@@ -356,14 +470,14 @@ function createLocalAdapter(options = {}) {
     const full = path.join(dirPath(kind), entry.file);
     const content = fs.readFileSync(full, "utf-8");
     const split = splitDocument(content);
-    if (!split) return null;
-    const object = frontmatterObject(parseFrontmatterEntries(split.frontmatter));
-    if (object.id !== undefined && String(object.id) !== entry.identity.ref) {
+    if (!split) {
       throw new LocalStoreError(
-        `local task ${entry.identity.ref} is corrupt: frontmatter id ` +
-          `${JSON.stringify(String(object.id))} does not match its filename`
+        `local task ${entry.identity.ref} is malformed: missing Backlog.md frontmatter`
       );
     }
+    const entries = parseFrontmatterEntries(split.frontmatter);
+    requireValidFrontmatter(entries, entry.identity.ref);
+    const object = frontmatterObject(entries);
     const state = kind === COMPLETED_DIR ? "closed" : "open";
     return normalizeTask({ identity: entry.identity, object, body: split.body, state });
   }
@@ -481,6 +595,42 @@ function createLocalAdapter(options = {}) {
     return dest;
   }
 
+  // After the completed copy is published, remove the active source to finish the
+  // move. A failed unlink means both stores momentarily claim the id, so roll the
+  // publication back — leaving the active source as the single authoritative task.
+  function retireSourceAfterPublish(identity, src, dest) {
+    const published = fileIdentity(dest);
+    try {
+      if (testHooks.beforeUnlinkSource) testHooks.beforeUnlinkSource(src);
+      fs.unlinkSync(src);
+    } catch (unlinkError) {
+      rollbackPublishedCopy(identity, src, dest, published, unlinkError);
+    }
+  }
+
+  // Undo exactly the copy this close created. Re-stat the destination first: if
+  // it vanished the source already survives alone; if its inode no longer matches
+  // our publication an external writer replaced it and we must not erase it.
+  function rollbackPublishedCopy(identity, src, dest, published, unlinkError) {
+    let live;
+    try {
+      live = fileIdentity(dest);
+    } catch (statError) {
+      if (statError.code === "ENOENT") throw closeSourceRetained(identity, src, unlinkError);
+      throw closeSplitStore(identity, src, dest, unlinkError, statError);
+    }
+    if (!sameFileIdentity(live, published)) {
+      throw closeSplitStore(identity, src, dest, unlinkError, null);
+    }
+    try {
+      if (testHooks.beforeRollback) testHooks.beforeRollback(dest);
+      fs.unlinkSync(dest);
+    } catch (rollbackError) {
+      throw closeSplitStore(identity, src, dest, unlinkError, rollbackError);
+    }
+    throw closeSourceRetained(identity, src, unlinkError);
+  }
+
   // --- rendered content builders ---
 
   function buildFilename(identity, title) {
@@ -530,11 +680,12 @@ function createLocalAdapter(options = {}) {
   }
 
   function list({ state = "open" } = {}) {
-    const kinds = state === "all"
-      ? [TASKS_DIR, COMPLETED_DIR]
-      : state === "closed"
-        ? [COMPLETED_DIR]
-        : [TASKS_DIR];
+    if (!Object.prototype.hasOwnProperty.call(LIST_STATE_KINDS, state)) {
+      throw new LocalStoreError(
+        `invalid local list state ${JSON.stringify(state)}; expected one of open, closed, all`
+      );
+    }
+    const kinds = LIST_STATE_KINDS[state];
     const tasks = [];
     const seen = new Map();
     for (const kind of kinds) {
@@ -547,8 +698,7 @@ function createLocalAdapter(options = {}) {
           );
         }
         seen.set(entry.identity.id, kind);
-        const task = readTask(kind, entry);
-        if (task) tasks.push(task);
+        tasks.push(readTask(kind, entry));
       }
     }
     return tasks.sort(compareByParentThenSub);
@@ -560,9 +710,7 @@ function createLocalAdapter(options = {}) {
     const kind = active ? TASKS_DIR : COMPLETED_DIR;
     const entry = active || completed;
     if (!entry) throw new LocalStoreError(`local task not found: ${identity.ref}`);
-    const task = readTask(kind, entry);
-    if (!task) throw new LocalStoreError(`local task file for ${identity.ref} is malformed`);
-    return task;
+    return readTask(kind, entry);
   }
 
   function create(input = {}) {
@@ -571,6 +719,15 @@ function createLocalAdapter(options = {}) {
     const title = input.title;
     if (typeof title !== "string" || !title.trim()) {
       throw new LocalStoreError("local task creation requires a non-empty title");
+    }
+    // Reject injection before the lock so no mkdir/temp/mtime mutation occurs.
+    assertNoControlChars("title", title);
+    if (input.status != null) assertNoControlChars("status", String(input.status));
+    if (input.priority != null) assertNoControlChars("priority", String(input.priority));
+    for (const field of NEUTRAL_LIST_FIELDS) {
+      if (Array.isArray(input[field])) {
+        for (const item of input[field]) assertNoControlChars(`${field} item`, String(item));
+      }
     }
     let requestedId = null;
     if (input.id !== undefined && input.id !== null) {
@@ -600,13 +757,13 @@ function createLocalAdapter(options = {}) {
     });
   }
 
-  const NEUTRAL_FIELDS = ["title", "status", "priority"];
-  const NEUTRAL_LIST_FIELDS = ["labels", "dependencies"];
-
   function update(selector, changes = {}) {
     rejectUnsupportedOptions("update", changes, UPDATE_OPTIONS);
     assertUsablePrefix();
     const identity = resolveIdentity(selector);
+    // Validate and coerce every field before the lock so a rejected injection or
+    // wrong-typed list never triggers an mkdir/lock/temp/mtime mutation.
+    const fieldChanges = buildUpdateFieldChanges(changes);
 
     return withStoreLock(() => {
       const { active: entry } = locateEntry(identity);
@@ -617,25 +774,17 @@ function createLocalAdapter(options = {}) {
       const content = fs.readFileSync(full, "utf-8");
       const split = splitDocument(content);
       if (!split) throw new LocalStoreError(`local task file for ${identity.ref} is malformed`);
+      const currentEntries = parseFrontmatterEntries(split.frontmatter);
+      requireValidFrontmatter(currentEntries, identity.ref);
 
-      const fieldChanges = {};
-      for (const field of NEUTRAL_FIELDS) {
-        if (changes[field] !== undefined) fieldChanges[field] = String(changes[field]);
-      }
-      for (const field of NEUTRAL_LIST_FIELDS) {
-        if (changes[field] !== undefined) {
-          if (!Array.isArray(changes[field])) {
-            throw new LocalStoreError(`local update ${field} must be an array`);
-          }
-          fieldChanges[field] = changes[field].map(String);
-        }
-      }
-      if (changes.updated_date !== undefined) fieldChanges.updated_date = String(changes.updated_date);
-
-      const entries = applyFrontmatterChanges(parseFrontmatterEntries(split.frontmatter), fieldChanges);
+      const entries = applyFrontmatterChanges(currentEntries, fieldChanges);
       const body = changes.body !== undefined ? normalizeBody(String(changes.body)) : split.body;
       const nextContent = `${stringifyFrontmatter(entries)}${body}`;
-      replaceFileAtomic(dirPath(TASKS_DIR), entry.file, nextContent);
+      // A change-free update (or one that resolves to identical bytes) must not
+      // rewrite the file, so the mtime and inode stay stable.
+      if (nextContent !== content) {
+        replaceFileAtomic(dirPath(TASKS_DIR), entry.file, nextContent);
+      }
       return { tracker: "local", id: identity.id, ref: identity.ref };
     });
   }
@@ -661,13 +810,13 @@ function createLocalAdapter(options = {}) {
       const content = fs.readFileSync(src, "utf-8");
       const split = splitDocument(content);
       if (!split) throw new LocalStoreError(`local task file for ${identity.ref} is malformed`);
+      const currentEntries = parseFrontmatterEntries(split.frontmatter);
+      requireValidFrontmatter(currentEntries, identity.ref);
 
-      const entries = applyFrontmatterChanges(parseFrontmatterEntries(split.frontmatter), {
-        status: DONE_STATUS,
-      });
+      const entries = applyFrontmatterChanges(currentEntries, { status: DONE_STATUS });
       const doneContent = `${stringifyFrontmatter(entries)}${split.body}`;
-      publishNewFile(dirPath(COMPLETED_DIR), activeEntry.file, doneContent);
-      fs.unlinkSync(src);
+      const dest = publishNewFile(dirPath(COMPLETED_DIR), activeEntry.file, doneContent);
+      retireSourceAfterPublish(identity, src, dest);
       return { tracker: "local", id: identity.id, ref: identity.ref };
     });
   }

--- a/skills/dev-backlog/scripts/local-tracker.js
+++ b/skills/dev-backlog/scripts/local-tracker.js
@@ -411,15 +411,27 @@ function realDirIssue(dir) {
   return null;
 }
 
-// --- close compensation: identity-checked rollback of a published copy ---
+// --- close compensation: identity-and-content-checked rollback ---
 
-function fileIdentity(target) {
-  const stat = fs.statSync(target);
-  return { dev: stat.dev, ino: stat.ino };
+function fileEvidence(target) {
+  // Bind the content hash to the same inode represented by the evidence: path
+  // stat followed by path read could itself observe two different files.
+  const fd = fs.openSync(target, "r");
+  try {
+    const stat = fs.fstatSync(fd);
+    if (!stat.isFile()) {
+      const error = new Error(`rollback target is not a regular file: ${target}`);
+      error.code = "EINVAL";
+      throw error;
+    }
+    return { dev: stat.dev, ino: stat.ino, hash: contentHash(fs.readFileSync(fd)) };
+  } finally {
+    fs.closeSync(fd);
+  }
 }
 
-function sameFileIdentity(a, b) {
-  return a.dev === b.dev && a.ino === b.ino;
+function sameFileEvidence(a, b) {
+  return a.dev === b.dev && a.ino === b.ino && a.hash === b.hash;
 }
 
 function closeSourceRetained(identity, src, cause) {
@@ -1081,8 +1093,26 @@ function createLocalAdapter(options = {}) {
   // After the completed copy is published, remove the active source to finish the
   // move. A failed unlink means both stores momentarily claim the id, so roll the
   // publication back — leaving the active source as the single authoritative task.
-  function retireSourceAfterPublish(identity, src, dest) {
-    const published = fileIdentity(dest);
+  function rollbackEvidence(target) {
+    const evidence = fileEvidence(target);
+    // Deterministically model inode reuse in regression tests without allowing a
+    // hook to alter the content proof used by production rollback decisions.
+    if (!testHooks.rollbackFileIdentity) return evidence;
+    const projected = testHooks.rollbackFileIdentity(target, evidence);
+    return { ...evidence, dev: projected.dev, ino: projected.ino };
+  }
+
+  function retireSourceAfterPublish(identity, src, dest, expectedHash) {
+    const published = rollbackEvidence(dest);
+    if (published.hash !== expectedHash) {
+      throw closeSplitStore(
+        identity,
+        src,
+        dest,
+        new Error("completed publication did not retain its exact intended bytes"),
+        null
+      );
+    }
     try {
       if (testHooks.beforeUnlinkSource) testHooks.beforeUnlinkSource(src);
       fs.unlinkSync(src);
@@ -1092,17 +1122,18 @@ function createLocalAdapter(options = {}) {
   }
 
   // Undo exactly the copy this close created. Re-stat the destination first: if
-  // it vanished the source already survives alone; if its inode no longer matches
-  // our publication an external writer replaced it and we must not erase it.
+  // it vanished the source already survives alone; if either its inode OR exact
+  // SHA-256 content differs from our publication, an external writer replaced it
+  // (including Linux inode reuse) and we must not erase it.
   function rollbackPublishedCopy(identity, src, dest, published, unlinkError) {
     let live;
     try {
-      live = fileIdentity(dest);
+      live = rollbackEvidence(dest);
     } catch (statError) {
       if (statError.code === "ENOENT") throw closeSourceRetained(identity, src, unlinkError);
       throw closeSplitStore(identity, src, dest, unlinkError, statError);
     }
-    if (!sameFileIdentity(live, published)) {
+    if (!sameFileEvidence(live, published)) {
       throw closeSplitStore(identity, src, dest, unlinkError, null);
     }
     try {
@@ -1302,6 +1333,7 @@ function createLocalAdapter(options = {}) {
 
       const entries = applyFrontmatterChanges(currentEntries, { status: DONE_STATUS });
       const doneContent = `${stringifyFrontmatter(entries, split.eol)}${split.body}`;
+      const destHash = contentHash(doneContent);
       const dest = path.join(dirPath(COMPLETED_DIR), activeEntry.file);
       // Journal only the validated relative identity/filename plus the exact
       // bytes we intend to publish (destHash). A crash anywhere between here and
@@ -1315,11 +1347,11 @@ function createLocalAdapter(options = {}) {
         id: identity.id,
         ref: identity.ref,
         file: activeEntry.file,
-        destHash: contentHash(doneContent),
+        destHash,
       });
       try {
         publishNewFile(dirPath(COMPLETED_DIR), activeEntry.file, doneContent);
-        retireSourceAfterPublish(identity, src, dest);
+        retireSourceAfterPublish(identity, src, dest, destHash);
       } catch (error) {
         removeCloseMarker();
         throw error;

--- a/skills/dev-backlog/scripts/local-tracker.test.js
+++ b/skills/dev-backlog/scripts/local-tracker.test.js
@@ -1150,6 +1150,93 @@ describe("local allocation lock is never auto-reclaimed and release is identity-
     assert.equal(fs.readFileSync(lockPath, "utf-8"), replacementBytes, "the replacement holder's lock is byte-for-byte untouched");
   });
 
+  it("captures and restores a replacement installed after release validation without unlinking its inode", (t) => {
+    const { backlogDir } = makeStore(t);
+    const lockPath = path.join(backlogDir, ".local-tracker.lock");
+    const replacementBytes = `${process.pid}:post-validation-replacement`;
+    let replacementIdentity;
+    const adapter = createLocalAdapter({
+      backlogDir,
+      now: FIXED_NOW,
+      testHooks: {
+        afterReleaseLockValidation(lp) {
+          // This is the old check->unlink window: preliminary fd/token/inode
+          // validation has passed, then a new owner replaces the pathname just
+          // before release would have unlinked it.
+          fs.unlinkSync(lp);
+          fs.writeFileSync(lp, replacementBytes);
+          replacementIdentity = fs.statSync(lp);
+        },
+      },
+    });
+
+    assert.throws(
+      () => adapter.create({ title: "Post validation race" }),
+      (error) =>
+        error instanceof LocalStoreError &&
+        /changed owner during release|foreign lock was preserved|reconcile/i.test(error.message)
+    );
+    assert.deepEqual(
+      listNames(backlogDir, "tasks"),
+      ["BACK-1 - post-validation-race.md"],
+      "the critical section commits before the fail-closed release"
+    );
+
+    const captures = fs
+      .readdirSync(backlogDir)
+      .filter((name) => name.startsWith(".local-tracker.lock.release."));
+    assert.equal(captures.length, 1, "the foreign capture remains available for reconciliation");
+    const capturePath = path.join(backlogDir, captures[0]);
+    const restoredIdentity = fs.statSync(lockPath);
+    const capturedIdentity = fs.statSync(capturePath);
+    assert.equal(fs.readFileSync(lockPath, "utf-8"), replacementBytes, "canonical replacement bytes survive");
+    assert.equal(fs.readFileSync(capturePath, "utf-8"), replacementBytes, "captured replacement bytes survive");
+    assert.equal(restoredIdentity.dev, replacementIdentity.dev);
+    assert.equal(restoredIdentity.ino, replacementIdentity.ino, "canonical path retains the replacement inode");
+    assert.equal(capturedIdentity.dev, replacementIdentity.dev);
+    assert.equal(capturedIdentity.ino, replacementIdentity.ino, "capture retains the same replacement inode");
+  });
+
+  it("preserves both a foreign capture and a newer canonical owner during no-overwrite restoration", (t) => {
+    const { backlogDir } = makeStore(t);
+    const lockPath = path.join(backlogDir, ".local-tracker.lock");
+    const capturedBytes = `${process.pid}:captured-foreign-owner`;
+    const newerBytes = `${process.pid}:newer-canonical-owner`;
+    let capturedIdentity;
+    let newerIdentity;
+    const adapter = createLocalAdapter({
+      backlogDir,
+      now: FIXED_NOW,
+      testHooks: {
+        afterReleaseLockValidation(lp) {
+          fs.unlinkSync(lp);
+          fs.writeFileSync(lp, capturedBytes);
+          capturedIdentity = fs.statSync(lp);
+        },
+        beforeForeignLockRestore(_capturePath, canonicalPath) {
+          // The atomic capture made canonical free, and a still-newer allocator
+          // acquired it before restoration. Restoration must not overwrite it.
+          fs.writeFileSync(canonicalPath, newerBytes, { flag: "wx" });
+          newerIdentity = fs.statSync(canonicalPath);
+        },
+      },
+    });
+
+    assert.throws(
+      () => adapter.create({ title: "Two owners" }),
+      (error) => error instanceof LocalStoreError && /newer owner|both locks were preserved/i.test(error.message)
+    );
+    const captures = fs
+      .readdirSync(backlogDir)
+      .filter((name) => name.startsWith(".local-tracker.lock.release."));
+    assert.equal(captures.length, 1);
+    const capturePath = path.join(backlogDir, captures[0]);
+    assert.equal(fs.readFileSync(lockPath, "utf-8"), newerBytes);
+    assert.equal(fs.statSync(lockPath).ino, newerIdentity.ino, "no-overwrite keeps the newer canonical inode");
+    assert.equal(fs.readFileSync(capturePath, "utf-8"), capturedBytes);
+    assert.equal(fs.statSync(capturePath).ino, capturedIdentity.ino, "the captured foreign inode is retained separately");
+  });
+
   it("never reclaims a dead-PID lock: two contenders both fail closed and the lock is untouched", (t) => {
     const { backlogDir } = makeStore(t);
     const lockPath = path.join(backlogDir, ".local-tracker.lock");

--- a/skills/dev-backlog/scripts/local-tracker.test.js
+++ b/skills/dev-backlog/scripts/local-tracker.test.js
@@ -757,3 +757,125 @@ describe("local update no-op and list-state validation edges", () => {
     assert.deepEqual(adapter.list().map((task) => task.ref), ["BACK-1"]);
   });
 });
+
+describe("local CRLF task files parse and preserve their newline style", () => {
+  const crlf = (id, status = "To Do") =>
+    [
+      "---",
+      `id: BACK-${id}`,
+      "title: Windows Task",
+      `status: ${status}`,
+      "labels:",
+      "  - infra",
+      "priority: medium",
+      "created_date: '2026-07-01'",
+      "---",
+      "## Description",
+      "line one",
+      "line two",
+      "",
+    ].join("\r\n");
+
+  const noBareLf = (content) => !/[^\r]\n/.test(content);
+
+  it("reads a valid CRLF file instead of treating id as missing", (t) => {
+    const { adapter } = makeStore(t, { seedTasks: [["BACK-1 - one.md", crlf(1)]] });
+    const task = adapter.read("BACK-1");
+    assert.equal(task.id, "1");
+    assert.equal(task.title, "Windows Task");
+    assert.equal(task.status, "To Do");
+    assert.deepEqual(task.labels, ["infra"]);
+    assert.deepEqual(adapter.list().map((x) => x.ref), ["BACK-1"]);
+  });
+
+  it("keeps CRLF newlines when updating a field", (t) => {
+    const { adapter, backlogDir } = makeStore(t, { seedTasks: [["BACK-1 - one.md", crlf(1)]] });
+    const before = read(backlogDir, "tasks", "BACK-1 - one.md");
+    adapter.update("BACK-1", { status: "In Progress" });
+    const after = read(backlogDir, "tasks", "BACK-1 - one.md");
+    // Exactly the status line changed; every other byte, including CRLF, is intact.
+    assert.equal(after, before.replace("status: To Do", "status: In Progress"));
+    assert.ok(after.includes("\r\n"), "CRLF endings survive the update");
+    assert.ok(noBareLf(after), "no bare LF was introduced");
+  });
+
+  it("keeps CRLF newlines when closing", (t) => {
+    const { adapter, backlogDir } = makeStore(t, { seedTasks: [["BACK-1 - one.md", crlf(1)]] });
+    const before = read(backlogDir, "tasks", "BACK-1 - one.md");
+    adapter.close("BACK-1");
+    const archived = read(backlogDir, "completed", "BACK-1 - one.md");
+    assert.equal(archived, before.replace("status: To Do", "status: Done"));
+    assert.ok(archived.includes("\r\n"));
+    assert.ok(noBareLf(archived), "no bare LF was introduced on close");
+  });
+});
+
+describe("local list items encode losslessly", () => {
+  it("round-trips YAML-significant label and dependency items", (t) => {
+    const { adapter, backlogDir } = makeStore(t);
+    const labels = ["#bug", "a: b", "true", "false", "[x]", "{a}", " leading", "trailing ", "quote's", "123"];
+    const dependencies = ["- dash", "@handle", "key: val", "BACK-9"];
+    adapter.create({ title: "Encoded", labels, dependencies });
+
+    const task = adapter.read("BACK-1");
+    assert.deepEqual(task.labels, labels);
+    assert.deepEqual(task.dependencies, dependencies);
+
+    // Survives a metadata-only update and a re-read of both read and list.
+    adapter.update("BACK-1", { priority: "high" });
+    assert.deepEqual(adapter.read("BACK-1").labels, labels);
+    assert.deepEqual(adapter.list()[0].dependencies, dependencies);
+
+    // YAML-significant items are quoted so meaning cannot change; a plain token stays bare.
+    const raw = read(backlogDir, "tasks", "BACK-1 - encoded.md");
+    assert.match(raw, /^ {2}- '#bug'$/m);
+    assert.match(raw, /^ {2}- 'a: b'$/m);
+    assert.match(raw, /^ {2}- 'true'$/m);
+    assert.match(raw, /^ {2}- '123'$/m);
+    assert.match(raw, /^ {2}- 'quote''s'$/m);
+    assert.match(raw, /^ {2}- BACK-9$/m);
+  });
+});
+
+describe("local allocation is precision-safe for large parent ids", () => {
+  it("allocates strictly above a parent id beyond Number.MAX_SAFE_INTEGER", (t) => {
+    const big = "9007199254740993"; // 2^53 + 1: rounds down when handled as a JS float
+    const { adapter, backlogDir } = makeStore(t, {
+      seedTasks: [[`BACK-${big} - big.md`, taskFile({ id: big, title: "Big" })]],
+    });
+    const created = adapter.create({ title: "Next" });
+    assert.equal(created.id, "9007199254740994");
+    assert.notEqual(created.id, "9007199254740992"); // the rounded-down (colliding) value
+    assert.ok(fs.existsSync(path.join(backlogDir, "tasks", "BACK-9007199254740994 - next.md")));
+    assert.equal(adapter.read(`BACK-${big}`).id, big);
+    assert.equal(adapter.read("BACK-9007199254740994").id, "9007199254740994");
+  });
+});
+
+describe("local publication cleans partial temp files when the write itself fails", () => {
+  function failingWrite(tmp) {
+    fs.writeFileSync(tmp, "partial bytes"); // a partial temp lands on disk...
+    const error = new Error("ENOSPC: no space left on device, write");
+    error.code = "ENOSPC";
+    throw error; // ...then the write itself is reported as failed
+  }
+
+  it("removes the stray temp on create when the write fails", (t) => {
+    const { backlogDir } = makeStore(t);
+    const adapter = createLocalAdapter({ backlogDir, now: FIXED_NOW, testHooks: { writeFile: failingWrite } });
+    assert.throws(() => adapter.create({ title: "Boom" }));
+    assert.deepEqual(listNames(backlogDir, "tasks"), []);
+    assert.deepEqual(strays(backlogDir, "tasks"), []);
+    assert.ok(!fs.existsSync(path.join(backlogDir, ".local-tracker.lock")));
+  });
+
+  it("removes the stray temp on update when the write fails and preserves the task", (t) => {
+    const { backlogDir } = makeStore(t, { seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One" })]] });
+    const before = read(backlogDir, "tasks", "BACK-1 - one.md");
+    const adapter = createLocalAdapter({ backlogDir, now: FIXED_NOW, testHooks: { writeFile: failingWrite } });
+    assert.throws(() => adapter.update("BACK-1", { status: "In Progress" }));
+    assert.equal(read(backlogDir, "tasks", "BACK-1 - one.md"), before, "original bytes untouched");
+    assert.deepEqual(strays(backlogDir, "tasks"), []);
+    assert.ok(!fs.existsSync(path.join(backlogDir, ".local-tracker.lock")));
+  });
+});

--- a/skills/dev-backlog/scripts/local-tracker.test.js
+++ b/skills/dev-backlog/scripts/local-tracker.test.js
@@ -3,6 +3,7 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
+const crypto = require("node:crypto");
 
 const {
   createLocalAdapter,
@@ -981,5 +982,263 @@ describe("local recovery treats the close journal as untrusted", () => {
 
     assert.ok(fs.existsSync(victim), "an untyped legacy marker cannot drive an arbitrary unlink");
     assert.ok(!fs.existsSync(path.join(backlogDir, CLOSE_MARKER)), "the legacy marker is cleared");
+  });
+
+  it("refuses roll-forward when a self-consistent marker names a different authoritative body", (t) => {
+    // Active source authoritative bytes (body X). A crash-safe close of THESE
+    // bytes would publish Done(X); anything else is not this source's publication.
+    const activeBytes =
+      "---\nid: BACK-1\ntitle: One\nstatus: To Do\nlabels: []\npriority: medium\ncreated_date: '2026-07-01'\n---\n## Description\nauthoritative alpha\n";
+    // A valid, self-consistent Done publication for the SAME ref BACK-1, but
+    // derived from a DIFFERENT body (Y). The marker below names its real hash, so
+    // marker and destination agree with each other — the trap the old code fell
+    // into, deleting the active source because it trusted marker.destHash alone.
+    const unrelatedDone =
+      "---\nid: BACK-1\ntitle: One\nstatus: Done\nlabels: []\npriority: medium\ncreated_date: '2026-07-01'\n---\n## Description\nunrelated beta\n";
+    const { backlogDir, adapter } = makeStore(t, {
+      seedTasks: [["BACK-1 - one.md", activeBytes]],
+      seedCompleted: [["BACK-1 - one.md", unrelatedDone]],
+    });
+    writeMarker(backlogDir, {
+      v: 1,
+      phase: "publish",
+      id: "1",
+      ref: "BACK-1",
+      file: "BACK-1 - one.md",
+      destHash: crypto.createHash("sha256").update(unrelatedDone, "utf-8").digest("hex"),
+    });
+
+    // Recovery derives Done(activeBytes) independently, sees it differ from both
+    // the marker and the destination, and refuses to roll forward. The close then
+    // fails closed on the surviving duplicate id.
+    assert.throws(() => adapter.close("BACK-1"), LocalStoreError);
+
+    // The authoritative active source is never deleted; the completed copy and the
+    // marker are handled without touching either file's bytes.
+    assert.equal(read(backlogDir, "tasks", "BACK-1 - one.md"), activeBytes, "authoritative active source preserved");
+    assert.equal(read(backlogDir, "completed", "BACK-1 - one.md"), unrelatedDone, "completed copy never altered");
+    assert.ok(!fs.existsSync(path.join(backlogDir, CLOSE_MARKER)), "the untrusted marker is discarded");
+
+    // Every read path continues to fail closed on the duplicate until an operator resolves it.
+    assert.throws(() => adapter.read("BACK-1"), LocalStoreError);
+    assert.throws(() => adapter.list({ state: "all" }), LocalStoreError);
+  });
+});
+
+describe("local enforces canonical directory integrity at every lifecycle op", () => {
+  const LOCAL_CONFIG = { task_prefix: "BACK", default_status: "To Do" };
+
+  function names(dir) {
+    return fs.readdirSync(dir).sort();
+  }
+
+  it("refuses every op when tasks/ is a symlink and never touches the target", (t) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "local-tracker-symtasks-"));
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+    if (!symlinkSupported(root)) return;
+    const backlogDir = path.join(root, "backlog");
+    fs.mkdirSync(path.join(backlogDir, "completed"), { recursive: true });
+    const outside = path.join(root, "outside");
+    fs.mkdirSync(outside, { recursive: true });
+    const outsideTask = taskFile({ id: 1, title: "Outside" });
+    fs.writeFileSync(path.join(outside, "BACK-1 - one.md"), outsideTask);
+    fs.symlinkSync(outside, path.join(backlogDir, "tasks")); // tasks/ -> outside
+    const before = names(outside);
+    const adapter = createLocalAdapter({ backlogDir, config: LOCAL_CONFIG, now: FIXED_NOW });
+
+    assert.throws(() => adapter.list(), LocalStoreError);
+    assert.throws(() => adapter.read("BACK-1"), LocalStoreError);
+    assert.throws(() => adapter.create({ title: "Nope" }), LocalStoreError);
+    assert.throws(() => adapter.update("BACK-1", { status: "Done" }), LocalStoreError);
+    assert.throws(() => adapter.close("BACK-1"), LocalStoreError);
+
+    assert.deepEqual(names(outside), before, "no file created/read outside the store");
+    assert.equal(fs.readFileSync(path.join(outside, "BACK-1 - one.md"), "utf-8"), outsideTask, "the external task is never followed or rewritten");
+    assert.ok(!fs.existsSync(path.join(backlogDir, ".local-tracker.lock")), "no lock is taken through the symlink");
+  });
+
+  it("refuses every op when completed/ is a symlink and never touches the target", (t) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "local-tracker-symdone-"));
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+    if (!symlinkSupported(root)) return;
+    const backlogDir = path.join(root, "backlog");
+    fs.mkdirSync(path.join(backlogDir, "tasks"), { recursive: true });
+    const activeBytes = taskFile({ id: 1, title: "One" });
+    fs.writeFileSync(path.join(backlogDir, "tasks", "BACK-1 - one.md"), activeBytes);
+    const outside = path.join(root, "outside");
+    fs.mkdirSync(outside, { recursive: true });
+    fs.symlinkSync(outside, path.join(backlogDir, "completed")); // completed/ -> outside
+    const adapter = createLocalAdapter({ backlogDir, config: LOCAL_CONFIG, now: FIXED_NOW });
+
+    assert.throws(() => adapter.list(), LocalStoreError);
+    assert.throws(() => adapter.read("BACK-1"), LocalStoreError);
+    assert.throws(() => adapter.create({ title: "Nope" }), LocalStoreError);
+    assert.throws(() => adapter.update("BACK-1", { status: "Done" }), LocalStoreError);
+    assert.throws(() => adapter.close("BACK-1"), LocalStoreError);
+
+    assert.deepEqual(names(outside), [], "close never publishes into the symlinked completed target");
+    assert.equal(fs.readFileSync(path.join(backlogDir, "tasks", "BACK-1 - one.md"), "utf-8"), activeBytes, "the active source is untouched");
+    assert.ok(!fs.existsSync(path.join(backlogDir, ".local-tracker.lock")), "no lock is left behind");
+  });
+
+  it("refuses every op when the backlog root is a symlink and never touches the target", (t) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "local-tracker-symroot-"));
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+    if (!symlinkSupported(root)) return;
+    const realStore = path.join(root, "real-store");
+    fs.mkdirSync(path.join(realStore, "tasks"), { recursive: true });
+    fs.mkdirSync(path.join(realStore, "completed"), { recursive: true });
+    fs.writeFileSync(path.join(realStore, "tasks", "BACK-1 - one.md"), taskFile({ id: 1, title: "One" }));
+    const backlogDir = path.join(root, "backlog");
+    fs.symlinkSync(realStore, backlogDir); // the configured root is itself a symlink
+    const adapter = createLocalAdapter({ backlogDir, config: LOCAL_CONFIG, now: FIXED_NOW });
+
+    assert.equal(adapter.availability().available, false, "a symlinked root reports unavailable");
+    assert.throws(() => adapter.list(), LocalStoreError);
+    assert.throws(() => adapter.read("BACK-1"), LocalStoreError);
+    assert.throws(() => adapter.create({ title: "Nope" }), LocalStoreError);
+    assert.throws(() => adapter.update("BACK-1", { status: "Done" }), LocalStoreError);
+    assert.throws(() => adapter.close("BACK-1"), LocalStoreError);
+
+    assert.deepEqual(names(path.join(realStore, "tasks")), ["BACK-1 - one.md"], "no task created through the symlinked root");
+    assert.deepEqual(names(path.join(realStore, "completed")), [], "close never archived through the symlinked root");
+    assert.ok(!fs.existsSync(path.join(realStore, ".local-tracker.lock")), "no lock created through the symlinked root");
+  });
+});
+
+describe("local allocation lock is never auto-reclaimed and release is identity-bound", () => {
+  function findDeadPid() {
+    for (const candidate of [999001, 999002, 999003, 4194303, 4194301]) {
+      try {
+        process.kill(candidate, 0);
+      } catch (error) {
+        if (error.code === "ESRCH") return candidate;
+      }
+    }
+    throw new Error("could not find a provably-dead pid for the test");
+  }
+
+  it("preserves a replacement lock installed between the critical section and release", (t) => {
+    const { backlogDir } = makeStore(t);
+    const lockPath = path.join(backlogDir, ".local-tracker.lock");
+    let replacementBytes = null;
+    const adapter = createLocalAdapter({
+      backlogDir,
+      now: FIXED_NOW,
+      testHooks: {
+        beforeReleaseLock(lp) {
+          // A replacement owner takes the lock after our critical section but
+          // before our release. Reuse OUR exact stamp bytes (same pid:token) yet
+          // give it a brand-new inode: token binding alone would still delete it,
+          // so only the file-identity binding protects the replacement holder.
+          replacementBytes = fs.readFileSync(lp, "utf-8");
+          fs.rmSync(lp);
+          fs.writeFileSync(lp, replacementBytes);
+        },
+      },
+    });
+
+    // The critical section itself completes, but release sees the file identity at
+    // the path no longer matches the instance we opened and fails clearly instead
+    // of unlinking a lock that is no longer ours.
+    assert.throws(
+      () => adapter.create({ title: "Raced" }),
+      (error) => error instanceof LocalStoreError && /changed owner|replacement/i.test(error.message)
+    );
+    assert.deepEqual(listNames(backlogDir, "tasks"), ["BACK-1 - raced.md"], "the critical section still ran; only release refused");
+    assert.ok(fs.existsSync(lockPath), "the replacement lock is not evicted even though its token matches");
+    assert.equal(fs.readFileSync(lockPath, "utf-8"), replacementBytes, "the replacement holder's lock is byte-for-byte untouched");
+  });
+
+  it("never reclaims a dead-PID lock: two contenders both fail closed and the lock is untouched", (t) => {
+    const { backlogDir } = makeStore(t);
+    const lockPath = path.join(backlogDir, ".local-tracker.lock");
+    const staleBytes = `${findDeadPid()}:stale-token`;
+    fs.writeFileSync(lockPath, staleBytes);
+
+    const contenders = [0, 1].map(() =>
+      createLocalAdapter({ backlogDir, now: FIXED_NOW, lock: { retries: 1, delayMs: 1 } })
+    );
+    for (const contender of contenders) {
+      assert.throws(
+        () => contender.create({ title: "Blocked by stale" }),
+        (error) => error instanceof LocalStoreError && /stale lock|no longer running|manually/i.test(error.message)
+      );
+    }
+
+    // Neither contender reclaimed or deleted the stale lock, and neither entered
+    // the critical section — so no concurrent critical sections could occur.
+    assert.equal(fs.readFileSync(lockPath, "utf-8"), staleBytes, "the stale lock is never reclaimed or deleted");
+    assert.deepEqual(listNames(backlogDir, "tasks"), [], "no contender entered the critical section");
+  });
+});
+
+function snapshotTree(root) {
+  const out = {};
+  const walk = (rel) => {
+    const abs = rel === "" ? root : path.join(root, rel);
+    const st = fs.lstatSync(abs, { bigint: true });
+    const type = st.isDirectory()
+      ? "dir"
+      : st.isSymbolicLink()
+        ? "symlink"
+        : st.isFile()
+          ? "file"
+          : "other";
+    const rec = { type, size: st.size, mtimeNs: st.mtimeNs, ino: st.ino };
+    if (type === "file") rec.content = fs.readFileSync(abs).toString("hex");
+    if (type === "symlink") rec.target = fs.readlinkSync(abs);
+    out[rel === "" ? "." : rel] = rec;
+    if (type === "dir") {
+      for (const name of fs.readdirSync(abs).sort()) {
+        walk(rel === "" ? name : path.join(rel, name));
+      }
+    }
+  };
+  walk("");
+  return out;
+}
+
+describe("local read paths never mutate the store (deep recursive before/after snapshot)", () => {
+  function seedRecoveryStore(t) {
+    const store = makeStore(t, {
+      seedTasks: [
+        ["BACK-1 - one.md", taskFile({ id: 1, title: "One" })],
+        // Malformed: a valid filename whose content fails validation (missing status).
+        ["BACK-2 - bad.md", "---\nid: BACK-2\ntitle: Two\n---\n## Description\nno status\n"],
+        // A stray temp left by a prior crash — reads must not sweep it.
+        [".local-tracker.99.2.deadbeef.tmp", "partial temp bytes"],
+      ],
+      seedCompleted: [["BACK-3 - three.md", taskFile({ id: 3, title: "Three", status: "Done" })]],
+    });
+    // Stale recovery metadata: a durable but stale close marker.
+    fs.writeFileSync(
+      path.join(store.backlogDir, CLOSE_MARKER),
+      JSON.stringify({ v: 1, phase: "publish", id: "1", ref: "BACK-1", file: "BACK-1 - one.md", destHash: "0".repeat(64) })
+    );
+    return store;
+  }
+
+  it("list() over valid + malformed + stale-marker state mutates nothing and takes no lock", (t) => {
+    const { backlogDir, adapter } = seedRecoveryStore(t);
+    const before = snapshotTree(backlogDir);
+    // A malformed task makes list fail closed — but it must still not mutate.
+    assert.throws(() => adapter.list({ state: "all" }), LocalStoreError);
+    const after = snapshotTree(backlogDir);
+    assert.deepEqual(after, before, "list() preserves every name, type, content, size, mtime, and inode");
+    assert.ok(!Object.prototype.hasOwnProperty.call(after, ".local-tracker.lock"), "list() never creates a lock");
+    assert.ok(Object.prototype.hasOwnProperty.call(after, CLOSE_MARKER), "list() never touches the recovery marker");
+  });
+
+  it("read() of valid, closed, and malformed tasks mutates nothing and takes no lock", (t) => {
+    const { backlogDir, adapter } = seedRecoveryStore(t);
+    const before = snapshotTree(backlogDir);
+    assert.equal(adapter.read("BACK-1").id, "1"); // valid open task
+    assert.equal(adapter.read("BACK-3").state, "closed"); // valid closed task
+    assert.throws(() => adapter.read("BACK-2"), LocalStoreError); // malformed content
+    const after = snapshotTree(backlogDir);
+    assert.deepEqual(after, before, "read() preserves every name, type, content, size, mtime, and inode");
+    assert.ok(!Object.prototype.hasOwnProperty.call(after, ".local-tracker.lock"), "read() never creates a lock");
+    assert.ok(Object.prototype.hasOwnProperty.call(after, CLOSE_MARKER), "read() never mutates recovery artifacts");
   });
 });

--- a/skills/dev-backlog/scripts/local-tracker.test.js
+++ b/skills/dev-backlog/scripts/local-tracker.test.js
@@ -418,7 +418,15 @@ describe("local canonical identity — fail closed on corruption", () => {
       seedCompleted: [["BACK-1 - archived.md", taskFile({ id: 1, title: "Archived", status: "Done" })]],
     });
     assert.throws(() => adapter.read("BACK-1"), LocalStoreError);
-    assert.throws(() => adapter.list({ state: "all" }), LocalStoreError);
+    for (const state of ["open", "closed", "all"]) {
+      assert.throws(
+        () => adapter.list({ state }),
+        (error) =>
+          error instanceof LocalStoreError &&
+          /exists in both active and completed|unique across the canonical stores/i.test(error.message),
+        `${state} filtering must not hide store-wide exact-id corruption`
+      );
+    }
   });
 });
 

--- a/skills/dev-backlog/scripts/local-tracker.test.js
+++ b/skills/dev-backlog/scripts/local-tracker.test.js
@@ -364,4 +364,147 @@ describe("local allocation critical section", () => {
     const strays = fs.readdirSync(path.join(backlogDir, "tasks")).filter((f) => f.includes(".tmp"));
     assert.deepEqual(strays, []);
   });
+
+  it("serializes update and close on the same store lock as create", (t) => {
+    const { adapter, backlogDir } = makeStore(t, {
+      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One" })]],
+    });
+    const contended = createLocalAdapter({
+      backlogDir,
+      now: FIXED_NOW,
+      lock: { retries: 0, delayMs: 1 },
+    });
+    const lockPath = path.join(backlogDir, ".local-tracker.lock");
+    fs.writeFileSync(lockPath, String(process.pid));
+
+    // A held store lock blocks update and close, not just create.
+    assert.throws(() => contended.update("BACK-1", { status: "In Progress" }), LocalStoreError);
+    assert.throws(() => contended.close("BACK-1"), LocalStoreError);
+    assert.match(read(backlogDir, "tasks", "BACK-1 - one.md"), /^status: To Do$/m);
+
+    fs.unlinkSync(lockPath);
+    adapter.update("BACK-1", { status: "In Progress" });
+    assert.ok(!fs.existsSync(lockPath), "update releases the store lock");
+    adapter.close("BACK-1");
+    assert.ok(!fs.existsSync(lockPath), "close releases the store lock");
+    assert.deepEqual(listNames(backlogDir, "completed"), ["BACK-1 - one.md"]);
+  });
+});
+
+describe("local canonical identity — fail closed on corruption", () => {
+  it("treats duplicate same-id files in one store as corruption", (t) => {
+    const { adapter } = makeStore(t, {
+      seedTasks: [
+        ["BACK-1 - one.md", taskFile({ id: 1, title: "One" })],
+        ["BACK-1 - dup.md", taskFile({ id: 1, title: "Dup" })],
+      ],
+    });
+    assert.throws(() => adapter.read("BACK-1"), LocalStoreError);
+    assert.throws(() => adapter.list(), LocalStoreError);
+  });
+
+  it("rejects a filename/frontmatter id mismatch rather than trusting the filename", (t) => {
+    const { adapter } = makeStore(t, {
+      seedTasks: [["BACK-1 - one.md", taskFile({ id: 2, title: "Mismatch" })]],
+    });
+    assert.throws(() => adapter.read("BACK-1"), LocalStoreError);
+    assert.throws(() => adapter.list(), LocalStoreError);
+  });
+
+  it("rejects the same id living in both active and completed stores", (t) => {
+    const { adapter } = makeStore(t, {
+      seedTasks: [["BACK-1 - active.md", taskFile({ id: 1, title: "Active" })]],
+      seedCompleted: [["BACK-1 - archived.md", taskFile({ id: 1, title: "Archived", status: "Done" })]],
+    });
+    assert.throws(() => adapter.read("BACK-1"), LocalStoreError);
+    assert.throws(() => adapter.list({ state: "all" }), LocalStoreError);
+  });
+});
+
+describe("local store-wide exact-id uniqueness on close", () => {
+  it("refuses to archive over a completed twin with a different slug and preserves bytes", (t) => {
+    const { adapter, backlogDir } = makeStore(t, {
+      seedTasks: [["BACK-1 - active-slug.md", taskFile({ id: 1, title: "Active", body: "\n## Description\nactive\n" })]],
+      seedCompleted: [["BACK-1 - other-slug.md", taskFile({ id: 1, title: "Other", status: "Done", body: "\n## Description\narchived\n" })]],
+    });
+    const activeBefore = read(backlogDir, "tasks", "BACK-1 - active-slug.md");
+    const completedBefore = read(backlogDir, "completed", "BACK-1 - other-slug.md");
+    assert.throws(() => adapter.close("BACK-1"), LocalStoreError);
+    assert.equal(read(backlogDir, "tasks", "BACK-1 - active-slug.md"), activeBefore);
+    assert.equal(read(backlogDir, "completed", "BACK-1 - other-slug.md"), completedBefore);
+    assert.deepEqual(listNames(backlogDir, "completed"), ["BACK-1 - other-slug.md"]);
+  });
+});
+
+describe("local rendered metadata round-trips through read", () => {
+  it("reads back non-empty labels and dependencies as arrays, not malformed objects", (t) => {
+    const { adapter } = makeStore(t);
+    adapter.create({
+      title: "Meta",
+      labels: ["infra", "urgent"],
+      dependencies: ["BACK-9", "BACK-8"],
+    });
+    const task = adapter.read("BACK-1");
+    assert.deepEqual(task.labels, ["infra", "urgent"]);
+    assert.deepEqual(task.dependencies, ["BACK-9", "BACK-8"]);
+    const listed = adapter.list().find((entry) => entry.ref === "BACK-1");
+    assert.deepEqual(listed.labels, ["infra", "urgent"]);
+    assert.deepEqual(listed.dependencies, ["BACK-9", "BACK-8"]);
+  });
+});
+
+describe("local body normalization", () => {
+  it("normalizes a create body without a leading newline into a readable task", (t) => {
+    const { adapter } = makeStore(t);
+    adapter.create({ title: "Plain", body: "just plain text without a leading newline" });
+    const task = adapter.read("BACK-1");
+    assert.match(task.body, /just plain text without a leading newline/);
+    assert.ok(task.body.startsWith("\n"), "body is separated from the frontmatter fence");
+  });
+
+  it("normalizes an update body without a leading newline", (t) => {
+    const { adapter } = makeStore(t, {
+      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One" })]],
+    });
+    adapter.update("BACK-1", { body: "replacement without a leading newline" });
+    const task = adapter.read("BACK-1");
+    assert.match(task.body, /replacement without a leading newline/);
+  });
+});
+
+describe("local canonical directory containment", () => {
+  it("rejects a task_prefix that could escape tasks/completed and reports unavailable", (t) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "local-tracker-esc-"));
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+    const backlogDir = path.join(root, "backlog");
+    fs.mkdirSync(path.join(backlogDir, "tasks"), { recursive: true });
+    fs.mkdirSync(path.join(backlogDir, "completed"), { recursive: true });
+
+    for (const bad of ["../ESC", "a/b", "a\\b", "..", "with space"]) {
+      const adapter = createLocalAdapter({ backlogDir, config: { task_prefix: bad }, now: FIXED_NOW });
+      assert.equal(adapter.availability().available, false, `prefix ${JSON.stringify(bad)} must be unavailable`);
+      assert.throws(() => adapter.create({ title: "Escape" }), LocalStoreError);
+    }
+
+    // Nothing escaped the canonical directories.
+    assert.deepEqual(fs.readdirSync(backlogDir).filter((name) => name.includes("ESC")), []);
+    assert.deepEqual(listNames(backlogDir, "tasks"), []);
+  });
+});
+
+describe("local pre-mutation unsupported-option failures", () => {
+  it("rejects provider-specific options on create, update, and close before mutating", (t) => {
+    const { adapter, backlogDir } = makeStore(t, {
+      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One" })]],
+    });
+    const before = read(backlogDir, "tasks", "BACK-1 - one.md");
+
+    assert.throws(() => adapter.create({ title: "Milestoned", milestone: "v1" }), LocalStoreError);
+    assert.throws(() => adapter.update("BACK-1", { status: "Done", milestone: "v1" }), LocalStoreError);
+    assert.throws(() => adapter.close("BACK-1", { reason: "done enough" }), LocalStoreError);
+
+    assert.equal(read(backlogDir, "tasks", "BACK-1 - one.md"), before, "no option-rejected mutation touched bytes");
+    assert.deepEqual(listNames(backlogDir, "tasks"), ["BACK-1 - one.md"]);
+    assert.deepEqual(listNames(backlogDir, "completed"), []);
+  });
 });

--- a/skills/dev-backlog/scripts/local-tracker.test.js
+++ b/skills/dev-backlog/scripts/local-tracker.test.js
@@ -879,3 +879,107 @@ describe("local publication cleans partial temp files when the write itself fail
     assert.ok(!fs.existsSync(path.join(backlogDir, ".local-tracker.lock")));
   });
 });
+
+const CLOSE_MARKER = ".local-tracker.close";
+
+function symlinkSupported(root) {
+  try {
+    const link = path.join(root, ".symlink-probe");
+    fs.symlinkSync(path.join(root, ".symlink-target"), link);
+    fs.unlinkSync(link);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("local rejects symlinked canonical paths", () => {
+  it("refuses a symlinked task file on read, list, and close without following it", (t) => {
+    const { root, backlogDir, adapter } = makeStore(t);
+    if (!symlinkSupported(root)) return; // platform without symlink privileges
+    // A real, well-formed task living OUTSIDE the backlog. A symlink in tasks/
+    // would let read/close follow it and touch bytes beyond the canonical store.
+    const outside = path.join(root, "outside.md");
+    fs.writeFileSync(outside, taskFile({ id: 1, title: "Outside", body: "\n## Description\nsecret\n" }));
+    fs.symlinkSync(outside, path.join(backlogDir, "tasks", "BACK-1 - one.md"));
+
+    assert.throws(() => adapter.read("BACK-1"), LocalStoreError);
+    assert.throws(() => adapter.list(), LocalStoreError);
+    assert.throws(() => adapter.close("BACK-1"), LocalStoreError);
+    assert.ok(fs.existsSync(outside), "the symlink target outside the backlog is never touched");
+  });
+
+  it("reports unavailable for a symlinked canonical directory", (t) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "local-tracker-symdir-"));
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+    if (!symlinkSupported(root)) return;
+    const backlogDir = path.join(root, "backlog");
+    fs.mkdirSync(backlogDir, { recursive: true });
+    fs.mkdirSync(path.join(backlogDir, "completed"), { recursive: true });
+    const elsewhere = path.join(root, "elsewhere");
+    fs.mkdirSync(elsewhere, { recursive: true });
+    fs.symlinkSync(elsewhere, path.join(backlogDir, "tasks")); // tasks/ is a symlink
+    const report = createLocalAdapter({ backlogDir, now: FIXED_NOW }).availability();
+    assert.equal(report.available, false);
+    assert.match(report.reason, /symlink/);
+  });
+});
+
+describe("local recovery treats the close journal as untrusted", () => {
+  function writeMarker(backlogDir, marker) {
+    fs.writeFileSync(path.join(backlogDir, CLOSE_MARKER), JSON.stringify(marker));
+  }
+
+  it("keeps list and read non-mutating when a stale marker is present", (t) => {
+    const { backlogDir, adapter } = makeStore(t, {
+      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One" })]],
+    });
+    writeMarker(backlogDir, { v: 1, phase: "publish", id: "1", ref: "BACK-1", file: "BACK-1 - one.md", destHash: "0".repeat(64) });
+    assert.equal(adapter.read("BACK-1").id, "1");
+    assert.equal(adapter.list().length, 1);
+    assert.ok(fs.existsSync(path.join(backlogDir, CLOSE_MARKER)), "read/list never delete the marker");
+    assert.ok(!fs.existsSync(path.join(backlogDir, ".local-tracker.lock")), "read/list never take the lock");
+  });
+
+  it("does not promote an unverified external destination or delete the active source", (t) => {
+    const { backlogDir, adapter } = makeStore(t, {
+      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One", body: "\n## Description\nauthoritative\n" })]],
+      seedCompleted: [["BACK-1 - one.md", taskFile({ id: 1, title: "External", status: "Done", body: "\n## Description\nexternal\n" })]],
+    });
+    const activeBefore = read(backlogDir, "tasks", "BACK-1 - one.md");
+    const externalBefore = read(backlogDir, "completed", "BACK-1 - one.md");
+    // Intent recorded, but the destination bytes never matched our publication.
+    writeMarker(backlogDir, { v: 1, phase: "publish", id: "1", ref: "BACK-1", file: "BACK-1 - one.md", destHash: "0".repeat(64) });
+
+    adapter.create({ title: "trigger recovery" }); // any mutation runs recover() first
+
+    assert.equal(read(backlogDir, "tasks", "BACK-1 - one.md"), activeBefore, "authoritative active source is retained");
+    assert.equal(read(backlogDir, "completed", "BACK-1 - one.md"), externalBefore, "the external destination is never promoted or altered");
+    assert.ok(!fs.existsSync(path.join(backlogDir, CLOSE_MARKER)), "the untrusted marker is discarded");
+  });
+
+  it("fails closed on a marker whose filename escapes the canonical store", (t) => {
+    const { root, backlogDir, adapter } = makeStore(t);
+    const victim = path.join(root, "victim.md");
+    fs.writeFileSync(victim, "do not delete me");
+    writeMarker(backlogDir, { v: 1, phase: "publish", id: "1", ref: "BACK-1", file: "../../victim.md", destHash: "0".repeat(64) });
+
+    adapter.create({ title: "trigger recovery" });
+
+    assert.ok(fs.existsSync(victim), "a traversal filename never reaches an unlink");
+    assert.ok(!fs.existsSync(path.join(backlogDir, CLOSE_MARKER)), "the malformed marker is cleared");
+  });
+
+  it("ignores a legacy absolute-path marker without deleting its targets", (t) => {
+    const { root, backlogDir, adapter } = makeStore(t);
+    const victim = path.join(root, "victim.md");
+    fs.writeFileSync(victim, "arbitrary file the old marker pointed at");
+    // The round-6 marker shape carried arbitrary absolute src/dest strings.
+    writeMarker(backlogDir, { src: victim, dest: victim });
+
+    adapter.create({ title: "trigger recovery" });
+
+    assert.ok(fs.existsSync(victim), "an untyped legacy marker cannot drive an arbitrary unlink");
+    assert.ok(!fs.existsSync(path.join(backlogDir, CLOSE_MARKER)), "the legacy marker is cleared");
+  });
+});

--- a/skills/dev-backlog/scripts/local-tracker.test.js
+++ b/skills/dev-backlog/scripts/local-tracker.test.js
@@ -548,7 +548,7 @@ describe("local close — unlink failure compensation and recovery", () => {
     assert.match(read(backlogDir, "completed", "BACK-1 - one.md"), /^status: Done$/m);
   });
 
-  it("does not erase an externally replaced completed destination during rollback", (t) => {
+  it("does not erase a byte-different replacement even when rollback sees the same dev and inode", (t) => {
     const { backlogDir } = makeStore(t, {
       seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One", body: "\n## Description\nactive\n" })]],
     });
@@ -558,8 +558,14 @@ describe("local close — unlink failure compensation and recovery", () => {
       backlogDir,
       now: FIXED_NOW,
       testHooks: {
+        rollbackFileIdentity() {
+          // Model Linux immediately reusing the publication's dev+ino for the
+          // replacement. Content evidence must independently veto deletion.
+          return { dev: 7, ino: 11 };
+        },
         beforeUnlinkSource() {
-          // Simulate another writer swapping our fresh publication for their own inode.
+          // Simulate another writer swapping our fresh publication while the
+          // filesystem reports the same projected identity for both files.
           fs.rmSync(completedPath);
           fs.writeFileSync(completedPath, external);
           throw new Error("injected source unlink failure");

--- a/skills/dev-backlog/scripts/local-tracker.test.js
+++ b/skills/dev-backlog/scripts/local-tracker.test.js
@@ -83,8 +83,8 @@ describe("local create — allocation, atomic publish, identity", () => {
     const second = adapter.create({ title: "Second task" });
     assert.equal(second.id, "2");
     assert.deepEqual(listNames(backlogDir, "tasks"), [
-      "BACK-1 - First-task.md",
-      "BACK-2 - Second-task.md",
+      "BACK-1 - first-task.md",
+      "BACK-2 - second-task.md",
     ]);
   });
 
@@ -114,7 +114,7 @@ describe("local create — allocation, atomic publish, identity", () => {
     });
     const sub = adapter.create({ title: "Child", id: "1.2" });
     assert.deepEqual(sub, { tracker: "local", id: "1.2", ref: "BACK-1.2" });
-    assert.ok(fs.existsSync(path.join(backlogDir, "tasks", "BACK-1.2 - Child.md")));
+    assert.ok(fs.existsSync(path.join(backlogDir, "tasks", "BACK-1.2 - child.md")));
     // parent allocation still counts only integer parents
     assert.equal(adapter.create({ title: "Sibling" }).id, "2");
   });
@@ -319,7 +319,7 @@ describe("local authority — no capabilities and no gh", () => {
     adapter.close(id);
 
     assert.equal(fs.existsSync(marker), false, "gh must never be invoked by the local adapter");
-    assert.deepEqual(listNames(backlogDir, "completed"), ["BACK-1 - Cycle.md"]);
+    assert.deepEqual(listNames(backlogDir, "completed"), ["BACK-1 - cycle.md"]);
   });
 
   it("reports no optional capabilities", (t) => {

--- a/skills/dev-backlog/scripts/local-tracker.test.js
+++ b/skills/dev-backlog/scripts/local-tracker.test.js
@@ -1,0 +1,367 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  createLocalAdapter,
+  LocalStoreError,
+} = require("./local-tracker.js");
+const { REQUIRED_ADAPTER_OPERATIONS } = require("./tracker.js");
+
+const FIXED_NOW = () => new Date("2026-07-11T09:00:00Z");
+
+function makeStore(t, { seedTasks = [], seedCompleted = [] } = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "local-tracker-"));
+  const backlogDir = path.join(root, "backlog");
+  fs.mkdirSync(path.join(backlogDir, "tasks"), { recursive: true });
+  fs.mkdirSync(path.join(backlogDir, "completed"), { recursive: true });
+  fs.writeFileSync(
+    path.join(backlogDir, "config.yml"),
+    'tracker: local\ntask_prefix: "BACK"\ndefault_status: "To Do"\nstatuses: ["To Do", "In Progress", "Done"]\n'
+  );
+  for (const [name, content] of seedTasks) {
+    fs.writeFileSync(path.join(backlogDir, "tasks", name), content);
+  }
+  for (const [name, content] of seedCompleted) {
+    fs.writeFileSync(path.join(backlogDir, "completed", name), content);
+  }
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return { root, backlogDir, adapter: createLocalAdapter({ backlogDir, now: FIXED_NOW }) };
+}
+
+function taskFile({ id, title, status = "To Do", body = "\n## Description\nseed body\n" }) {
+  return (
+    `---\n` +
+    `id: BACK-${id}\n` +
+    `title: ${title}\n` +
+    `status: ${status}\n` +
+    `labels: []\n` +
+    `priority: medium\n` +
+    `created_date: '2026-07-01'\n` +
+    `---` +
+    body
+  );
+}
+
+function read(backlogDir, dir, name) {
+  return fs.readFileSync(path.join(backlogDir, dir, name), "utf-8");
+}
+
+function listNames(backlogDir, dir) {
+  return fs.readdirSync(path.join(backlogDir, dir)).filter((f) => f.endsWith(".md")).sort();
+}
+
+describe("local adapter shape and authority", () => {
+  it("exposes exactly the seven required operations and empty capabilities", (t) => {
+    const { adapter } = makeStore(t);
+    assert.deepEqual(Object.keys(adapter), REQUIRED_ADAPTER_OPERATIONS);
+    assert.deepEqual(adapter.capabilities(), []);
+    assert.deepEqual(adapter.availability(), { available: true });
+  });
+
+  it("reports an actionable unavailable reason for a malformed store without fallback", (t) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "local-tracker-bad-"));
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+    const filePath = path.join(root, "not-a-dir");
+    fs.writeFileSync(filePath, "i am a file");
+    const adapter = createLocalAdapter({ backlogDir: filePath, now: FIXED_NOW });
+    const report = adapter.availability();
+    assert.equal(report.available, false);
+    assert.ok(typeof report.reason === "string" && report.reason.trim().length > 0);
+  });
+});
+
+describe("local create — allocation, atomic publish, identity", () => {
+  it("allocates the next positive parent id and returns a normalized url-free identity", (t) => {
+    const { adapter, backlogDir } = makeStore(t);
+    const first = adapter.create({ title: "First task" });
+    assert.deepEqual(first, { tracker: "local", id: "1", ref: "BACK-1" });
+    assert.equal(Object.prototype.hasOwnProperty.call(first, "url"), false);
+
+    const second = adapter.create({ title: "Second task" });
+    assert.equal(second.id, "2");
+    assert.deepEqual(listNames(backlogDir, "tasks"), [
+      "BACK-1 - First-task.md",
+      "BACK-2 - Second-task.md",
+    ]);
+  });
+
+  it("allocates across active and completed exact-prefix files", (t) => {
+    const { adapter } = makeStore(t, {
+      seedTasks: [["BACK-3 - active.md", taskFile({ id: 3, title: "Active" })]],
+      seedCompleted: [["BACK-7 - done.md", taskFile({ id: 7, title: "Done", status: "Done" })]],
+    });
+    assert.equal(adapter.create({ title: "Next" }).id, "8");
+  });
+
+  it("keeps BACK-1 and BACK-11 distinct when choosing the next id", (t) => {
+    const { adapter } = makeStore(t, {
+      seedTasks: [
+        ["BACK-1 - one.md", taskFile({ id: 1, title: "One" })],
+        ["BACK-11 - eleven.md", taskFile({ id: 11, title: "Eleven" })],
+      ],
+    });
+    assert.equal(adapter.create({ title: "After" }).id, "12");
+    assert.equal(adapter.read("BACK-1").id, "1");
+    assert.equal(adapter.read("BACK-11").id, "11");
+  });
+
+  it("creates an explicit free decimal subtask without disturbing parent allocation", (t) => {
+    const { adapter, backlogDir } = makeStore(t, {
+      seedTasks: [["BACK-1 - parent.md", taskFile({ id: 1, title: "Parent" })]],
+    });
+    const sub = adapter.create({ title: "Child", id: "1.2" });
+    assert.deepEqual(sub, { tracker: "local", id: "1.2", ref: "BACK-1.2" });
+    assert.ok(fs.existsSync(path.join(backlogDir, "tasks", "BACK-1.2 - Child.md")));
+    // parent allocation still counts only integer parents
+    assert.equal(adapter.create({ title: "Sibling" }).id, "2");
+  });
+
+  it("refuses an explicit id that already exists and leaves the store untouched", (t) => {
+    const { adapter, backlogDir } = makeStore(t, {
+      seedTasks: [["BACK-1 - parent.md", taskFile({ id: 1, title: "Parent" })]],
+    });
+    const before = read(backlogDir, "tasks", "BACK-1 - parent.md");
+    assert.throws(() => adapter.create({ title: "Dup", id: "1" }), LocalStoreError);
+    assert.equal(read(backlogDir, "tasks", "BACK-1 - parent.md"), before);
+    assert.deepEqual(listNames(backlogDir, "tasks"), ["BACK-1 - parent.md"]);
+    assert.ok(!fs.existsSync(path.join(backlogDir, ".local-tracker.lock")));
+  });
+
+  it("rejects missing/blank titles before any filesystem mutation", (t) => {
+    const { adapter, backlogDir } = makeStore(t);
+    for (const bad of [undefined, "", "   ", 5, null]) {
+      assert.throws(() => adapter.create({ title: bad }), LocalStoreError);
+    }
+    assert.deepEqual(listNames(backlogDir, "tasks"), []);
+  });
+
+  it("rejects an explicit foreign-prefix or malformed id", (t) => {
+    const { adapter } = makeStore(t);
+    for (const bad of ["OTHER-1", "BACK-1", "0", "1.0", "1.2.3", "-1", "x"]) {
+      assert.throws(() => adapter.create({ title: "T", id: bad }), LocalStoreError);
+    }
+  });
+});
+
+describe("local list and read", () => {
+  it("lists open, closed, and all exact-prefix tasks and skips foreign/malformed files", (t) => {
+    const { adapter } = makeStore(t, {
+      seedTasks: [
+        ["BACK-1 - one.md", taskFile({ id: 1, title: "One" })],
+        ["BACK-2 - two.md", taskFile({ id: 2, title: "Two", status: "In Progress" })],
+        ["OTHER-9 - foreign.md", taskFile({ id: 9, title: "Foreign" })],
+        ["not-a-task.md", "no frontmatter here"],
+      ],
+      seedCompleted: [
+        ["BACK-5 - five.md", taskFile({ id: 5, title: "Five", status: "Done" })],
+      ],
+    });
+
+    const open = adapter.list();
+    assert.deepEqual(open.map((t2) => t2.ref), ["BACK-1", "BACK-2"]);
+    assert.equal(open.every((t2) => t2.tracker === "local" && t2.state === "open"), true);
+    assert.equal(open.every((t2) => !("url" in t2)), true);
+
+    const closed = adapter.list({ state: "closed" });
+    assert.deepEqual(closed.map((t2) => t2.ref), ["BACK-5"]);
+    assert.equal(closed[0].state, "closed");
+
+    const all = adapter.list({ state: "all" });
+    assert.deepEqual(all.map((t2) => t2.ref), ["BACK-1", "BACK-2", "BACK-5"]);
+  });
+
+  it("reads one task by identity, ref string, or bare id and exposes neutral fields", (t) => {
+    const { adapter } = makeStore(t, {
+      seedTasks: [["BACK-2 - two.md", taskFile({ id: 2, title: "Two", status: "In Progress" })]],
+      seedCompleted: [["BACK-5 - five.md", taskFile({ id: 5, title: "Five", status: "Done" })]],
+    });
+    for (const selector of ["BACK-2", "2", { tracker: "local", id: "2", ref: "BACK-2" }]) {
+      const task = adapter.read(selector);
+      assert.equal(task.id, "2");
+      assert.equal(task.title, "Two");
+      assert.equal(task.status, "In Progress");
+      assert.equal(task.state, "open");
+      assert.equal("url" in task, false);
+    }
+    assert.equal(adapter.read("BACK-5").state, "closed");
+  });
+
+  it("does not mutate files during list/read", (t) => {
+    const { adapter, backlogDir } = makeStore(t, {
+      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One" })]],
+    });
+    const before = read(backlogDir, "tasks", "BACK-1 - one.md");
+    adapter.list({ state: "all" });
+    adapter.read("BACK-1");
+    assert.equal(read(backlogDir, "tasks", "BACK-1 - one.md"), before);
+  });
+
+  it("rejects a foreign-prefix read selector rather than inferring it", (t) => {
+    const { adapter } = makeStore(t);
+    assert.throws(() => adapter.read("OTHER-1"), LocalStoreError);
+    assert.throws(() => adapter.read("BACK-404"), LocalStoreError);
+  });
+});
+
+describe("local update — metadata/state without body loss", () => {
+  it("changes only requested fields and preserves body/AC bytes exactly", (t) => {
+    const body =
+      "\n## Description\nHuman authored prose with UTF-8 ☕ and trailing spaces.  \n" +
+      "\n## Acceptance Criteria\n<!-- AC:BEGIN -->\n- [x] done item\n- [ ] pending item\n<!-- AC:END -->\n";
+    const { adapter, backlogDir } = makeStore(t, {
+      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One", body })]],
+    });
+    const original = read(backlogDir, "tasks", "BACK-1 - one.md");
+    const originalBody = original.slice(original.indexOf("\n## Description"));
+
+    adapter.update("BACK-1", { status: "In Progress" });
+    const updated = read(backlogDir, "tasks", "BACK-1 - one.md");
+    const updatedBody = updated.slice(updated.indexOf("\n## Description"));
+
+    assert.equal(updatedBody, originalBody, "body bytes must be preserved");
+    assert.match(updated, /^status: In Progress$/m);
+    assert.equal(adapter.read("BACK-1").status, "In Progress");
+  });
+
+  it("preserves unrelated frontmatter and only rewrites the requested keys", (t) => {
+    const { adapter, backlogDir } = makeStore(t, {
+      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One" })]],
+    });
+    adapter.update("BACK-1", { labels: ["infra", "urgent"], priority: "high" });
+    const updated = read(backlogDir, "tasks", "BACK-1 - one.md");
+    assert.match(updated, /^priority: high$/m);
+    assert.match(updated, /^labels:\n {2}- infra\n {2}- urgent$/m);
+    assert.match(updated, /^created_date: '2026-07-01'$/m);
+    assert.match(updated, /^id: BACK-1$/m);
+  });
+
+  it("replaces the body only when the caller supplies one explicitly", (t) => {
+    const { adapter, backlogDir } = makeStore(t, {
+      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One" })]],
+    });
+    adapter.update("BACK-1", { body: "\n## Description\nrewritten by caller\n" });
+    const updated = read(backlogDir, "tasks", "BACK-1 - one.md");
+    assert.match(updated, /rewritten by caller/);
+  });
+
+  it("refuses to update a task that is not active", (t) => {
+    const { adapter } = makeStore(t, {
+      seedCompleted: [["BACK-5 - five.md", taskFile({ id: 5, title: "Five", status: "Done" })]],
+    });
+    assert.throws(() => adapter.update("BACK-5", { status: "To Do" }), LocalStoreError);
+    assert.throws(() => adapter.update("BACK-404", { status: "To Do" }), LocalStoreError);
+  });
+});
+
+describe("local close — exact archive without overwrite", () => {
+  it("moves exactly one active task to completed with status Done and preserved body", (t) => {
+    const body = "\n## Description\nkeep me\n";
+    const { adapter, backlogDir } = makeStore(t, {
+      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One", body })]],
+    });
+    const closed = adapter.close("BACK-1");
+    assert.deepEqual(closed, { tracker: "local", id: "1", ref: "BACK-1" });
+    assert.deepEqual(listNames(backlogDir, "tasks"), []);
+    assert.deepEqual(listNames(backlogDir, "completed"), ["BACK-1 - one.md"]);
+    const archived = read(backlogDir, "completed", "BACK-1 - one.md");
+    assert.match(archived, /^status: Done$/m);
+    assert.ok(archived.includes("keep me"));
+  });
+
+  it("refuses to overwrite an existing completed destination and keeps both files", (t) => {
+    const { adapter, backlogDir } = makeStore(t, {
+      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One", body: "\n## Description\nactive\n" })]],
+      seedCompleted: [["BACK-1 - one.md", taskFile({ id: 1, title: "One", status: "Done", body: "\n## Description\narchived\n" })]],
+    });
+    const beforeCompleted = read(backlogDir, "completed", "BACK-1 - one.md");
+    assert.throws(() => adapter.close("BACK-1"), LocalStoreError);
+    assert.equal(read(backlogDir, "completed", "BACK-1 - one.md"), beforeCompleted);
+    assert.ok(fs.existsSync(path.join(backlogDir, "tasks", "BACK-1 - one.md")));
+  });
+
+  it("is idempotent when the task is already closed", (t) => {
+    const { adapter, backlogDir } = makeStore(t, {
+      seedCompleted: [["BACK-5 - five.md", taskFile({ id: 5, title: "Five", status: "Done" })]],
+    });
+    const before = read(backlogDir, "completed", "BACK-5 - five.md");
+    const result = adapter.close("BACK-5");
+    assert.deepEqual(result, { tracker: "local", id: "5", ref: "BACK-5" });
+    assert.equal(read(backlogDir, "completed", "BACK-5 - five.md"), before);
+  });
+
+  it("throws for a task that exists in neither store", (t) => {
+    const { adapter } = makeStore(t);
+    assert.throws(() => adapter.close("BACK-404"), LocalStoreError);
+  });
+});
+
+describe("local authority — no capabilities and no gh", () => {
+  it("runs a full create/read/update/close cycle without invoking gh", (t) => {
+    const { adapter, backlogDir } = makeStore(t);
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "local-tracker-bin-"));
+    t.after(() => fs.rmSync(binDir, { recursive: true, force: true }));
+    const marker = path.join(binDir, "gh-was-called");
+    fs.writeFileSync(path.join(binDir, "gh"), `#!/bin/sh\ntouch "${marker}"\nexit 1\n`);
+    fs.chmodSync(path.join(binDir, "gh"), 0o755);
+
+    const savedPath = process.env.PATH;
+    process.env.PATH = `${binDir}:${savedPath}`;
+    t.after(() => {
+      process.env.PATH = savedPath;
+    });
+
+    const id = adapter.create({ title: "Cycle" });
+    adapter.read(id);
+    adapter.update(id, { status: "In Progress" });
+    adapter.close(id);
+
+    assert.equal(fs.existsSync(marker), false, "gh must never be invoked by the local adapter");
+    assert.deepEqual(listNames(backlogDir, "completed"), ["BACK-1 - Cycle.md"]);
+  });
+
+  it("reports no optional capabilities", (t) => {
+    const { adapter } = makeStore(t);
+    assert.deepEqual(adapter.capabilities(), []);
+  });
+});
+
+describe("local allocation critical section", () => {
+  it("fails clearly on lock contention and never removes a lock it does not own", (t) => {
+    const { adapter, backlogDir } = makeStore(t);
+    const contended = createLocalAdapter({
+      backlogDir,
+      now: FIXED_NOW,
+      lock: { retries: 0, delayMs: 1 },
+    });
+    const lockPath = path.join(backlogDir, ".local-tracker.lock");
+    fs.writeFileSync(lockPath, String(process.pid));
+    assert.throws(() => contended.create({ title: "Blocked" }), LocalStoreError);
+    assert.ok(fs.existsSync(lockPath), "foreign lock must be preserved");
+    assert.deepEqual(listNames(backlogDir, "tasks"), []);
+
+    fs.unlinkSync(lockPath);
+    assert.equal(adapter.create({ title: "After release" }).id, "1");
+    assert.ok(!fs.existsSync(lockPath), "lock is released on the success path");
+  });
+
+  it("cleans up the lock and temp files when publication fails mid-operation", (t) => {
+    const { backlogDir } = makeStore(t);
+    const adapter = createLocalAdapter({
+      backlogDir,
+      now: FIXED_NOW,
+      testHooks: {
+        beforePublish() {
+          throw new Error("injected publish failure");
+        },
+      },
+    });
+    assert.throws(() => adapter.create({ title: "Boom" }));
+    assert.deepEqual(listNames(backlogDir, "tasks"), []);
+    assert.ok(!fs.existsSync(path.join(backlogDir, ".local-tracker.lock")));
+    const strays = fs.readdirSync(path.join(backlogDir, "tasks")).filter((f) => f.includes(".tmp"));
+    assert.deepEqual(strays, []);
+  });
+});

--- a/skills/dev-backlog/scripts/local-tracker.test.js
+++ b/skills/dev-backlog/scripts/local-tracker.test.js
@@ -508,3 +508,252 @@ describe("local pre-mutation unsupported-option failures", () => {
     assert.deepEqual(listNames(backlogDir, "completed"), []);
   });
 });
+
+function strays(backlogDir, dir) {
+  return fs.readdirSync(path.join(backlogDir, dir)).filter((name) => name.includes(".tmp"));
+}
+
+describe("local close — unlink failure compensation and recovery", () => {
+  it("rolls back the completed publication when the source unlink fails", (t) => {
+    const { backlogDir } = makeStore(t, {
+      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One", body: "\n## Description\nkeep\n" })]],
+    });
+    const adapter = createLocalAdapter({
+      backlogDir,
+      now: FIXED_NOW,
+      testHooks: {
+        beforeUnlinkSource() {
+          throw new Error("injected source unlink failure");
+        },
+      },
+    });
+    const before = read(backlogDir, "tasks", "BACK-1 - one.md");
+    assert.throws(() => adapter.close("BACK-1"), LocalStoreError);
+
+    // Exactly one intact authoritative copy remains: the byte-identical active source.
+    assert.equal(read(backlogDir, "tasks", "BACK-1 - one.md"), before);
+    assert.deepEqual(listNames(backlogDir, "tasks"), ["BACK-1 - one.md"]);
+    assert.deepEqual(listNames(backlogDir, "completed"), []);
+    // Lock and temp state are cleaned on the failure path.
+    assert.ok(!fs.existsSync(path.join(backlogDir, ".local-tracker.lock")));
+    assert.deepEqual(strays(backlogDir, "tasks"), []);
+    assert.deepEqual(strays(backlogDir, "completed"), []);
+
+    // Recovery: once the fault clears, a fresh close archives cleanly.
+    const healthy = createLocalAdapter({ backlogDir, now: FIXED_NOW });
+    healthy.close("BACK-1");
+    assert.deepEqual(listNames(backlogDir, "tasks"), []);
+    assert.deepEqual(listNames(backlogDir, "completed"), ["BACK-1 - one.md"]);
+    assert.match(read(backlogDir, "completed", "BACK-1 - one.md"), /^status: Done$/m);
+  });
+
+  it("does not erase an externally replaced completed destination during rollback", (t) => {
+    const { backlogDir } = makeStore(t, {
+      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One", body: "\n## Description\nactive\n" })]],
+    });
+    const completedPath = path.join(backlogDir, "completed", "BACK-1 - one.md");
+    const external = taskFile({ id: 1, title: "External owner", status: "Done", body: "\n## Description\nexternal\n" });
+    const adapter = createLocalAdapter({
+      backlogDir,
+      now: FIXED_NOW,
+      testHooks: {
+        beforeUnlinkSource() {
+          // Simulate another writer swapping our fresh publication for their own inode.
+          fs.rmSync(completedPath);
+          fs.writeFileSync(completedPath, external);
+          throw new Error("injected source unlink failure");
+        },
+      },
+    });
+    assert.throws(() => adapter.close("BACK-1"), (error) => error instanceof LocalStoreError && /both/.test(error.message));
+
+    // The externally owned destination is preserved byte-for-byte, and the active source survives.
+    assert.equal(fs.readFileSync(completedPath, "utf-8"), external);
+    assert.ok(fs.existsSync(path.join(backlogDir, "tasks", "BACK-1 - one.md")));
+    assert.ok(!fs.existsSync(path.join(backlogDir, ".local-tracker.lock")));
+    assert.deepEqual(strays(backlogDir, "completed"), []);
+  });
+
+  it("preserves both copies and reports a split store when rollback also fails", (t) => {
+    const { backlogDir } = makeStore(t, {
+      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One", body: "\n## Description\nkeep\n" })]],
+    });
+    const adapter = createLocalAdapter({
+      backlogDir,
+      now: FIXED_NOW,
+      testHooks: {
+        beforeUnlinkSource() {
+          throw new Error("injected source unlink failure");
+        },
+        beforeRollback() {
+          throw new Error("injected rollback failure");
+        },
+      },
+    });
+    assert.throws(() => adapter.close("BACK-1"), (error) => error instanceof LocalStoreError && /both/.test(error.message));
+
+    // No data loss: both the active source and the completed copy stay intact.
+    assert.ok(fs.existsSync(path.join(backlogDir, "tasks", "BACK-1 - one.md")));
+    assert.deepEqual(listNames(backlogDir, "completed"), ["BACK-1 - one.md"]);
+    assert.ok(!fs.existsSync(path.join(backlogDir, ".local-tracker.lock")));
+    assert.deepEqual(strays(backlogDir, "completed"), []);
+
+    // The store now fails closed on the duplicate id until an operator resolves it.
+    const healthy = createLocalAdapter({ backlogDir, now: FIXED_NOW });
+    assert.throws(() => healthy.read("BACK-1"), LocalStoreError);
+    assert.throws(() => healthy.list({ state: "all" }), LocalStoreError);
+
+    // Recovery: removing the duplicate completed copy restores a clean close.
+    fs.rmSync(path.join(backlogDir, "completed", "BACK-1 - one.md"));
+    healthy.close("BACK-1");
+    assert.deepEqual(listNames(backlogDir, "tasks"), []);
+    assert.deepEqual(listNames(backlogDir, "completed"), ["BACK-1 - one.md"]);
+  });
+});
+
+describe("local required frontmatter validation", () => {
+  const INVALID = {
+    "missing id": "---\ntitle: One\nstatus: To Do\n---\n## Description\nx\n",
+    "missing title": "---\nid: BACK-1\nstatus: To Do\n---\n## Description\nx\n",
+    "missing status": "---\nid: BACK-1\ntitle: One\n---\n## Description\nx\n",
+    "duplicate id": "---\nid: BACK-1\nid: BACK-1\ntitle: One\nstatus: To Do\n---\n## Description\nx\n",
+    "wrong-type title": "---\nid: BACK-1\ntitle:\n  - a\n  - b\nstatus: To Do\n---\n## Description\nx\n",
+    "empty status": "---\nid: BACK-1\ntitle: One\nstatus: ''\n---\n## Description\nx\n",
+    "no frontmatter": "just a body, no frontmatter fence\n",
+  };
+  for (const [label, content] of Object.entries(INVALID)) {
+    it(`rejects ${label} on read and list before returning a task`, (t) => {
+      const { adapter } = makeStore(t, { seedTasks: [["BACK-1 - one.md", content]] });
+      assert.throws(() => adapter.read("BACK-1"), LocalStoreError);
+      assert.throws(() => adapter.list(), LocalStoreError);
+      assert.throws(() => adapter.list({ state: "all" }), LocalStoreError);
+    });
+  }
+
+  it("requires the frontmatter id to equal the filename ref", (t) => {
+    const { adapter } = makeStore(t, {
+      seedTasks: [["BACK-1 - one.md", taskFile({ id: 2, title: "Mismatch" })]],
+    });
+    assert.throws(() => adapter.read("BACK-1"), LocalStoreError);
+    assert.throws(() => adapter.list(), LocalStoreError);
+  });
+
+  it("rejects invalid required frontmatter on update and close before mutating", (t) => {
+    const missingStatus = "---\nid: BACK-1\ntitle: One\n---\n## Description\nx\n";
+    const { adapter, backlogDir } = makeStore(t, {
+      seedTasks: [["BACK-1 - one.md", missingStatus]],
+    });
+    const before = read(backlogDir, "tasks", "BACK-1 - one.md");
+    assert.throws(() => adapter.update("BACK-1", { status: "In Progress" }), LocalStoreError);
+    assert.throws(() => adapter.close("BACK-1"), LocalStoreError);
+    assert.equal(read(backlogDir, "tasks", "BACK-1 - one.md"), before, "no mutation touched bytes");
+    assert.deepEqual(listNames(backlogDir, "completed"), []);
+  });
+
+  it("accepts a well-formed task the way create renders it", (t) => {
+    const { adapter } = makeStore(t);
+    adapter.create({ title: "Well formed", labels: ["a"], dependencies: ["BACK-9"] });
+    assert.equal(adapter.read("BACK-1").title, "Well formed");
+    assert.deepEqual(adapter.list().map((task) => task.ref), ["BACK-1"]);
+  });
+});
+
+describe("local metadata injection is rejected fail-closed", () => {
+  const CREATE_INJECTIONS = {
+    status: "In Progress\ninjected: true",
+    title: "Title\nid: BACK-999",
+    priority: "high\nmalicious: 1",
+  };
+  for (const [field, value] of Object.entries(CREATE_INJECTIONS)) {
+    it(`rejects a newline-injecting ${field} on create without writing`, (t) => {
+      const { adapter, backlogDir } = makeStore(t);
+      const input = { title: field === "title" ? value : "Safe", [field]: value };
+      assert.throws(() => adapter.create(input), LocalStoreError);
+      assert.deepEqual(listNames(backlogDir, "tasks"), []);
+      assert.ok(!fs.existsSync(path.join(backlogDir, ".local-tracker.lock")));
+      assert.deepEqual(strays(backlogDir, "tasks"), []);
+    });
+  }
+
+  it("rejects newline-injecting labels and dependencies on create", (t) => {
+    const { adapter, backlogDir } = makeStore(t);
+    assert.throws(() => adapter.create({ title: "Safe", labels: ["ok", "bad\nid: BACK-999"] }), LocalStoreError);
+    assert.throws(() => adapter.create({ title: "Safe", dependencies: ["BACK-2\ninjected: true"] }), LocalStoreError);
+    assert.deepEqual(listNames(backlogDir, "tasks"), []);
+  });
+
+  it("also rejects carriage returns, NUL, and tabs in scalar metadata", (t) => {
+    const { adapter, backlogDir } = makeStore(t);
+    for (const bad of ["A\rB", "A B", "A\tB"]) {
+      assert.throws(() => adapter.create({ title: "Safe", status: bad }), LocalStoreError);
+    }
+    assert.throws(() => adapter.create({ title: "Tab\tinject" }), LocalStoreError);
+    assert.deepEqual(listNames(backlogDir, "tasks"), []);
+  });
+
+  it("rejects injection on update and leaves bytes and mtime unchanged", (t) => {
+    const { adapter, backlogDir } = makeStore(t, {
+      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One" })]],
+    });
+    const filePath = path.join(backlogDir, "tasks", "BACK-1 - one.md");
+    const before = fs.readFileSync(filePath, "utf-8");
+    const mtimeBefore = fs.statSync(filePath).mtimeMs;
+    const injections = [
+      { status: "Done\ninjected: true" },
+      { title: "New\nid: BACK-9" },
+      { priority: "high\nx: 1" },
+      { labels: ["ok", "bad\nkey: v"] },
+      { dependencies: ["BACK-2\nkey: v"] },
+      { updated_date: "2026-07-11\ninjected: true" },
+    ];
+    for (const change of injections) {
+      assert.throws(() => adapter.update("BACK-1", change), LocalStoreError);
+    }
+    assert.equal(fs.readFileSync(filePath, "utf-8"), before, "bytes unchanged");
+    assert.equal(fs.statSync(filePath).mtimeMs, mtimeBefore, "mtime unchanged (no temp/mtime mutation)");
+    assert.ok(!fs.existsSync(path.join(backlogDir, ".local-tracker.lock")));
+    assert.deepEqual(strays(backlogDir, "tasks"), []);
+  });
+});
+
+describe("local update no-op and list-state validation edges", () => {
+  it("treats update with no changes as a byte and mtime no-op", (t) => {
+    const { adapter, backlogDir } = makeStore(t, {
+      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One" })]],
+    });
+    const filePath = path.join(backlogDir, "tasks", "BACK-1 - one.md");
+    const before = fs.readFileSync(filePath, "utf-8");
+    const mtimeBefore = fs.statSync(filePath).mtimeMs;
+    const result = adapter.update("BACK-1", {});
+    assert.deepEqual(result, { tracker: "local", id: "1", ref: "BACK-1" });
+    assert.equal(fs.readFileSync(filePath, "utf-8"), before, "bytes unchanged");
+    assert.equal(fs.statSync(filePath).mtimeMs, mtimeBefore, "mtime unchanged");
+    assert.deepEqual(strays(backlogDir, "tasks"), []);
+  });
+
+  it("no-ops when every requested field already holds its current value", (t) => {
+    const { adapter, backlogDir } = makeStore(t, {
+      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One", status: "To Do" })]],
+    });
+    const filePath = path.join(backlogDir, "tasks", "BACK-1 - one.md");
+    const before = fs.readFileSync(filePath, "utf-8");
+    const mtimeBefore = fs.statSync(filePath).mtimeMs;
+    adapter.update("BACK-1", { status: "To Do" });
+    assert.equal(fs.readFileSync(filePath, "utf-8"), before, "value-preserving update keeps bytes");
+    assert.equal(fs.statSync(filePath).mtimeMs, mtimeBefore, "value-preserving update keeps mtime");
+  });
+
+  it("rejects an invalid list state instead of silently defaulting to open", (t) => {
+    const { adapter } = makeStore(t, {
+      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One" })]],
+      seedCompleted: [["BACK-5 - five.md", taskFile({ id: 5, title: "Five", status: "Done" })]],
+    });
+    for (const bad of ["opened", "OPEN", "active", "Open", "", null, 1, "toString", "__proto__"]) {
+      assert.throws(() => adapter.list({ state: bad }), LocalStoreError);
+    }
+    assert.deepEqual(adapter.list({ state: "open" }).map((task) => task.ref), ["BACK-1"]);
+    assert.deepEqual(adapter.list({ state: "closed" }).map((task) => task.ref), ["BACK-5"]);
+    assert.deepEqual(adapter.list({ state: "all" }).map((task) => task.ref), ["BACK-1", "BACK-5"]);
+    assert.deepEqual(adapter.list().map((task) => task.ref), ["BACK-1"]);
+  });
+});

--- a/skills/dev-backlog/scripts/tracker.js
+++ b/skills/dev-backlog/scripts/tracker.js
@@ -6,6 +6,7 @@
  */
 
 const { createGithubAdapter } = require("./github-tracker.js");
+const { createLocalAdapter } = require("./local-tracker.js");
 
 const TRACKER_KEYS = Object.freeze(["github", "local"]);
 const REQUIRED_ADAPTER_OPERATIONS = Object.freeze([
@@ -26,8 +27,7 @@ const CAPABILITY_NAMES = Object.freeze([
   "closing-semantics",
 ]);
 
-const LOCAL_UNAVAILABLE_REASON =
-  "local tracker persistence is not implemented; issue #276 adds it";
+const DEFAULT_BACKLOG_DIR = "backlog";
 
 class TrackerConfigurationError extends Error {
   constructor(value) {
@@ -171,10 +171,12 @@ function resolveTracker(config, { adapters = TRACKER_ADAPTERS } = {}) {
   return Object.freeze({ tracker, adapter, availability });
 }
 
-function resolveConfiguredTracker(config, { execFile, adapters } = {}) {
-  const registered = adapters || (execFile
-    ? { ...TRACKER_ADAPTERS, github: createGithubAdapter({ execFile }) }
-    : TRACKER_ADAPTERS);
+function resolveConfiguredTracker(config, { execFile, adapters, backlogDir } = {}) {
+  const registered = adapters || {
+    ...TRACKER_ADAPTERS,
+    github: execFile ? createGithubAdapter({ execFile }) : TRACKER_ADAPTERS.github,
+    local: backlogDir ? createLocalAdapter({ backlogDir }) : TRACKER_ADAPTERS.local,
+  };
   return resolveTracker(config, { adapters: registered });
 }
 
@@ -271,21 +273,9 @@ function invokeCapability(resolved, capability, operation, ...args) {
   return operation(...args);
 }
 
-function unavailableLocalOperation() {
-  throw new TrackerUnavailableError("local", LOCAL_UNAVAILABLE_REASON);
-}
-
 const TRACKER_ADAPTERS = Object.freeze({
   github: createGithubAdapter(),
-  local: Object.freeze({
-    availability: () => ({ available: false, reason: LOCAL_UNAVAILABLE_REASON }),
-    capabilities: () => [],
-    list: unavailableLocalOperation,
-    read: unavailableLocalOperation,
-    create: unavailableLocalOperation,
-    update: unavailableLocalOperation,
-    close: unavailableLocalOperation,
-  }),
+  local: createLocalAdapter({ backlogDir: DEFAULT_BACKLOG_DIR }),
 });
 
 module.exports = {
@@ -306,4 +296,5 @@ module.exports = {
   resolveConfiguredTracker,
   invokeCapability,
   createGithubAdapter,
+  createLocalAdapter,
 };

--- a/skills/dev-backlog/scripts/tracker.test.js
+++ b/skills/dev-backlog/scripts/tracker.test.js
@@ -1,6 +1,7 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 
 const {
@@ -13,11 +14,22 @@ const {
   TrackerUnavailableError,
   UnsupportedTrackerCapabilityError,
   invokeCapability,
+  resolveConfiguredTracker,
   resolveTracker,
   selectTracker,
   validateAdapter,
   validateIdentity,
 } = require("./tracker.js");
+
+function makeLocalBacklog(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "tracker-local-"));
+  const backlogDir = path.join(root, "backlog");
+  fs.mkdirSync(path.join(backlogDir, "tasks"), { recursive: true });
+  fs.mkdirSync(path.join(backlogDir, "completed"), { recursive: true });
+  fs.writeFileSync(path.join(backlogDir, "config.yml"), 'tracker: local\ntask_prefix: "BACK"\n');
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return backlogDir;
+}
 
 function makeAdapter(overrides = {}) {
   return {
@@ -88,13 +100,40 @@ describe("configured-only resolution", () => {
     }
   });
 
-  it("fails explicitly selected local resolution with its #276 reason", () => {
+  it("resolves explicitly selected local against a usable store without github fallback", (t) => {
+    const backlogDir = makeLocalBacklog(t);
+    let githubProbes = 0;
+    const github = makeAdapter({
+      availability: () => {
+        githubProbes += 1;
+        return { available: true };
+      },
+    });
+
+    const resolved = resolveConfiguredTracker(
+      { tracker: "local" },
+      { backlogDir, adapters: undefined }
+    );
+
+    assert.equal(resolved.tracker, "local");
+    assert.deepEqual(resolved.availability, { available: true });
+    assert.deepEqual(resolved.adapter.capabilities(), []);
+    assert.equal(githubProbes, 0);
+    void github;
+  });
+
+  it("fails a malformed local store with an actionable reason and no fallback", (t) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "tracker-local-bad-"));
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+    const filePath = path.join(root, "backlog");
+    fs.writeFileSync(filePath, "not a directory");
+
     assert.throws(
-      () => resolveTracker({ tracker: "local" }),
+      () => resolveConfiguredTracker({ tracker: "local" }, { backlogDir: filePath }),
       (error) => {
         assert.ok(error instanceof TrackerUnavailableError);
         assert.equal(error.tracker, "local");
-        assert.match(error.reason, /#276/);
+        assert.ok(error.reason && error.reason.trim().length > 0);
         return true;
       }
     );
@@ -245,26 +284,24 @@ describe("normalized tracker identity", () => {
 });
 
 describe("local adapter and optional capabilities", () => {
-  it("reports local as implementation-pending and fails every lifecycle operation consistently", () => {
+  it("registers a usable, capability-free local adapter in the default slot", () => {
     const local = TRACKER_ADAPTERS.local;
-    const report = local.availability();
-    assert.equal(report.available, false);
-    assert.match(report.reason, /#276/);
+    assert.deepEqual(Object.keys(local), REQUIRED_ADAPTER_OPERATIONS);
+    assert.deepEqual(local.capabilities(), []);
 
-    const errors = [];
-    for (const operation of ["list", "read", "create", "update", "close"]) {
-      assert.throws(
-        () => local[operation](),
-        (error) => {
-          errors.push(error);
-          assert.ok(error instanceof TrackerUnavailableError);
-          assert.equal(error.tracker, "local");
-          assert.equal(error.reason, report.reason);
-          return true;
-        }
-      );
+    const report = local.availability();
+    assert.equal(typeof report.available, "boolean");
+    if (!report.available) {
+      assert.ok(report.reason && report.reason.trim().length > 0);
     }
-    assert.equal(new Set(errors.map((error) => error.message)).size, 1);
+  });
+
+  it("selects the local adapter without probing github when local is configured", (t) => {
+    const backlogDir = makeLocalBacklog(t);
+    const resolved = resolveConfiguredTracker({ tracker: "local" }, { backlogDir });
+    const created = resolved.adapter.create({ title: "Seam smoke" });
+    assert.deepEqual(created, { tracker: "local", id: "1", ref: "BACK-1" });
+    assert.equal("url" in created, false);
   });
 
   it("reports only the six named optional provider capabilities", () => {


### PR DESCRIPTION
## Dispatch Summary

```text
All four consistency blockers in issue #276 are fixed, with regression tests verified against the old source, all gates green, and a local-only commit (nothing pushed).

## Summary

**Blocker 1 — recovery must not trust `marker.destHash`.** `recover()` now calls a new `deriveExpectedDone(src, ref)` that independently recomputes the exact Done bytes+hash from the *fully validated* active source. Roll-forward (deleting the active source) happens only when **derived hash === journaled hash === dest
```

## Score Log

- Run: issue-276-20260711093008439-e4d7a71f
- Executor: claude
- Branch: relay/issue-276-local-adapter-claude