### PR TITLE
chore: record local adapter completion (#276)

### DIFF
--- a/backlog/sprints/2026-07-tracker-local-cycle.md
+++ b/backlog/sprints/2026-07-tracker-local-cycle.md
@@ -15,7 +15,7 @@ The same core sprint cycle is executable and documented in backward-compatible G
 ## Plan
 
 ### Batch 1 - Implement local canonical persistence
-- [ ] #276 Add offline local canonical task adapter (~3hr)
+- [x] #276 Add offline local canonical task adapter (~3hr) → PR #298 (merged)
 
 ### Batch 2 - Persist a deliberate setup choice (after #276)
 - [ ] #277 Add idempotent tracker-aware setup-dev-backlog (~2hr)
@@ -33,3 +33,4 @@ The same core sprint cycle is executable and documented in backward-compatible G
 
 ## Progress
 - 2026-07-11: Sprint B opened as three serial batches after Sprint A and GitHub regression baseline completed; live issues #276-#278 remain the task source of truth.
+- 2026-07-11: #276 merged via PR #298 after TDD, offline lifecycle proof, real multi-process allocation, crash-recovery and fail-closed filesystem review. Final gates: Node 576 pass plus one pre-existing skip, smoke 155/155, GitHub Actions green, and all review threads resolved.

--- a/backlog/tasks/BACK-276 - feat-add-offline-local-canonical-task-adapter.md
+++ b/backlog/tasks/BACK-276 - feat-add-offline-local-canonical-task-adapter.md
@@ -1,7 +1,7 @@
 ---
 id: BACK-276
 title: 'feat: add offline local canonical task adapter'
-status: To Do
+status: Done
 labels:
   - enhancement
 priority: medium
@@ -19,13 +19,13 @@ Implement an offline local adapter that completes canonical task lifecycle and t
 
 ## Acceptance Criteria
 
-- [ ] Local list/read/create/update/close operations work against Backlog.md-compatible `backlog/tasks/` and `backlog/completed/` files.
-- [ ] ID allocation is deterministic, collision-safe, prefix-aware, and preserves existing decimal subtask compatibility.
-- [ ] Create and update preserve human-authored descriptions and AC checkbox state; close archives the exact task atomically.
-- [ ] Local plan/work/complete uses normalized task refs and does not invoke `gh` or require GitHub authentication.
-- [ ] Unsupported milestone, PR relationship, mirror, progress issue, comment, and close-keyword operations return actionable capability errors.
-- [ ] Offline integration tests run with `gh` absent from `PATH` and prove create → plan → read/work state → complete/archive.
-- [ ] Concurrent or duplicate ID allocation fails safely rather than overwriting a task.
+- [x] Local list/read/create/update/close operations work against Backlog.md-compatible `backlog/tasks/` and `backlog/completed/` files.
+- [x] ID allocation is deterministic, collision-safe, prefix-aware, and preserves existing decimal subtask compatibility.
+- [x] Create and update preserve human-authored descriptions and AC checkbox state; close archives the exact task atomically.
+- [x] Local plan/work/complete uses normalized task refs and does not invoke `gh` or require GitHub authentication.
+- [x] Unsupported milestone, PR relationship, mirror, progress issue, comment, and close-keyword operations return actionable capability errors.
+- [x] Offline integration tests run with `gh` absent from `PATH` and prove create → plan → read/work state → complete/archive.
+- [x] Concurrent or duplicate ID allocation fails safely rather than overwriting a task.
 
 ## Non-Goals
 


### PR DESCRIPTION
## Summary
- mark #276 Done in its thin task mirror
- record PR #298 and final verification evidence in Sprint B

## Verification
- git diff --check

Bookkeeping only; runtime implementation merged in #298.