### PR TITLE
feat: Phase 1a multi-track resolvers — scope, portfolio, --track (#291)

### DIFF
--- a/skills/dev-backlog/scripts/context-hook.sh
+++ b/skills/dev-backlog/scripts/context-hook.sh
@@ -33,7 +33,15 @@ else
   ACTIVE_STATUS=$?
 fi
 if [ "$ACTIVE_STATUS" -eq 2 ]; then
-  echo "[Sprint warning] Multiple active sprints found; resolve backlog/sprints/ before editing."
+  COUNT=$(find_active_sprints "$SPRINTS_DIR" | grep -c . || true)
+  PARTS=""
+  while IFS= read -r sprint; do
+    [ -z "$sprint" ] && continue
+    NAME=$(basename "$sprint" .md)
+    count_checkboxes "$sprint"
+    PARTS="$PARTS, $NAME($CB_DONE/$CB_TOTAL)"
+  done < <(find_active_sprints "$SPRINTS_DIR")
+  echo "[Sprint portfolio] $COUNT tracks active: ${PARTS#, }"
   exit 0
 fi
 

--- a/skills/dev-backlog/scripts/lib.js
+++ b/skills/dev-backlog/scripts/lib.js
@@ -195,10 +195,59 @@ function estimateSize(labels) {
   return "";
 }
 
+/**
+ * Resolve a sprint's scope key from its frontmatter (multi-track partitioning).
+ * Priority: non-empty `component:` wins; else `scope:` path globs; else none.
+ * A track declares one axis, never both (PRD D1).
+ */
+function sprintScopeKey(frontmatter) {
+  const fm = frontmatter || {};
+  const component = typeof fm.component === "string" ? fm.component.trim() : "";
+  if (component) return { kind: "component", value: component };
+  const scope = Array.isArray(fm.scope)
+    ? fm.scope.map((glob) => String(glob).trim()).filter(Boolean)
+    : [];
+  if (scope.length) return { kind: "scope", globs: scope };
+  return { kind: "none" };
+}
+
+// Reduce a path glob to a comparable directory prefix:
+// "src/auth/**" -> "src/auth", "src/auth/*" -> "src/auth", "src/auth/" -> "src/auth".
+function normalizeScopePrefix(glob) {
+  return String(glob).replace(/\/+\**$/, "").replace(/\/+$/, "");
+}
+
+function globsOverlap(a, b) {
+  const na = normalizeScopePrefix(a);
+  const nb = normalizeScopePrefix(b);
+  if (na === "" || nb === "") return true; // a root scope overlaps anything
+  if (na === nb) return true;
+  return na.startsWith(`${nb}/`) || nb.startsWith(`${na}/`); // nested paths overlap
+}
+
+/**
+ * Do two sprints' scopes overlap? The single shared predicate consumed by
+ * sprint-state (OVERLAPPING_TRACKS), sprint-init (refuse), and backlog-doctor.
+ * component: exact equality; scope: globs: normalized path-prefix containment.
+ * Cross-axis or scopeless pairs return false — "cannot prove overlap" — and the
+ * doctor separately warns on two scopeless active tracks.
+ */
+function scopesOverlap(frontmatterA, frontmatterB) {
+  const a = sprintScopeKey(frontmatterA);
+  const b = sprintScopeKey(frontmatterB);
+  if (a.kind === "component" && b.kind === "component") return a.value === b.value;
+  if (a.kind === "scope" && b.kind === "scope") {
+    return a.globs.some((ga) => b.globs.some((gb) => globsOverlap(ga, gb)));
+  }
+  return false;
+}
+
 module.exports = {
   slugify,
   escapeYaml,
   parseSimpleYaml,
+  sprintScopeKey,
+  scopesOverlap,
   readConfig,
   readTriageConfig,
   estimateSize,

--- a/skills/dev-backlog/scripts/lib.sh
+++ b/skills/dev-backlog/scripts/lib.sh
@@ -62,6 +62,23 @@ find_active_sprint() {
   printf "%s\n" "$active"
 }
 
+# Print the active sprint file whose slug (basename) or component: matches $2.
+# Return 0 and print the path when found; return 1 when no active track matches.
+# Usage: SPRINT=$(resolve_track "$SPRINTS_DIR" "$TRACK")
+resolve_track() {
+  local sprints_dir="$1" track="$2" f slug component
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    slug=$(basename "$f" .md)
+    component=$(awk -F': *' '/^component:/{gsub(/["'"'"']/,"",$2); print $2; exit}' "$f")
+    if [ "$slug" = "$track" ] || [ "$component" = "$track" ]; then
+      printf '%s\n' "$f"
+      return 0
+    fi
+  done < <(find_active_sprints "$sprints_dir")
+  return 1
+}
+
 # Count checkbox states in a sprint file through the shared task-ref parser.
 # Sets: CB_TOTAL, CB_DONE, CB_IN_FLIGHT, CB_TODO
 # Usage: count_checkboxes "$FILE"

--- a/skills/dev-backlog/scripts/lib.test.js
+++ b/skills/dev-backlog/scripts/lib.test.js
@@ -5,6 +5,7 @@ const path = require("path");
 const {
   slugify,
   escapeYaml,
+  scopesOverlap,
   readConfig,
   readTriageConfig,
   estimateSize,
@@ -346,5 +347,24 @@ describe("fetchOpenIssues", () => {
     assert.deepEqual(issues, []);
     assert.equal(calls.length, 1);
     assert.equal(calls[0].args[0], "api");
+  });
+});
+
+describe("scopesOverlap", () => {
+  it("component: overlaps only on exact equality", () => {
+    assert.equal(scopesOverlap({ component: "auth" }, { component: "auth" }), true);
+    assert.equal(scopesOverlap({ component: "auth" }, { component: "billing" }), false);
+  });
+
+  it("scope: globs overlap on normalized path-prefix containment", () => {
+    assert.equal(scopesOverlap({ scope: ["src/auth/**"] }, { scope: ["src/billing/**"] }), false);
+    assert.equal(scopesOverlap({ scope: ["src/auth/**"] }, { scope: ["src/auth/**"] }), true);
+    assert.equal(scopesOverlap({ scope: ["src/auth/**"] }, { scope: ["src/auth/session/**"] }), true);
+  });
+
+  it("cross-axis or scopeless pairs cannot prove overlap (false)", () => {
+    assert.equal(scopesOverlap({ component: "auth" }, { scope: ["src/auth/**"] }), false);
+    assert.equal(scopesOverlap({}, {}), false);
+    assert.equal(scopesOverlap({ component: "auth" }, {}), false);
   });
 });

--- a/skills/dev-backlog/scripts/next.sh
+++ b/skills/dev-backlog/scripts/next.sh
@@ -11,15 +11,21 @@ source "$SCRIPT_DIR/lib.sh"
 
 BACKLOG_DIR="backlog"
 JSON=0
-for arg in "$@"; do
-  if [ "$arg" = "--json" ]; then
-    JSON=1
-  else
-    BACKLOG_DIR="$arg"
-  fi
+TRACK=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --json) JSON=1 ;;
+    --track) shift; TRACK="${1:-}" ;;
+    --track=*) TRACK="${1#--track=}" ;;
+    *) BACKLOG_DIR="$1" ;;
+  esac
+  shift
 done
 
 if [ "$JSON" -eq 1 ]; then
+  if [ -n "$TRACK" ]; then
+    exec node "$SCRIPT_DIR/sprint-state.js" --mode next --track "$TRACK" "$BACKLOG_DIR"
+  fi
   exec node "$SCRIPT_DIR/sprint-state.js" --mode next "$BACKLOG_DIR"
 fi
 
@@ -30,21 +36,45 @@ if [ ! -d "$SPRINTS_DIR" ]; then
   exit 1
 fi
 
-ACTIVE=$(find_active_sprint "$SPRINTS_DIR" 2>/dev/null)
-ACTIVE_STATUS=$?
+if [ -n "$TRACK" ]; then
+  ACTIVE=$(resolve_track "$SPRINTS_DIR" "$TRACK")
+  if [ -z "$ACTIVE" ]; then
+    echo "No active track matches '$TRACK'. Active tracks:"
+    find_active_sprints "$SPRINTS_DIR" | while IFS= read -r sprint; do
+      [ -z "$sprint" ] && continue
+      echo "  - $(basename "$sprint" .md)"
+    done
+    exit 1
+  fi
+else
+  ACTIVE=$(find_active_sprint "$SPRINTS_DIR" 2>/dev/null)
+  ACTIVE_STATUS=$?
 
-if [ "$ACTIVE_STATUS" -eq 2 ]; then
-  echo "Multiple active sprints found. Resolve backlog/sprints/ before choosing next work."
-  find_active_sprints "$SPRINTS_DIR" | while IFS= read -r sprint; do
-    echo "  - $(basename "$sprint")"
-  done
-  exit 1
-fi
+  if [ "$ACTIVE_STATUS" -eq 2 ]; then
+    # Multiple disjoint tracks: a portfolio. Overlap is the doctor's fail signal.
+    ACTIVE_COUNT=$(find_active_sprints "$SPRINTS_DIR" | grep -c . || true)
+    echo "=== $ACTIVE_COUNT active tracks (portfolio) ==="
+    echo ""
+    find_active_sprints "$SPRINTS_DIR" | while IFS= read -r sprint; do
+      [ -z "$sprint" ] && continue
+      NAME=$(basename "$sprint" .md)
+      count_checkboxes "$sprint"
+      LINE="$NAME: $CB_DONE/$CB_TOTAL done"
+      [ "$CB_IN_FLIGHT" -gt 0 ] && LINE="$LINE, $CB_IN_FLIGHT in-flight"
+      echo "$LINE"
+      NEXT_ITEM=$(next_todo_item "$sprint" 2>/dev/null || true)
+      [ -n "$NEXT_ITEM" ] && echo "  Next: $NEXT_ITEM"
+    done
+    echo ""
+    echo "Use 'next.sh --track <slug>' for a single track."
+    exit 0
+  fi
 
-if [ "$ACTIVE_STATUS" -ne 0 ]; then
-  echo "No active sprint found."
-  echo "Check GitHub: gh issue list --state open"
-  exit 0
+  if [ "$ACTIVE_STATUS" -ne 0 ]; then
+    echo "No active sprint found."
+    echo "Check GitHub: gh issue list --state open"
+    exit 0
+  fi
 fi
 
 SPRINT_NAME=$(basename "$ACTIVE" .md)

--- a/skills/dev-backlog/scripts/smoke-test.sh
+++ b/skills/dev-backlog/scripts/smoke-test.sh
@@ -105,7 +105,7 @@ RECOVERY_JSON=$(printf '{"status":%s,"next":%s}' "$STATUS_JSON" "$NEXT_JSON")
 assert_json_eval "recovery live: files-only state is orientable" "$RECOVERY_JSON" '
 const recovery = JSON.parse(require("fs").readFileSync(0, "utf8"));
 const { status, next } = recovery;
-if (status.schema_version !== 1 || next.schema_version !== 1) {
+if (status.schema_version !== 2 || next.schema_version !== 2) {
   process.exit(1);
 }
 const sprintPath = status.active_sprint && status.active_sprint.path;
@@ -428,7 +428,7 @@ OUT=$(bash "$SCRIPT_DIR/status.sh" --json "$TEST_DIR/backlog")
 assert_json_eval "status json: structured state" "$OUT" '
 const j = JSON.parse(require("fs").readFileSync(0, "utf8"));
 if (
-  j.schema_version !== 1 ||
+  j.schema_version !== 2 ||
   !j.active_sprint ||
   j.active_sprint.frontmatter.status !== "active" ||
   j.active_sprint.goal !== "Test the checkbox parsing." ||
@@ -445,7 +445,7 @@ OUT=$(bash "$SCRIPT_DIR/next.sh" --json "$TEST_DIR/backlog")
 assert_json_eval "next json: next batch" "$OUT" '
 const j = JSON.parse(require("fs").readFileSync(0, "utf8"));
 if (
-  j.schema_version !== 1 ||
+  j.schema_version !== 2 ||
   !("next_batch" in j) ||
   !j.next_batch ||
   j.next_batch.heading !== "### Batch 3 — Remaining" ||
@@ -591,38 +591,69 @@ status: active
 - [ ] #2 Task B
 EOF
 
+# Two scopeless active tracks are disjoint-by-default (cannot prove overlap):
+# a portfolio, not an error (#291). Overlap is handled as fail-loud below.
 set +e
 OUT=$(bash "$SCRIPT_DIR/next.sh" "$TEST_DIR/backlog" 2>&1)
 STATUS=$?
 set -e
-assert_equals "next multiple-active: exit code" "$STATUS" "1"
-assert_contains "next multiple-active: message" "$OUT" "Multiple active sprints found"
-assert_contains "next multiple-active: lists first" "$OUT" "2026-03-active-a.md"
-assert_contains "next multiple-active: lists second" "$OUT" "2026-03-active-b.md"
+assert_equals "next portfolio: exit code" "$STATUS" "0"
+assert_contains "next portfolio: header" "$OUT" "active tracks (portfolio)"
+assert_contains "next portfolio: lists first" "$OUT" "2026-03-active-a"
+assert_contains "next portfolio: lists second" "$OUT" "2026-03-active-b"
 
 OUT=$(bash "$SCRIPT_DIR/status.sh" "$TEST_DIR/backlog" 2>&1)
-assert_contains "status multiple-active: warning" "$OUT" "Multiple active sprints found"
-assert_contains "status multiple-active: lists first" "$OUT" "2026-03-active-a.md"
-assert_contains "status multiple-active: lists second" "$OUT" "2026-03-active-b.md"
+assert_contains "status portfolio: header" "$OUT" "active tracks (portfolio)"
+assert_contains "status portfolio: lists first" "$OUT" "2026-03-active-a"
+assert_contains "status portfolio: lists second" "$OUT" "2026-03-active-b"
 
 set +e
 OUT=$(bash "$SCRIPT_DIR/next.sh" --json "$TEST_DIR/backlog" 2>&1)
 STATUS=$?
 set -e
-assert_equals "next json multiple-active: exit code" "$STATUS" "1"
-assert_contains "next json multiple-active: error" "$OUT" "Multiple active sprint files found"
-
-set +e
-OUT=$(bash "$SCRIPT_DIR/status.sh" --json "$TEST_DIR/backlog" 2>&1)
-STATUS=$?
-set -e
-assert_equals "status json multiple-active: exit code" "$STATUS" "1"
-assert_contains "status json multiple-active: error" "$OUT" "Multiple active sprint files found"
+assert_equals "next json portfolio: exit code" "$STATUS" "0"
+assert_json_eval "next json portfolio: two disjoint tracks, no single active_sprint" "$OUT" '
+const j = JSON.parse(require("fs").readFileSync(0, "utf8"));
+if (j.schema_version !== 2 || j.active_sprint !== null) process.exit(1);
+if (!Array.isArray(j.active_sprints) || j.active_sprints.length !== 2) process.exit(1);
+'
 
 OUT=$(bash "$SCRIPT_DIR/context-hook.sh" "$TEST_DIR/backlog" 2>&1)
-assert_contains "hook multiple-active: warning" "$OUT" "Multiple active sprints found"
+assert_contains "hook portfolio: line" "$OUT" "[Sprint portfolio] 2 tracks active"
+
+# --track selects one disjoint track (single render, other track excluded)
+OUT=$(bash "$SCRIPT_DIR/next.sh" --track 2026-03-active-a "$TEST_DIR/backlog" 2>&1)
+assert_contains "next --track: shows selected track" "$OUT" "2026-03-active-a"
+assert_not_contains "next --track: excludes other track" "$OUT" "Task B"
 
 rm "$TEST_DIR/backlog/sprints/2026-03-active-a.md" "$TEST_DIR/backlog/sprints/2026-03-active-b.md"
+
+# Overlapping scope (same component) is fail-loud in JSON mode (#291).
+cat > "$TEST_DIR/backlog/sprints/2026-03-ov-a.md" << 'EOF'
+---
+status: active
+component: "shared-thing"
+---
+
+## Plan
+- [ ] #1 Task A
+EOF
+cat > "$TEST_DIR/backlog/sprints/2026-03-ov-b.md" << 'EOF'
+---
+status: active
+component: "shared-thing"
+---
+
+## Plan
+- [ ] #2 Task B
+EOF
+set +e
+OUT=$(bash "$SCRIPT_DIR/next.sh" --json "$TEST_DIR/backlog" 2>&1)
+STATUS=$?
+set -e
+assert_equals "next json overlap: fail-loud exit code" "$STATUS" "1"
+assert_contains "next json overlap: message" "$OUT" "Active tracks overlap on scope"
+rm "$TEST_DIR/backlog/sprints/2026-03-ov-a.md" "$TEST_DIR/backlog/sprints/2026-03-ov-b.md"
 
 # --- status.sh: local files section ---
 mkdir -p "$TEST_DIR/backlog/tasks"
@@ -1187,8 +1218,17 @@ mt_write_sprint "$MT_OVERLAP_DIR/backlog/sprints/2026-07-auth-b.md" "AuthB" 4 '[
 set +e
 OUT=$(cd "$MT_OVERLAP_DIR" && node "$SCRIPT_DIR/backlog-doctor.js" --json 2>/dev/null)
 set -e
-if printf "%s" "$OUT" | grep -qF "Active tracks overlap on scope"; then MT_OVERLAP_RES="pass"; else MT_OVERLAP_RES="fail"; fi
-gated_assert "multi-track: doctor emits scope-overlap message, not generic multi-active (#293 B2)" "$GATE_MT_OVERLAP" "$MT_OVERLAP_RES"
+# Key on the active_sprint CHECK's own summary — not a raw grep of the whole
+# doctor output. From #291 the OVERLAPPING_TRACKS message can appear in a
+# skipped in-flight check summary; only #293 makes the active_sprint verdict
+# itself carry the overlap message, which is what this gate should track.
+if printf "%s" "$OUT" | node -e '
+const j = JSON.parse(require("fs").readFileSync(0, "utf8"));
+const c = (j.checks || []).find((x) => x.name === "active_sprint");
+const summary = (c && c.detail && c.detail.summary) || "";
+process.exit(/Active tracks overlap on scope/.test(summary) ? 0 : 1);
+' 2>/dev/null; then MT_OVERLAP_RES="pass"; else MT_OVERLAP_RES="fail"; fi
+gated_assert "multi-track: doctor active_sprint verdict emits scope-overlap message (#293 B2)" "$GATE_MT_OVERLAP" "$MT_OVERLAP_RES"
 
 # (3) Back-compat (ENFORCED, GATE=1 — must stay GREEN on HEAD and after Phase 1).
 #     A single active track behaves exactly as today; this is the G4 text anchor
@@ -1200,6 +1240,31 @@ OUT=$(cd "$MT_SINGLE_DIR" && node "$SCRIPT_DIR/backlog-doctor.js" 2>/dev/null ||
 assert_contains "multi-track G4: single active track still reports 'Exactly one active sprint' (text)" "$OUT" "Exactly one active sprint"
 OUT=$(cd "$MT_SINGLE_DIR" && bash "$SCRIPT_DIR/next.sh" 2>/dev/null || true)
 assert_contains "multi-track G4: single-track next.sh still names the sprint (text)" "$OUT" "2026-07-solo"
+
+# --- Phase 1a (#291) ENFORCED: resolvers deliver the portfolio + track selection ---
+# Reuses MT_DISJOINT_DIR (two disjoint-scope tracks: 2026-07-auth, 2026-07-billing).
+set +e
+OUT=$(cd "$MT_DISJOINT_DIR" && node "$SCRIPT_DIR/sprint-state.js" --json)
+set -e
+assert_json_eval "multi-track #291: sprint-state emits schema-2 portfolio for disjoint tracks" "$OUT" '
+const j = JSON.parse(require("fs").readFileSync(0, "utf8"));
+if (j.schema_version !== 2) process.exit(1);
+if (j.active_sprint !== null) process.exit(1);
+if (!Array.isArray(j.active_sprints) || j.active_sprints.length !== 2) process.exit(1);
+'
+OUT=$(cd "$MT_DISJOINT_DIR" && node "$SCRIPT_DIR/sprint-state.js" --track 2026-07-auth)
+assert_json_eval "multi-track #291: --track resolves exactly one sprint (single shape)" "$OUT" '
+const j = JSON.parse(require("fs").readFileSync(0, "utf8"));
+if (!j.active_sprint || !/2026-07-auth\.md$/.test(j.active_sprint.path)) process.exit(1);
+if (!Array.isArray(j.active_sprints) || j.active_sprints.length !== 1) process.exit(1);
+'
+OUT=$(cd "$MT_DISJOINT_DIR" && bash "$SCRIPT_DIR/next.sh")
+assert_contains "multi-track #291: next.sh renders a portfolio for N>1" "$OUT" "active tracks (portfolio)"
+assert_contains "multi-track #291: portfolio names track auth" "$OUT" "2026-07-auth"
+assert_contains "multi-track #291: portfolio names track billing" "$OUT" "2026-07-billing"
+OUT=$(cd "$MT_DISJOINT_DIR" && bash "$SCRIPT_DIR/next.sh" --track 2026-07-billing)
+assert_contains "multi-track #291: next.sh --track shows the selected track" "$OUT" "2026-07-billing"
+assert_not_contains "multi-track #291: next.sh --track excludes other tracks" "$OUT" "2026-07-auth"
 
 # --- Results ---
 echo ""

--- a/skills/dev-backlog/scripts/sprint-mirror.js
+++ b/skills/dev-backlog/scripts/sprint-mirror.js
@@ -91,10 +91,13 @@ function resolveSprintState({
     throw new Error(`sprint-state.js produced invalid JSON: ${error.message}`);
   }
 
-  if (state.schema_version !== 1) {
+  if (state.schema_version !== 1 && state.schema_version !== 2) {
     throw new Error(`Unsupported sprint-state schema_version: ${state.schema_version}`);
   }
 
+  // v2 keeps `active_sprint` populated only when exactly one track is active; a
+  // portfolio (N>1) leaves it null. sprint-mirror still mirrors one sprint —
+  // per-track selection is #292's work.
   if (!state.active_sprint) {
     throw new Error("No active sprint found. sprint-mirror requires exactly one active sprint.");
   }

--- a/skills/dev-backlog/scripts/sprint-mirror.test.js
+++ b/skills/dev-backlog/scripts/sprint-mirror.test.js
@@ -39,7 +39,7 @@ function planItem(overrides = {}) {
 
 function sprintState(overrides = {}) {
   return {
-    schema_version: 1,
+    schema_version: 2,
     active_sprint: {
       path: "backlog/sprints/2026-07-sample-sprint.md",
       frontmatter: { status: "active" },
@@ -155,7 +155,7 @@ describe("resolveSprintState", () => {
   });
 
   it("rejects an unsupported schema_version", () => {
-    const { execFile } = makeExecFile({ state: { ...sprintState(), schema_version: 2 } });
+    const { execFile } = makeExecFile({ state: { ...sprintState(), schema_version: 99 } });
     assert.throws(() => resolveSprintState({ execFile }), /Unsupported sprint-state schema_version/);
   });
 

--- a/skills/dev-backlog/scripts/sprint-state.js
+++ b/skills/dev-backlog/scripts/sprint-state.js
@@ -8,14 +8,17 @@
 
 const fs = require("fs");
 const path = require("path");
-const { parseSimpleYaml, readConfig } = require("./lib.js");
+const { parseSimpleYaml, readConfig, scopesOverlap } = require("./lib.js");
 const {
   containsTaskRef,
   githubIssueNumber,
   parsePlanCheckbox,
 } = require("./task-ref.js");
 
-const SCHEMA_VERSION = 1;
+// v2 (multi-track): adds `active_sprints[]`; `active_sprint` + the top-level
+// single-sprint fields are retained (sole element when exactly one is active,
+// null when a portfolio) so v1 consumers keep working. See PRD §5.2 / R5.
+const SCHEMA_VERSION = 2;
 const DEFAULT_BACKLOG_DIR = "backlog";
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
@@ -31,15 +34,31 @@ const STATE_BY_MARKER = {
 };
 
 function usage() {
-  return "Usage: sprint-state.js [--mode status|next] [backlog-dir]";
+  return "Usage: sprint-state.js [--mode status|next] [--track slug | --component slug] [backlog-dir]";
 }
 
 function parseArgs(args) {
   const options = {
     mode: "status",
     backlogDir: DEFAULT_BACKLOG_DIR,
+    track: null,
+    component: null,
   };
   let backlogDirSet = false;
+
+  const valueFlag = (arg, i, name, key) => {
+    if (arg === `--${name}`) {
+      const next = args[i + 1];
+      if (!next) return { consumed: 1, error: `Missing value for --${name}. ${usage()}` };
+      options[key] = next;
+      return { consumed: 2 };
+    }
+    if (arg.startsWith(`--${name}=`)) {
+      options[key] = arg.slice(`--${name}=`.length);
+      return { consumed: 1 };
+    }
+    return null;
+  };
 
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
@@ -56,6 +75,17 @@ function parseArgs(args) {
       options.mode = arg.slice("--mode=".length);
       continue;
     }
+    let handled = false;
+    for (const [name, key] of [["track", "track"], ["component", "component"]]) {
+      const res = valueFlag(arg, i, name, key);
+      if (res) {
+        if (res.error) return { ...options, error: res.error };
+        i += res.consumed - 1;
+        handled = true;
+        break;
+      }
+    }
+    if (handled) continue;
     if (arg.startsWith("--")) {
       return { ...options, error: `Unknown argument: ${arg}. ${usage()}` };
     }
@@ -70,17 +100,51 @@ function parseArgs(args) {
     return { ...options, error: `Invalid --mode: ${options.mode}. ${usage()}` };
   }
 
+  if (options.track && options.component) {
+    return { ...options, error: `Use only one of --track / --component. ${usage()}` };
+  }
+
   return options;
 }
 
-function emptyState() {
+// Per-sprint fields shared by the single and portfolio shapes. Kept null/empty
+// at the top level of a portfolio (N>1) so v1 consumers that read
+// active_sprint/plan_items degrade to "no single active sprint".
+function emptyTopLevel() {
   return {
-    schema_version: SCHEMA_VERSION,
     active_sprint: null,
     plan_items: [],
     next_batch: null,
     latest_progress: [],
     in_flight: [],
+  };
+}
+
+function emptyState() {
+  return {
+    schema_version: SCHEMA_VERSION,
+    active_sprints: [],
+    ...emptyTopLevel(),
+  };
+}
+
+// One active track: retain the v1 top-level fields (back-compat) and also list
+// it under active_sprints[].
+function singleState(perSprint) {
+  return {
+    schema_version: SCHEMA_VERSION,
+    active_sprints: [perSprint],
+    ...perSprint,
+  };
+}
+
+// N disjoint active tracks: the portfolio. Top-level singular fields are
+// null/empty; consumers read active_sprints[] or pass --track/--component.
+function portfolioState(perSprints) {
+  return {
+    schema_version: SCHEMA_VERSION,
+    active_sprints: perSprints,
+    ...emptyTopLevel(),
   };
 }
 
@@ -300,8 +364,8 @@ function parseSprintContent({
       ...computeAge(item, progressEntries, frontmatter.started, today),
     }));
 
+  // Per-sprint state (no schema_version — that lives on the top-level wrapper).
   return {
-    schema_version: SCHEMA_VERSION,
     active_sprint: {
       path: sprintPath,
       frontmatter,
@@ -314,9 +378,45 @@ function parseSprintContent({
   };
 }
 
+function sprintSlug(sprintPath) {
+  return path.basename(sprintPath, ".md");
+}
+
+// Ascending by frontmatter `started:` (D4), filename as a stable tiebreaker.
+function comparePerSprint(a, b) {
+  const sa = a.active_sprint.frontmatter.started || "";
+  const sb = b.active_sprint.frontmatter.started || "";
+  if (sa !== sb) return sa < sb ? -1 : 1;
+  return a.active_sprint.path < b.active_sprint.path ? -1 : 1;
+}
+
+function matchesSelector(perSprint, { track, component }) {
+  const fm = perSprint.active_sprint.frontmatter || {};
+  const fmComponent = typeof fm.component === "string" ? fm.component.trim() : "";
+  if (component) return fmComponent === component;
+  // --track matches the sprint slug or its component handle.
+  return sprintSlug(perSprint.active_sprint.path) === track || fmComponent === track;
+}
+
+function firstOverlappingPair(perSprints) {
+  for (let i = 0; i < perSprints.length; i += 1) {
+    for (let j = i + 1; j < perSprints.length; j += 1) {
+      if (scopesOverlap(
+        perSprints[i].active_sprint.frontmatter,
+        perSprints[j].active_sprint.frontmatter
+      )) {
+        return [perSprints[i], perSprints[j]];
+      }
+    }
+  }
+  return null;
+}
+
 function readSprintState({
   backlogDir = DEFAULT_BACKLOG_DIR,
   today = new Date(),
+  track = null,
+  component = null,
   existsSync = fs.existsSync,
   readdirSync = fs.readdirSync,
   readFileSync = fs.readFileSync,
@@ -329,22 +429,39 @@ function readSprintState({
   });
 
   if (activeFiles.length === 0) return emptyState();
-  if (activeFiles.length > 1) {
-    const error = new Error(
-      `Multiple active sprint files found:\n${activeFiles.map((file) => `  ${file}`).join("\n")}`
-    );
-    error.code = "MULTIPLE_ACTIVE_SPRINTS";
-    error.files = activeFiles;
-    throw error;
+
+  const taskPrefix = readConfig(backlogDir).task_prefix;
+  const perSprints = activeFiles
+    .map((sprintPath) => parseSprintContent({
+      sprintPath,
+      content: readFileSync(sprintPath, "utf-8"),
+      today,
+      taskPrefix,
+    }))
+    .sort(comparePerSprint);
+
+  // Explicit track/component selector: resolve to that one track deterministically.
+  if (track || component) {
+    const matches = perSprints.filter((s) => matchesSelector(s, { track, component }));
+    if (matches.length === 0) return emptyState();
+    return singleState(matches[0]);
   }
 
-  const sprintPath = activeFiles[0];
-  return parseSprintContent({
-    sprintPath,
-    content: readFileSync(sprintPath, "utf-8"),
-    today,
-    taskPrefix: readConfig(backlogDir).task_prefix,
-  });
+  if (perSprints.length === 1) return singleState(perSprints[0]);
+
+  // N active tracks: a portfolio when scopes are disjoint; fail loud on overlap.
+  const overlap = firstOverlappingPair(perSprints);
+  if (overlap) {
+    const [a, b] = overlap;
+    const error = new Error(
+      `Active tracks overlap on scope:\n  ${a.active_sprint.path}\n  ${b.active_sprint.path}\n`
+      + "Give them disjoint component:/scope: or close one before continuing."
+    );
+    error.code = "OVERLAPPING_TRACKS";
+    error.files = [a.active_sprint.path, b.active_sprint.path];
+    throw error;
+  }
+  return portfolioState(perSprints);
 }
 
 function main() {
@@ -359,7 +476,11 @@ function main() {
   }
 
   try {
-    const state = readSprintState({ backlogDir: parsed.backlogDir });
+    const state = readSprintState({
+      backlogDir: parsed.backlogDir,
+      track: parsed.track,
+      component: parsed.component,
+    });
     console.log(JSON.stringify(state, null, 2));
   } catch (error) {
     console.error(error.message);

--- a/skills/dev-backlog/scripts/sprint-state.test.js
+++ b/skills/dev-backlog/scripts/sprint-state.test.js
@@ -69,7 +69,7 @@ Expose actor-readable execution state.
       today: new Date("2026-07-03T00:00:00Z"),
     });
 
-    assert.equal(state.schema_version, 1);
+    assert.equal(state.schema_version, 2);
     assert.equal(state.active_sprint.path, sprintPath);
     assert.equal(state.active_sprint.frontmatter.status, "active");
     assert.deepEqual(state.active_sprint.frontmatter.objectives, ["O1", "O2"]);
@@ -118,14 +118,65 @@ Expose actor-readable execution state.
     }]);
   });
 
-  it("throws on ambiguous active sprint state", () => {
+  it("returns a portfolio for multiple disjoint active tracks, ordered by started", () => {
+    writeFile(
+      path.join(backlogDir, "sprints", "auth.md"),
+      "---\nstatus: active\nstarted: 2026-07-02\ncomponent: \"auth\"\n---\n"
+    );
+    writeFile(
+      path.join(backlogDir, "sprints", "billing.md"),
+      "---\nstatus: active\nstarted: 2026-07-01\ncomponent: \"billing\"\n---\n"
+    );
+
+    const state = readSprintState({ backlogDir });
+    assert.equal(state.schema_version, 2);
+    assert.equal(state.active_sprint, null);
+    assert.equal(state.active_sprints.length, 2);
+    assert.deepEqual(
+      state.active_sprints.map((s) => s.active_sprint.frontmatter.component),
+      ["billing", "auth"]
+    );
+  });
+
+  it("returns a portfolio for two scopeless active tracks (cannot prove overlap)", () => {
     writeFile(path.join(backlogDir, "sprints", "a.md"), "---\nstatus: active\n---\n");
     writeFile(path.join(backlogDir, "sprints", "b.md"), "---\nstatus: active\n---\n");
 
+    const state = readSprintState({ backlogDir });
+    assert.equal(state.active_sprints.length, 2);
+    assert.equal(state.active_sprint, null);
+  });
+
+  it("throws OVERLAPPING_TRACKS when two active tracks share scope", () => {
+    writeFile(path.join(backlogDir, "sprints", "a.md"), "---\nstatus: active\ncomponent: \"auth\"\n---\n");
+    writeFile(path.join(backlogDir, "sprints", "b.md"), "---\nstatus: active\ncomponent: \"auth\"\n---\n");
+
     assert.throws(
       () => readSprintState({ backlogDir }),
-      /Multiple active sprint files found/
+      /Active tracks overlap on scope/
     );
+  });
+
+  it("resolves a single track by --component or --track slug", () => {
+    writeFile(
+      path.join(backlogDir, "sprints", "auth.md"),
+      "---\nstatus: active\nstarted: 2026-07-02\ncomponent: \"auth\"\n---\n"
+    );
+    writeFile(
+      path.join(backlogDir, "sprints", "billing.md"),
+      "---\nstatus: active\nstarted: 2026-07-01\ncomponent: \"billing\"\n---\n"
+    );
+
+    const byComponent = readSprintState({ backlogDir, component: "auth" });
+    assert.equal(byComponent.active_sprint.frontmatter.component, "auth");
+    assert.equal(byComponent.active_sprints.length, 1);
+
+    const byTrackSlug = readSprintState({ backlogDir, track: "billing" });
+    assert.equal(byTrackSlug.active_sprint.frontmatter.component, "billing");
+
+    const noMatch = readSprintState({ backlogDir, component: "missing" });
+    assert.equal(noMatch.active_sprint, null);
+    assert.deepEqual(noMatch.active_sprints, []);
   });
 
   it("uses the configured prefix for mixed GitHub and local Plan identities", () => {
@@ -149,7 +200,7 @@ started: 2026-07-01
       today: new Date("2026-07-04T00:00:00Z"),
     });
 
-    assert.equal(state.schema_version, 1);
+    assert.equal(state.schema_version, 2);
     assert.deepEqual(state.plan_items.map(({ tracker, id, ref, issue_number }) => ({
       tracker, id, ref, issue_number,
     })), [

--- a/skills/dev-backlog/scripts/status.sh
+++ b/skills/dev-backlog/scripts/status.sh
@@ -8,15 +8,21 @@ source "$SCRIPT_DIR/lib.sh"
 
 BACKLOG_DIR="backlog"
 JSON=0
-for arg in "$@"; do
-  if [ "$arg" = "--json" ]; then
-    JSON=1
-  else
-    BACKLOG_DIR="$arg"
-  fi
+TRACK=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --json) JSON=1 ;;
+    --track) shift; TRACK="${1:-}" ;;
+    --track=*) TRACK="${1#--track=}" ;;
+    *) BACKLOG_DIR="$1" ;;
+  esac
+  shift
 done
 
 if [ "$JSON" -eq 1 ]; then
+  if [ -n "$TRACK" ]; then
+    exec node "$SCRIPT_DIR/sprint-state.js" --mode status --track "$TRACK" "$BACKLOG_DIR"
+  fi
   exec node "$SCRIPT_DIR/sprint-state.js" --mode status "$BACKLOG_DIR"
 fi
 
@@ -25,12 +31,26 @@ SPRINTS_DIR="$BACKLOG_DIR/sprints"
 # --- Active Sprint ---
 echo "=== Active Sprint ==="
 if [ -d "$SPRINTS_DIR" ]; then
-  ACTIVE=$(find_active_sprint "$SPRINTS_DIR" 2>/dev/null)
-  ACTIVE_STATUS=$?
+  if [ -n "$TRACK" ]; then
+    ACTIVE=$(resolve_track "$SPRINTS_DIR" "$TRACK")
+    if [ -z "$ACTIVE" ]; then ACTIVE_STATUS=1; else ACTIVE_STATUS=0; fi
+  else
+    ACTIVE=$(find_active_sprint "$SPRINTS_DIR" 2>/dev/null)
+    ACTIVE_STATUS=$?
+  fi
   if [ "$ACTIVE_STATUS" -eq 2 ]; then
-    echo "!! Multiple active sprints found. Resolve before continuing:"
+    ACTIVE_COUNT=$(find_active_sprints "$SPRINTS_DIR" | grep -c . || true)
+    echo "$ACTIVE_COUNT active tracks (portfolio):"
     find_active_sprints "$SPRINTS_DIR" | while IFS= read -r sprint; do
-      echo "  - $(basename "$sprint")"
+      [ -z "$sprint" ] && continue
+      NAME=$(basename "$sprint" .md)
+      count_checkboxes "$sprint"
+      if [ "$CB_TOTAL" -gt 0 ]; then PCT=$((CB_DONE * 100 / CB_TOTAL)); else PCT=0; fi
+      if [ "$CB_IN_FLIGHT" -gt 0 ]; then
+        echo "  $NAME: $CB_DONE/$CB_TOTAL ($PCT%) — $CB_IN_FLIGHT in-flight"
+      else
+        echo "  $NAME: $CB_DONE/$CB_TOTAL ($PCT%)"
+      fi
     done
   elif [ "$ACTIVE_STATUS" -eq 0 ]; then
     SPRINT_NAME=$(basename "$ACTIVE" .md)
@@ -67,7 +87,11 @@ if [ -d "$SPRINTS_DIR" ]; then
       echo ">> All items done — ready to close sprint"
     fi
   else
-    echo "(no active sprint)"
+    if [ -n "$TRACK" ]; then
+      echo "(no active track matches '$TRACK')"
+    else
+      echo "(no active sprint)"
+    fi
   fi
 else
   echo "(no backlog/sprints/ directory)"


### PR DESCRIPTION
## Summary

Phase 1a of multi-track sprints (epic #289) — the **read-side resolvers**. Multiple disjoint-scope sprints can now be read as a portfolio, while a single active track stays byte-identical (G4). No lifecycle or doctor changes yet (those are #292/#293).

## Changes

- **`lib.js`** — `scopesOverlap()`: the one shared overlap predicate (`component:` equality; `scope:` glob normalized path-prefix containment). Consumed by sprint-state now; sprint-init (#292) and backlog-doctor (#293) will reuse it.
- **`sprint-state.js`** — `schema_version` → **2**. No-arg emits `active_sprints[]` (ordered by `started:` asc) plus the retained top-level `active_sprint` (sole element when N==1, `null` for a portfolio) so v1 consumers keep working. `--track`/`--component` resolve one track deterministically. `MULTIPLE_ACTIVE_SPRINTS` throw replaced by `OVERLAPPING_TRACKS`, raised **only on scope collision** — disjoint tracks are a portfolio, not an error.
- **`sprint-mirror.js`** — accept `schema_version` 2 (atomic with the bump — review finding B3; landing the bump alone would have broken single-track mirror).
- **`next.sh` / `status.sh` / `context-hook.sh`** — render a portfolio for N>1 disjoint tracks and add `--track` selection; a single active track is unchanged (G4 text).

## Validation

```
smoke-test.sh: 166 tests, 166 passed, 0 failed
known-RED gates: 2 xfail (GATE_MT_DISJOINT / GATE_MT_OVERLAP stay RED)
```

The two multi-track gates **stay RED on purpose** — they assert `backlog-doctor` behavior, which is #293's rewrite; #291 does not touch the doctor. All Node test suites pass (sprint-state +5 multi-track cases, lib +scopesOverlap, mirror schema-2), and the smoke multi-active section was rewritten from the old single-active-invariant messages to the portfolio contract.

**Note (pre-existing, not this PR):** `sprint-init.test.js` #13 is red on `main` already (it asserts `objectives: []` but sprint-init omits spec fields per #258). CI runs only the bash smoke suite, so the Node-suite rot went unnoticed. Recommend fixing in #292 (which touches `sprint-init.js`).

Refs #291, #289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)