### PR TITLE
feat: add idempotent tracker-aware setup-dev-backlog (#277)

### DIFF
--- a/skills/dev-backlog/scripts/github-ownership.test.js
+++ b/skills/dev-backlog/scripts/github-ownership.test.js
@@ -13,6 +13,9 @@ const ALLOWED_DIRECT_GH = new Set([
   "skills/dev-backlog/scripts/github-milestones.js",
   "skills/dev-backlog/scripts/github-mirrors.js",
   "skills/dev-backlog/scripts/progress-sync-github.js",
+  // Setup owns only provider recommendation/repair diagnostics (`gh auth status`),
+  // never task lifecycle operations.
+  "skills/dev-backlog/scripts/setup-dev-backlog.js",
   "skills/backlog-triage/scripts/triage-github.js",
 ]);
 
@@ -26,7 +29,7 @@ function productionJavascriptFiles(directory) {
 }
 
 describe("direct gh production ownership", () => {
-  it("confines execution to the required adapter and explicit GitHub capability transports", () => {
+  it("confines execution to the adapter, capability transports, and setup diagnostics", () => {
     const directPattern = /execFile(?:Sync)?\(\s*["']gh["']|^[ \t]*["']gh["'][ \t]*,/m;
     const directFiles = SCRIPT_ROOTS
       .flatMap(productionJavascriptFiles)

--- a/skills/dev-backlog/scripts/init.sh
+++ b/skills/dev-backlog/scripts/init.sh
@@ -1,39 +1,19 @@
 #!/bin/bash
-set -uo pipefail
-# Bootstrap backlog/ directory for a new project.
+set -euo pipefail
+# Compatibility wrapper for the tracker-aware Node setup entrypoint.
 #
 # Usage: bash scripts/init.sh [project-name]
 #        project-name defaults to the current directory name.
 #
-# Creates:
-#   backlog/sprints/
-#   backlog/tasks/
-#   backlog/completed/
-#   backlog/config.yml
-
 PROJECT_NAME="${1:-$(basename "$(pwd)")}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ARGS=(--project-name "$PROJECT_NAME" --non-interactive)
 
-if [ -d "backlog" ]; then
-  echo "backlog/ already exists. Nothing to do."
-  exit 0
+# The historical init.sh entrypoint created a GitHub-backed fresh config.
+# Existing configs are passed without explicit intent so their valid tracker is
+# preserved and legacy configs receive the one-time GitHub compatibility pin.
+if [ ! -f "backlog/config.yml" ]; then
+  ARGS+=(--tracker github)
 fi
 
-mkdir -p backlog/{sprints,tasks,completed}
-
-cat > backlog/config.yml << EOF
-project_name: "$PROJECT_NAME"
-task_prefix: "BACK"
-default_status: "To Do"
-statuses: ["To Do", "In Progress", "Done"]
-EOF
-
-echo "Created backlog/ structure:"
-echo "  backlog/sprints/     ← Sprint execution files"
-echo "  backlog/tasks/       ← GitHub issue mirror"
-echo "  backlog/completed/   ← Archived done tasks"
-echo "  backlog/config.yml   ← Project config (prefix: BACK)"
-echo ""
-echo "Next steps:"
-echo "  1. Set up GitHub labels: see references/github-sync.md"
-echo "  2. Pull issues: node scripts/sync-pull.js"
-echo "  3. Plan a sprint: node scripts/sprint-init.js \"topic\""
+exec node "$SCRIPT_DIR/setup-dev-backlog.js" "${ARGS[@]}"

--- a/skills/dev-backlog/scripts/lib.js
+++ b/skills/dev-backlog/scripts/lib.js
@@ -110,11 +110,39 @@ function parseYamlScalar(raw) {
   return value;
 }
 
+function isBlockScalarValue(raw) {
+  const value = stripYamlSeparationComment(raw).trim();
+  return /^(?:(?:[&!]\S+)\s+)*(?:[>|](?:[1-9][+-]?|[+-][1-9]?)?)$/.test(value);
+}
+
+function quotedScalarCloses(text, quote, start = 0) {
+  for (let index = start; index < text.length; index += 1) {
+    if (quote === "'" && text[index] === "'" && text[index + 1] === "'") {
+      index += 1;
+    } else if (quote === '"' && text[index] === "\\" && index + 1 < text.length) {
+      index += 1;
+    } else if (text[index] === quote) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function parseSimpleYaml(raw) {
   const root = {};
   const stack = [{ indent: -1, value: root }];
+  let physicalScalar = null;
 
   for (const line of raw.split(/\r?\n/)) {
+    if (physicalScalar && physicalScalar.kind === "block") {
+      if (!line.trim()) continue;
+      const indent = line.match(/^\s*/)[0].length;
+      if (indent > physicalScalar.indent) continue;
+      physicalScalar = null;
+    } else if (physicalScalar && physicalScalar.kind === "quoted") {
+      if (quotedScalarCloses(line, physicalScalar.quote)) physicalScalar = null;
+      continue;
+    }
     if (!line.trim() || line.trimStart().startsWith("#")) continue;
 
     const match = line.match(/^(\s*)([A-Za-z0-9_-]+):(.*)$/);
@@ -136,6 +164,15 @@ function parseSimpleYaml(raw) {
     }
 
     parent[key] = parseYamlScalar(rawValue);
+    if (isBlockScalarValue(rawValue)) {
+      physicalScalar = { kind: "block", indent };
+    } else {
+      const scalar = stripYamlSeparationComment(rawValue).trimStart();
+      const quote = scalar[0];
+      if ((quote === "'" || quote === '"') && !quotedScalarCloses(scalar, quote, 1)) {
+        physicalScalar = { kind: "quoted", quote };
+      }
+    }
   }
 
   return root;

--- a/skills/dev-backlog/scripts/lib.js
+++ b/skills/dev-backlog/scripts/lib.js
@@ -62,8 +62,36 @@ function parseInlineArray(raw) {
   return inner.split(",").map((part) => stripQuotes(part.trim()));
 }
 
+function stripYamlSeparationComment(raw) {
+  let quote = null;
+  const firstNonSpace = raw.search(/\S/);
+  for (let index = 0; index < raw.length; index += 1) {
+    const char = raw[index];
+    if (quote === "'") {
+      if (char === "'" && raw[index + 1] === "'") index += 1;
+      else if (char === "'") quote = null;
+      continue;
+    }
+    if (quote === '"') {
+      if (char === "\\" && index + 1 < raw.length) index += 1;
+      else if (char === '"') quote = null;
+      continue;
+    }
+    const previousNonSpace = raw.slice(0, index).trimEnd().at(-1);
+    if ((char === "'" || char === '"') &&
+        (index === firstNonSpace || previousNonSpace === "[" || previousNonSpace === ",")) {
+      quote = char;
+      continue;
+    }
+    if (char === "#" && index > 0 && /[ \t]/.test(raw[index - 1])) {
+      return raw.slice(0, index);
+    }
+  }
+  return raw;
+}
+
 function parseYamlScalar(raw) {
-  const value = raw.trim();
+  const value = stripYamlSeparationComment(raw).trim();
   if (!value) return "";
   if (
     (value.startsWith('"') && value.endsWith('"')) ||
@@ -89,7 +117,7 @@ function parseSimpleYaml(raw) {
   for (const line of raw.split(/\r?\n/)) {
     if (!line.trim() || line.trimStart().startsWith("#")) continue;
 
-    const match = line.match(/^(\s*)([A-Za-z0-9_-]+):(?:\s*(.*))?$/);
+    const match = line.match(/^(\s*)([A-Za-z0-9_-]+):(.*)$/);
     if (!match) continue;
 
     const indent = match[1].length;

--- a/skills/dev-backlog/scripts/lib.test.js
+++ b/skills/dev-backlog/scripts/lib.test.js
@@ -187,6 +187,39 @@ describe("readConfig", () => {
     }
   });
 
+  it("does not parse block scalar physical content as config keys", () => {
+    const parsed = parseSimpleYaml([
+      "tracker: local",
+      "literal: |",
+      "  tracker: github",
+      "  task_prefix: HIDDEN",
+      "folded: &copy !text >-2 # keep",
+      "  tracker: github",
+      "  task_prefix: ALSO-HIDDEN",
+      "task_prefix: REAL",
+      "",
+    ].join("\n"));
+    assert.equal(parsed.tracker, "local");
+    assert.equal(parsed.task_prefix, "REAL");
+  });
+
+  it("does not parse multiline quoted scalar content as config keys", () => {
+    const parsed = parseSimpleYaml([
+      "tracker: local",
+      "single: 'first line",
+      "  tracker: github",
+      "  it''s still quoted",
+      "  last line'",
+      'double: "first \\"still quoted',
+      "  tracker: github",
+      '  last line"',
+      "task_prefix: REAL",
+      "",
+    ].join("\n"));
+    assert.equal(parsed.tracker, "local");
+    assert.equal(parsed.task_prefix, "REAL");
+  });
+
   it("reads task_prefix from valid config", () => {
     fs.writeFileSync(path.join(tmpDir, "config.yml"), 'task_prefix: "PROJ"\n');
     const config = readConfig(tmpDir);

--- a/skills/dev-backlog/scripts/lib.test.js
+++ b/skills/dev-backlog/scripts/lib.test.js
@@ -7,6 +7,7 @@ const {
   escapeYaml,
   readConfig,
   readTriageConfig,
+  parseSimpleYaml,
   estimateSize,
   fetchOpenIssues,
   CONFIG_DEFAULTS,
@@ -150,6 +151,40 @@ describe("readConfig", () => {
     const compatibilityConfig = readConfig(tmpDir);
     assert.equal(compatibilityConfig.tracker, "github");
     assert.equal(compatibilityConfig.task_prefix, "PROJ");
+  });
+
+  it("strips only quote-aware YAML separation comments", () => {
+    assert.deepEqual(
+      parseSimpleYaml([
+        "tracker: local # keep",
+        "plain: value#suffix",
+        "single: 'it''s # inside' # outside",
+        'double: "say \\"#\\" here" # outside',
+        "count: 75 # outside",
+        'items: ["one # inside", two] # outside',
+        "",
+      ].join("\n")),
+      {
+        tracker: "local",
+        plain: "value#suffix",
+        single: "it's # inside",
+        double: 'say \\"#\\" here',
+        count: 75,
+        items: ["one # inside", "two"],
+      }
+    );
+  });
+
+  it("reads quoted and unquoted tracker values with separated comments", () => {
+    for (const [line, expected] of [
+      ["tracker: local # keep\n", "local"],
+      ["tracker: 'local'\t# keep\n", "local"],
+      ['tracker: "github"  # keep\n', "github"],
+      ["tracker: local#suffix\n", "local#suffix"],
+    ]) {
+      fs.writeFileSync(path.join(tmpDir, "config.yml"), line);
+      assert.equal(readConfig(tmpDir).tracker, expected);
+    }
   });
 
   it("reads task_prefix from valid config", () => {

--- a/skills/dev-backlog/scripts/setup-dev-backlog.integration.test.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.integration.test.js
@@ -1,0 +1,184 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const SCRIPT = path.join(__dirname, "setup-dev-backlog.js");
+const INIT = path.join(__dirname, "init.sh");
+
+function makeRoot(t, prefix = "setup-integration-") {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+
+function providerTrap(t) {
+  const bin = makeRoot(t, "setup-provider-trap-");
+  const log = path.join(bin, "calls.log");
+  for (const command of ["git", "gh"]) {
+    const executable = path.join(bin, command);
+    fs.writeFileSync(executable, `#!/bin/sh\nprintf '%s\\n' ${command} >> "${log}"\nexit 91\n`);
+    fs.chmodSync(executable, 0o755);
+  }
+  return {
+    env: { ...process.env, PATH: `${bin}${path.delimiter}${process.env.PATH}` },
+    calls: () => fs.existsSync(log) ? fs.readFileSync(log, "utf8").trim().split("\n") : [],
+  };
+}
+
+function runCli(root, args, env = process.env) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], { cwd: root, env, encoding: "utf8" });
+}
+
+function snapshot(root) {
+  const result = {};
+  function walk(current, relative = "") {
+    if (!fs.existsSync(current)) return;
+    for (const name of fs.readdirSync(current).sort()) {
+      const full = path.join(current, name);
+      const key = path.join(relative, name);
+      const stat = fs.lstatSync(full);
+      result[key] = {
+        type: stat.isDirectory() ? "directory" : "file",
+        bytes: stat.isFile() ? fs.readFileSync(full).toString("base64") : null,
+        ino: stat.ino,
+        mtimeMs: stat.mtimeMs,
+      };
+      if (stat.isDirectory()) walk(full, key);
+    }
+  }
+  walk(root);
+  return result;
+}
+
+describe("setup-dev-backlog real process integration", () => {
+  it("creates fresh explicit local/github configs without invoking provider commands", (t) => {
+    const trap = providerTrap(t);
+    for (const tracker of ["local", "github"]) {
+      const root = makeRoot(t, `setup-fresh-${tracker}-`);
+      const run = runCli(root, [
+        "--tracker", tracker,
+        "--non-interactive",
+        "--json",
+        "--project-name", `project:${tracker}\nquoted`,
+      ], trap.env);
+      assert.equal(run.status, 0, run.stderr);
+      const result = JSON.parse(run.stdout);
+      assert.equal(result.selection, tracker);
+      const config = fs.readFileSync(path.join(root, "backlog/config.yml"), "utf8");
+      assert.match(config, new RegExp(`^tracker: ${tracker}$`, "m"));
+      assert.match(config, /^project_name: "project:.*\\nquoted"$/m);
+      assert.deepEqual(fs.readdirSync(path.join(root, "backlog")).sort(), [
+        "completed", "config.yml", "sprints", "tasks",
+      ]);
+    }
+    assert.deepEqual(trap.calls(), []);
+  });
+
+  it("refuses no-choice and duplicate tracker arguments before mutation with runnable commands", (t) => {
+    for (const args of [
+      ["--non-interactive"],
+      ["--tracker", "local", "--tracker=github", "--non-interactive"],
+    ]) {
+      const root = makeRoot(t, "setup-refusal-");
+      const run = runCli(root, args);
+      assert.notEqual(run.status, 0);
+      if (args.length === 1) {
+        assert.match(run.stderr, new RegExp(process.execPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+        assert.match(run.stderr, /setup-dev-backlog\.js.*--tracker.*local.*--non-interactive/);
+      } else {
+        assert.match(run.stderr, /--tracker may be supplied only once/);
+      }
+      assert.equal(fs.existsSync(path.join(root, "backlog")), false);
+    }
+  });
+
+  it("pins legacy GitHub authority before allowing an explicit local switch", (t) => {
+    const root = makeRoot(t, "setup-legacy-");
+    const trap = providerTrap(t);
+    fs.mkdirSync(path.join(root, "backlog/tasks"), { recursive: true });
+    const configPath = path.join(root, "backlog/config.yml");
+    fs.writeFileSync(configPath, "project_name: legacy\r\nnotes: keep");
+    fs.writeFileSync(path.join(root, "backlog/tasks/BACK-1.md"), "legacy mirror bytes\r\n");
+    const before = snapshot(root);
+
+    const refused = runCli(root, ["--tracker", "local", "--non-interactive"], trap.env);
+    assert.notEqual(refused.status, 0);
+    assert.match(refused.stderr, /First pin compatibility/);
+    assert.deepEqual(snapshot(root), before);
+
+    const pin = runCli(root, ["--non-interactive", "--json"], trap.env);
+    assert.equal(pin.status, 0, pin.stderr);
+    assert.equal(JSON.parse(pin.stdout).selectionSource, "legacy-pin");
+    assert.equal(
+      fs.readFileSync(configPath, "utf8"),
+      "project_name: legacy\r\nnotes: keep\r\ntracker: github"
+    );
+    const taskBeforeSwitch = snapshot(path.join(root, "backlog/tasks"));
+
+    const switched = runCli(root, ["--tracker=local", "--non-interactive"], trap.env);
+    assert.equal(switched.status, 0, switched.stderr);
+    assert.match(fs.readFileSync(configPath, "utf8"), /\r\ntracker: local$/);
+    assert.deepEqual(snapshot(path.join(root, "backlog/tasks")), taskBeforeSwitch);
+    assert.deepEqual(trap.calls(), []);
+  });
+
+  it("repairs partial structure and reruns byte/idempotently without provider probes", (t) => {
+    const root = makeRoot(t, "setup-partial-");
+    const trap = providerTrap(t);
+    fs.mkdirSync(path.join(root, "backlog/tasks"), { recursive: true });
+    fs.mkdirSync(path.join(root, "backlog/sprints"));
+    fs.writeFileSync(path.join(root, "backlog/config.yml"), "\uFEFFproject_name: existing\r\ntracker: local\r\nnote: |\r\n  tracker: github\r\n");
+    fs.writeFileSync(path.join(root, "backlog/tasks/BACK-2.md"), "task bytes");
+    fs.writeFileSync(path.join(root, "backlog/sprints/current.md"), "sprint bytes\n");
+
+    const first = runCli(root, ["--non-interactive"], trap.env);
+    assert.equal(first.status, 0, first.stderr);
+    const repaired = snapshot(path.join(root, "backlog"));
+    assert.equal(repaired.completed.type, "directory");
+    const second = runCli(root, ["--non-interactive"], trap.env);
+    assert.equal(second.status, 0, second.stderr);
+    assert.deepEqual(snapshot(path.join(root, "backlog")), repaired);
+    assert.deepEqual(trap.calls(), []);
+  });
+
+  it("rejects malformed state before touching user files", (t) => {
+    const root = makeRoot(t, "setup-malformed-");
+    fs.mkdirSync(path.join(root, "backlog/tasks"), { recursive: true });
+    fs.writeFileSync(path.join(root, "backlog/config.yml"), "tracker: local\ntracker: github\n");
+    fs.writeFileSync(path.join(root, "backlog/tasks/user.md"), "user content");
+    const before = snapshot(root);
+    const run = runCli(root, ["--non-interactive"]);
+    assert.notEqual(run.status, 0);
+    assert.match(run.stderr, /Invalid tracker configuration/);
+    assert.match(run.stderr, /setup-dev-backlog\.js/);
+    assert.deepEqual(snapshot(root), before);
+  });
+
+  it("keeps init.sh fresh-GitHub compatibility and preserves an existing local choice", (t) => {
+    const trap = providerTrap(t);
+    const fresh = makeRoot(t, "setup-init-fresh-");
+    const freshRun = spawnSync("bash", [INIT, "wrapper-demo"], {
+      cwd: fresh, env: trap.env, encoding: "utf8",
+    });
+    assert.equal(freshRun.status, 0, freshRun.stderr);
+    assert.match(fs.readFileSync(path.join(fresh, "backlog/config.yml"), "utf8"), /^tracker: github$/m);
+
+    const existing = makeRoot(t, "setup-init-existing-");
+    fs.mkdirSync(path.join(existing, "backlog"));
+    fs.writeFileSync(path.join(existing, "backlog/config.yml"), "project_name: stable\ntracker: local\n");
+    const first = spawnSync("bash", [INIT, "ignored"], {
+      cwd: existing, env: trap.env, encoding: "utf8",
+    });
+    assert.equal(first.status, 0, first.stderr);
+    const stable = snapshot(path.join(existing, "backlog"));
+    const second = spawnSync("bash", [INIT, "changed-remote"], {
+      cwd: existing, env: trap.env, encoding: "utf8",
+    });
+    assert.equal(second.status, 0, second.stderr);
+    assert.deepEqual(snapshot(path.join(existing, "backlog")), stable);
+    assert.deepEqual(trap.calls(), []);
+  });
+});

--- a/skills/dev-backlog/scripts/setup-dev-backlog.integration.test.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.integration.test.js
@@ -35,22 +35,70 @@ function runCli(root, args, env = process.env) {
 function snapshot(root) {
   const result = {};
   function walk(current, relative = "") {
-    if (!fs.existsSync(current)) return;
+    let currentStat;
+    try {
+      currentStat = fs.lstatSync(current);
+    } catch (error) {
+      if (error.code === "ENOENT") return;
+      throw error;
+    }
+    if (!currentStat.isDirectory() || currentStat.isSymbolicLink()) {
+      result[relative || "."] = {
+        type: currentStat.isSymbolicLink() ? "symlink" : "file",
+        bytes: currentStat.isFile() ? fs.readFileSync(current).toString("base64") : null,
+        target: currentStat.isSymbolicLink() ? fs.readlinkSync(current) : null,
+        ino: currentStat.ino,
+        mtimeMs: currentStat.mtimeMs,
+      };
+      return;
+    }
     for (const name of fs.readdirSync(current).sort()) {
       const full = path.join(current, name);
       const key = path.join(relative, name);
       const stat = fs.lstatSync(full);
       result[key] = {
-        type: stat.isDirectory() ? "directory" : "file",
+        type: stat.isSymbolicLink() ? "symlink" : stat.isDirectory() ? "directory" : "file",
         bytes: stat.isFile() ? fs.readFileSync(full).toString("base64") : null,
+        target: stat.isSymbolicLink() ? fs.readlinkSync(full) : null,
         ino: stat.ino,
         mtimeMs: stat.mtimeMs,
       };
-      if (stat.isDirectory()) walk(full, key);
+      if (stat.isDirectory() && !stat.isSymbolicLink()) walk(full, key);
     }
   }
   walk(root);
   return result;
+}
+
+function withoutDirectoryTimes(tree) {
+  return Object.fromEntries(Object.entries(tree).map(([key, value]) => [
+    key,
+    value.type === "directory" ? { ...value, mtimeMs: undefined } : value,
+  ]));
+}
+
+function faultPreload(t, source) {
+  const root = makeRoot(t, "setup-preload-");
+  const preload = path.join(root, "fault.cjs");
+  fs.writeFileSync(preload, source);
+  return preload;
+}
+
+function providerStubs(t, { remote, ghStatus }) {
+  const bin = makeRoot(t, "setup-provider-stubs-");
+  fs.writeFileSync(path.join(bin, "git"), `#!/bin/sh\nprintf '%s\\n' '${remote}'\n`);
+  fs.writeFileSync(path.join(bin, "gh"), `#!/bin/sh\nexit ${ghStatus}\n`);
+  fs.chmodSync(path.join(bin, "git"), 0o755);
+  fs.chmodSync(path.join(bin, "gh"), 0o755);
+  const preload = faultPreload(t, [
+    'Object.defineProperty(process.stdin, "isTTY", { value: true });',
+    'Object.defineProperty(process.stdout, "isTTY", { value: true });',
+  ].join("\n"));
+  return {
+    ...process.env,
+    PATH: `${bin}${path.delimiter}${process.env.PATH}`,
+    NODE_OPTIONS: `--require=${preload}`,
+  };
 }
 
 describe("setup-dev-backlog real process integration", () => {
@@ -155,6 +203,128 @@ describe("setup-dev-backlog real process integration", () => {
     assert.match(run.stderr, /Invalid tracker configuration/);
     assert.match(run.stderr, /setup-dev-backlog\.js/);
     assert.deepEqual(snapshot(root), before);
+  });
+
+  it("rejects every dangling canonical symlink before any mutation", (t) => {
+    for (const relative of [
+      "backlog",
+      "backlog/config.yml",
+      "backlog/sprints",
+      "backlog/tasks",
+      "backlog/completed",
+    ]) {
+      const root = makeRoot(t, "setup-dangling-");
+      const link = path.join(root, relative);
+      fs.mkdirSync(path.dirname(link), { recursive: true });
+      fs.symlinkSync(path.join(root, "missing-target"), link);
+      const before = snapshot(root);
+      const run = runCli(root, ["--tracker", "local", "--non-interactive"]);
+      assert.notEqual(run.status, 0, `${relative}: ${run.stderr}`);
+      assert.match(run.stderr, /unsafe (?:backlog|config) path/, relative);
+      assert.deepEqual(snapshot(root), before, relative);
+    }
+  });
+
+  it("rolls back real-process setup on mkdir, write, and rename failures", (t) => {
+    const failures = {
+      mkdir: [
+        'const fs = require("node:fs");',
+        'const original = fs.mkdirSync;',
+        'fs.mkdirSync = function (target, options) {',
+        '  if (String(target).endsWith("/backlog/tasks")) throw new Error("injected mkdir failure");',
+        '  return original.call(this, target, options);',
+        '};',
+      ].join("\n"),
+      write: [
+        'const fs = require("node:fs");',
+        'const original = fs.writeFileSync;',
+        'fs.writeFileSync = function (target, content, options) {',
+        '  if (String(target).includes(".config.yml.") && String(target).endsWith(".tmp")) {',
+        '    original.call(this, target, "partial", options);',
+        '    throw new Error("injected write failure");',
+        '  }',
+        '  return original.call(this, target, content, options);',
+        '};',
+      ].join("\n"),
+      rename: [
+        'const fs = require("node:fs");',
+        'const original = fs.renameSync;',
+        'fs.renameSync = function (from, to) {',
+        '  if (String(to).endsWith("/backlog/config.yml")) throw new Error("injected rename failure");',
+        '  return original.call(this, from, to);',
+        '};',
+      ].join("\n"),
+    };
+
+    for (const [failure, source] of Object.entries(failures)) {
+      const root = makeRoot(t, `setup-failure-${failure}-`);
+      const preload = faultPreload(t, source);
+      if (failure !== "mkdir") {
+        fs.mkdirSync(path.join(root, "backlog"));
+        for (const name of ["sprints", "tasks", "completed"]) {
+          fs.mkdirSync(path.join(root, "backlog", name));
+        }
+        fs.writeFileSync(
+          path.join(root, "backlog/config.yml"),
+          "project_name: preserved\r\ntracker: local\r\n# exact bytes"
+        );
+      }
+      const before = snapshot(root);
+      const run = runCli(root, ["--tracker", failure === "mkdir" ? "local" : "github", "--non-interactive"], {
+        ...process.env,
+        NODE_OPTIONS: `--require=${preload}`,
+      });
+      assert.notEqual(run.status, 0, failure);
+      assert.match(run.stderr, new RegExp(`injected ${failure} failure`));
+      assert.deepEqual(withoutDirectoryTimes(snapshot(root)), withoutDirectoryTimes(before), failure);
+    }
+  });
+
+  it("changes only the tracker bytes around complex preserved YAML lexical contexts", (t) => {
+    const root = makeRoot(t, "setup-lexical-preservation-");
+    fs.mkdirSync(path.join(root, "backlog"));
+    const original = [
+      '"note:with:colons": &copy !text |-2',
+      "    tracker: text in block",
+      "single: 'first line",
+      "  tracker: text in single quote",
+      "  last line'",
+      'double: "first line',
+      "  tracker: text in double quote",
+      '  last line"',
+      "tracker: github # selected",
+      "tail: preserved",
+    ].join("\r\n");
+    fs.writeFileSync(path.join(root, "backlog/config.yml"), original);
+
+    const run = runCli(root, ["--tracker", "local", "--non-interactive"]);
+    assert.equal(run.status, 0, run.stderr);
+    assert.equal(
+      fs.readFileSync(path.join(root, "backlog/config.yml"), "utf8"),
+      original.replace("tracker: github # selected", "tracker: local # selected")
+    );
+  });
+
+  it("uses stubbed origin and gh evidence for fresh interactive recommendations", (t) => {
+    for (const row of [
+      { remote: "https://github.com/owner/repo.git", ghStatus: 0, expected: "github" },
+      { remote: "https://github.com/owner/repo/issues", ghStatus: 0, expected: "local" },
+      { remote: "https://github.com/owner/repo.git", ghStatus: 1, expected: "local" },
+    ]) {
+      const root = makeRoot(t, `setup-interactive-${row.expected}-`);
+      const run = spawnSync(process.execPath, [SCRIPT, "--json"], {
+        cwd: root,
+        env: providerStubs(t, row),
+        encoding: "utf8",
+        input: "\n",
+      });
+      assert.equal(run.status, 0, run.stderr);
+      const jsonStart = run.stdout.indexOf("{");
+      const result = JSON.parse(run.stdout.slice(jsonStart));
+      assert.equal(result.selection, row.expected);
+      assert.equal(result.selectionSource, "recommended");
+      assert.equal(result.evidence.remote, row.remote.includes("/issues") ? "non-github" : "github");
+    }
   });
 
   it("keeps init.sh fresh-GitHub compatibility and preserves an existing local choice", (t) => {

--- a/skills/dev-backlog/scripts/setup-dev-backlog.integration.test.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.integration.test.js
@@ -354,6 +354,16 @@ describe("setup-dev-backlog real process integration", () => {
       "note: !<unterminated\ntracker: local\n",
       'note: "bad\\q"\ntracker: local\n',
       "%YAML 1.2\n---\ntracker: local\n",
+      "%TAG ! tag:example.com,2026:\ntracker: local\n",
+      "%FOO bar\ntracker: local\n",
+      "note: &\ntracker: local\n",
+      "note: !\ntracker: local\n",
+      "note: *\ntracker: local\n",
+      "note: !<>\ntracker: local\n",
+      'note: "bad\\uD800"\ntracker: local\n',
+      "note: \0\ntracker: local\n",
+      "note: \x01\ntracker: local\n",
+      "note: \ufffe\ntracker: local\n",
     ]) {
       const root = makeRoot(t, "setup-document-state-");
       fs.mkdirSync(path.join(root, "backlog"));
@@ -401,6 +411,50 @@ describe("setup-dev-backlog real process integration", () => {
     assert.equal(run.status, 0, run.stderr);
     const after = snapshot(root);
     assert.deepEqual(after["backlog/config.yml"], before["backlog/config.yml"]);
+    assert.equal(fs.readFileSync(path.join(root, "backlog/config.yml"), "utf8"), raw);
+  });
+
+  it("rejects a raw surrogate from the real CLI read boundary without mutation", (t) => {
+    const root = makeRoot(t, "setup-surrogate-");
+    fs.mkdirSync(path.join(root, "backlog"));
+    fs.writeFileSync(path.join(root, "backlog/config.yml"), "tracker: local\n");
+    const preload = faultPreload(t, [
+      'const fs = require("node:fs");',
+      'const original = fs.readFileSync;',
+      'fs.readFileSync = function (target, options) {',
+      '  if (String(target).endsWith("/backlog/config.yml") && options === "utf8") {',
+      '    return "note: \\ud800\\ntracker: local\\n";',
+      '  }',
+      '  return original.call(this, target, options);',
+      '};',
+    ].join("\n"));
+    const before = snapshot(root);
+    const run = runCli(root, ["--non-interactive"], {
+      ...process.env,
+      NODE_OPTIONS: `--require=${preload}`,
+    });
+    assert.notEqual(run.status, 0);
+    assert.match(run.stderr, /raw surrogate/);
+    assert.deepEqual(snapshot(root), before);
+  });
+
+  it("preserves valid Unicode anchors, aliases, tags, and quoted escapes", (t) => {
+    const root = makeRoot(t, "setup-valid-unicode-");
+    fs.mkdirSync(path.join(root, "backlog"));
+    const raw = [
+      "note: &한글 값",
+      "copy: *한글",
+      "tagged: !<tag:example.com,2026:value> 값",
+      "local: !foo 값",
+      "standard: !!str 값",
+      'escaped: "\\N \\u263A \\U0001F600"',
+      "raw: 😀",
+      "tracker: local",
+      "",
+    ].join("\n");
+    fs.writeFileSync(path.join(root, "backlog/config.yml"), raw);
+    const run = runCli(root, ["--non-interactive"]);
+    assert.equal(run.status, 0, run.stderr);
     assert.equal(fs.readFileSync(path.join(root, "backlog/config.yml"), "utf8"), raw);
   });
 

--- a/skills/dev-backlog/scripts/setup-dev-backlog.integration.test.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.integration.test.js
@@ -305,6 +305,34 @@ describe("setup-dev-backlog real process integration", () => {
     );
   });
 
+  it("preserves plain apostrophes and rejects advanced tracker keys before mutation", (t) => {
+    const preserved = makeRoot(t, "setup-plain-quotes-");
+    fs.mkdirSync(path.join(preserved, "backlog"));
+    const plainRaw = "note: don't stop\nmessage: say \"go\" now\ntracker: local\n";
+    fs.writeFileSync(path.join(preserved, "backlog/config.yml"), plainRaw);
+    const preservedRun = runCli(preserved, ["--non-interactive"]);
+    assert.equal(preservedRun.status, 0, preservedRun.stderr);
+    assert.equal(fs.readFileSync(path.join(preserved, "backlog/config.yml"), "utf8"), plainRaw);
+
+    for (const declaration of [
+      "items: [tracker: github]",
+      "&authority tracker: github",
+      "? tracker\n: github",
+      'mapping: {"track\\x65r": github}',
+      "mapping: {emoji: 😀, tracker: github}",
+      "mapping: [\n  {emoji: 😀,\n   tracker: github}\n]",
+    ]) {
+      const root = makeRoot(t, "setup-advanced-key-");
+      fs.mkdirSync(path.join(root, "backlog"));
+      fs.writeFileSync(path.join(root, "backlog/config.yml"), `${declaration}\ntracker: local\n`);
+      const before = snapshot(root);
+      const run = runCli(root, ["--non-interactive"]);
+      assert.notEqual(run.status, 0, declaration);
+      assert.match(run.stderr, /Invalid tracker configuration/, declaration);
+      assert.deepEqual(snapshot(root), before, declaration);
+    }
+  });
+
   it("uses stubbed origin and gh evidence for fresh interactive recommendations", (t) => {
     for (const row of [
       { remote: "https://github.com/owner/repo.git", ghStatus: 0, expected: "github" },

--- a/skills/dev-backlog/scripts/setup-dev-backlog.integration.test.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.integration.test.js
@@ -205,6 +205,20 @@ describe("setup-dev-backlog real process integration", () => {
     assert.deepEqual(snapshot(root), before);
   });
 
+  it("rejects tracker values with an unseparated hash before real CLI mutation", (t) => {
+    for (const tracker of ["local", "github"]) {
+      const root = makeRoot(t, `setup-comment-boundary-${tracker}-`);
+      fs.mkdirSync(path.join(root, "backlog/tasks"), { recursive: true });
+      fs.writeFileSync(path.join(root, "backlog/config.yml"), `tracker: ${tracker}#not-a-comment\n`);
+      fs.writeFileSync(path.join(root, "backlog/tasks/user.md"), "user bytes\n");
+      const before = snapshot(root);
+      const run = runCli(root, ["--non-interactive"]);
+      assert.notEqual(run.status, 0, tracker);
+      assert.match(run.stderr, /Invalid tracker configuration/);
+      assert.deepEqual(snapshot(root), before, tracker);
+    }
+  });
+
   it("rejects every dangling canonical symlink before any mutation", (t) => {
     for (const relative of [
       "backlog",

--- a/skills/dev-backlog/scripts/setup-dev-backlog.integration.test.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.integration.test.js
@@ -333,6 +333,28 @@ describe("setup-dev-backlog real process integration", () => {
     }
   });
 
+  it("rejects incomplete EOF and cross-line authority before any real CLI mutation", (t) => {
+    for (const raw of [
+      'note: "unterminated\ntracker: local\n',
+      "mapping: {other: value\ntracker: local\n",
+      "tracker: local\n?\n",
+      "?\n  tracker\n: github\ntracker: local\n",
+      '?\n  "track\\\n    er"\n: github\ntracker: local\n',
+      "key_name: &authority tracker\n*authority: github\ntracker: local\n",
+      "*unknown: value\ntracker: local\n",
+      "<<: *unknown\ntracker: local\n",
+    ]) {
+      const root = makeRoot(t, "setup-document-state-");
+      fs.mkdirSync(path.join(root, "backlog"));
+      fs.writeFileSync(path.join(root, "backlog/config.yml"), raw);
+      const before = snapshot(root);
+      const run = runCli(root, ["--non-interactive"]);
+      assert.notEqual(run.status, 0, raw);
+      assert.match(run.stderr, /Invalid tracker configuration/, raw);
+      assert.deepEqual(snapshot(root), before, raw);
+    }
+  });
+
   it("uses stubbed origin and gh evidence for fresh interactive recommendations", (t) => {
     for (const row of [
       { remote: "https://github.com/owner/repo.git", ghStatus: 0, expected: "github" },

--- a/skills/dev-backlog/scripts/setup-dev-backlog.integration.test.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.integration.test.js
@@ -348,6 +348,12 @@ describe("setup-dev-backlog real process integration", () => {
       "tracker: local\n---\n",
       "---\n---\ntracker: local\n",
       "---\ntracker: local\n...\n",
+      "mapping: ]\ntracker: local\n",
+      "mapping: {items: [one}}\ntracker: local\n",
+      "mapping: {items: [one]\ntracker: local\n",
+      "note: !<unterminated\ntracker: local\n",
+      'note: "bad\\q"\ntracker: local\n',
+      "%YAML 1.2\n---\ntracker: local\n",
     ]) {
       const root = makeRoot(t, "setup-document-state-");
       fs.mkdirSync(path.join(root, "backlog"));
@@ -372,11 +378,29 @@ describe("setup-dev-backlog real process integration", () => {
       "  ...",
       'quoted: "--- and ..."',
       "tracker: local",
+      "plain: continued",
+      "  ---",
+      "  ...",
+      "'<<': *empty",
+      "flow: {'<<': *empty}",
       "",
     ].join("\n");
     fs.writeFileSync(path.join(root, "backlog/config.yml"), raw);
     const run = runCli(root, ["--non-interactive"]);
     assert.equal(run.status, 0, run.stderr);
+    assert.equal(fs.readFileSync(path.join(root, "backlog/config.yml"), "utf8"), raw);
+  });
+
+  it("preserves matching multiline flow state without changing config bytes", (t) => {
+    const root = makeRoot(t, "setup-flow-stack-");
+    fs.mkdirSync(path.join(root, "backlog"));
+    const raw = "mapping: {items: [one,\n  two]}\ntracker: local\n";
+    fs.writeFileSync(path.join(root, "backlog/config.yml"), raw);
+    const before = snapshot(root);
+    const run = runCli(root, ["--non-interactive"]);
+    assert.equal(run.status, 0, run.stderr);
+    const after = snapshot(root);
+    assert.deepEqual(after["backlog/config.yml"], before["backlog/config.yml"]);
     assert.equal(fs.readFileSync(path.join(root, "backlog/config.yml"), "utf8"), raw);
   });
 

--- a/skills/dev-backlog/scripts/setup-dev-backlog.integration.test.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.integration.test.js
@@ -343,6 +343,11 @@ describe("setup-dev-backlog real process integration", () => {
       "key_name: &authority tracker\n*authority: github\ntracker: local\n",
       "*unknown: value\ntracker: local\n",
       "<<: *unknown\ntracker: local\n",
+      "<<: [*one, *two]\ntracker: local\n",
+      "mapping: {<<: *unknown}\ntracker: local\n",
+      "tracker: local\n---\n",
+      "---\n---\ntracker: local\n",
+      "---\ntracker: local\n...\n",
     ]) {
       const root = makeRoot(t, "setup-document-state-");
       fs.mkdirSync(path.join(root, "backlog"));
@@ -353,6 +358,26 @@ describe("setup-dev-backlog real process integration", () => {
       assert.match(run.stderr, /Invalid tracker configuration/, raw);
       assert.deepEqual(snapshot(root), before, raw);
     }
+  });
+
+  it("preserves null anchors, alias values, and markers inside scalar content", (t) => {
+    const root = makeRoot(t, "setup-narrow-yaml-");
+    fs.mkdirSync(path.join(root, "backlog"));
+    const raw = [
+      "---",
+      "note: &empty",
+      "note2: *empty",
+      "literal: |",
+      "  ---",
+      "  ...",
+      'quoted: "--- and ..."',
+      "tracker: local",
+      "",
+    ].join("\n");
+    fs.writeFileSync(path.join(root, "backlog/config.yml"), raw);
+    const run = runCli(root, ["--non-interactive"]);
+    assert.equal(run.status, 0, run.stderr);
+    assert.equal(fs.readFileSync(path.join(root, "backlog/config.yml"), "utf8"), raw);
   });
 
   it("uses stubbed origin and gh evidence for fresh interactive recommendations", (t) => {

--- a/skills/dev-backlog/scripts/setup-dev-backlog.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.js
@@ -140,8 +140,8 @@ function lineRecords(raw) {
   return records;
 }
 
-function consumeQuotedToken(line, start, quote) {
-  let raw = "";
+function consumeQuotedToken(line, start, quote, initialRaw = "") {
+  let raw = initialRaw;
   for (let index = start + 1; index < line.length; index += 1) {
     if (quote === "'" && line[index] === "'" && line[index + 1] === "'") {
       raw += "''";
@@ -199,10 +199,29 @@ function tokenizeYamlLine(line, state = {}) {
   let nodeBoundary = flowDepth > 0 ? Boolean(state.nodeBoundary) : true;
 
   if (carriedQuote) {
-    const continuation = consumeQuotedToken(line, -1, carriedQuote);
-    if (!continuation.closed) {
-      return { tokens, state: { quote: carriedQuote, flowDepth, nodeBoundary: false } };
+    let continuationStart = -1;
+    let initialRaw = carriedQuote.raw;
+    if (carriedQuote.char === '"' && initialRaw.endsWith("\\")) {
+      initialRaw = initialRaw.slice(0, -1);
+      while (/[ \t]/.test(line[continuationStart + 1] || "")) continuationStart += 1;
+    } else {
+      initialRaw += " ";
     }
+    const continuation = consumeQuotedToken(line, continuationStart, carriedQuote.char, initialRaw);
+    if (!continuation.closed) {
+      return {
+        tokens,
+        state: {
+          quote: { char: carriedQuote.char, raw: continuation.raw },
+          flowDepth,
+          nodeBoundary: false,
+        },
+      };
+    }
+    const value = carriedQuote.char === "'"
+      ? continuation.raw.replaceAll("''", "'")
+      : decodeDoubleQuotedScalar(continuation.raw);
+    tokens.push({ type: "scalar", value, quoted: true });
     index = continuation.end;
     carriedQuote = null;
     nodeBoundary = false;
@@ -219,7 +238,7 @@ function tokenizeYamlLine(line, state = {}) {
     if (nodeBoundary && (char === "'" || char === '"')) {
       const quoted = consumeQuotedToken(line, index, char);
       if (!quoted.closed) {
-        return { tokens, state: { quote: char, flowDepth, nodeBoundary: false } };
+        return { tokens, state: { quote: { char, raw: quoted.raw }, flowDepth, nodeBoundary: false } };
       }
       const value = char === "'"
         ? quoted.raw.replaceAll("''", "'")
@@ -238,18 +257,31 @@ function tokenizeYamlLine(line, state = {}) {
       } else {
         while (index < line.length && !/[ \t,\[\]{}]/.test(line[index])) index += 1;
       }
-      tokens.push({ type: "property", value: line.slice(start, index) });
+      tokens.push({
+        type: "property",
+        value: line.slice(start, index),
+        anchor: char === "&" ? line.slice(start + 1, index) : null,
+      });
       continue;
     }
 
-    if (char === "{" || char === "[") {
+    if (nodeBoundary && char === "*") {
+      const start = index + 1;
+      index = start;
+      while (index < line.length && /[A-Za-z0-9_-]/.test(line[index])) index += 1;
+      tokens.push({ type: "alias", name: line.slice(start, index) });
+      nodeBoundary = false;
+      continue;
+    }
+
+    if (nodeBoundary && (char === "{" || char === "[")) {
       tokens.push({ type: char });
       flowDepth += 1;
       nodeBoundary = true;
       index += 1;
       continue;
     }
-    if (char === "}" || char === "]") {
+    if (flowDepth > 0 && (char === "}" || char === "]")) {
       tokens.push({ type: char });
       flowDepth = Math.max(0, flowDepth - 1);
       nodeBoundary = false;
@@ -268,7 +300,7 @@ function tokenizeYamlLine(line, state = {}) {
       index += 1;
       continue;
     }
-    if (nodeBoundary && char === "?" && /[ \t]/.test(line[index + 1] || "")) {
+    if (nodeBoundary && char === "?" && (line[index + 1] === undefined || /[ \t]/.test(line[index + 1]))) {
       tokens.push({ type: "?" });
       index += 1;
       continue;
@@ -282,7 +314,7 @@ function tokenizeYamlLine(line, state = {}) {
     const start = index;
     while (index < line.length) {
       const current = line[index];
-      if (current === "#" || current === "{" || current === "[" || current === "}" || current === "]") break;
+      if (current === "#" || (flowDepth > 0 && /[{}\[\]]/.test(current))) break;
       if (flowDepth > 0 && current === ",") break;
       if (current === ":" && isColonIndicator(line, index)) break;
       index += 1;
@@ -296,15 +328,62 @@ function tokenizeYamlLine(line, state = {}) {
   return { tokens, state: { quote: null, flowDepth, nodeBoundary } };
 }
 
-function trackerKeyCount(tokens) {
+function resolveAliasValue(token, anchors) {
+  if (token.type !== "alias") return token.type === "scalar" ? token.value : undefined;
+  const anchored = anchors.get(token.name);
+  return anchored && anchored.kind === "scalar" ? anchored.value : undefined;
+}
+
+function trackerKeyCount(tokens, anchors, onAmbiguousAlias) {
   let count = 0;
   for (let index = 0; index < tokens.length; index += 1) {
-    if (tokens[index].type !== "scalar" || tokens[index].value !== "tracker") continue;
+    if (tokens[index].type !== "scalar" && tokens[index].type !== "alias") continue;
     const next = tokens[index + 1];
     const previous = tokens[index - 1];
-    if ((next && next.type === ":") || (previous && previous.type === "?")) count += 1;
+    const keyPosition = (next && next.type === ":") || (previous && previous.type === "?");
+    if (!keyPosition) continue;
+    const anchored = tokens[index].type === "alias" ? anchors.get(tokens[index].name) : null;
+    const value = resolveAliasValue(tokens[index], anchors);
+    if (value === "tracker") count += 1;
+    else if (tokens[index].type === "alias" && !anchored) onAmbiguousAlias(tokens[index].name);
   }
   return count;
+}
+
+function firstNodeToken(tokens, start = 0) {
+  return tokens.slice(start).find((token) => token.type === "scalar" || token.type === "alias" || token.type === "{" || token.type === "[");
+}
+
+function recordDocumentAnchors(tokens, documentState) {
+  const pending = [...documentState.pendingAnchors];
+  documentState.pendingAnchors.length = 0;
+  if (pending.length > 0) {
+    const node = firstNodeToken(tokens);
+    if (node) {
+      const value = resolveAliasValue(node, documentState.anchors);
+      for (const name of pending) {
+        documentState.anchors.set(name, node.type === "scalar" || node.type === "alias"
+          ? { kind: "scalar", value }
+          : { kind: "collection" });
+      }
+    } else {
+      documentState.pendingAnchors.push(...pending);
+    }
+  }
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token.type === "property" && token.anchor) {
+      const node = firstNodeToken(tokens, index + 1);
+      if (node) {
+        const value = resolveAliasValue(node, documentState.anchors);
+        documentState.anchors.set(token.anchor, node.type === "scalar" || node.type === "alias"
+          ? { kind: "scalar", value }
+          : { kind: "collection" });
+      } else {
+        documentState.pendingAnchors.push(token.anchor);
+      }
+    }
+  }
 }
 
 function isBlockScalarHeader(tokens) {
@@ -315,10 +394,17 @@ function isBlockScalarHeader(tokens) {
   return tokens.some((token) => token.type === ":");
 }
 
-function trackerCandidates(raw) {
+function trackerCandidates(raw, configPath) {
   const candidates = [];
   let blockScalarParentIndent = null;
   let lexicalState = { quote: null, flowDepth: 0, nodeBoundary: true };
+  const documentState = { anchors: new Map(), pendingAnchors: [], explicitKeyPending: false };
+  const ambiguousAlias = (name) => {
+    throw new ConfigValidationError(
+      configPath,
+      `alias ${JSON.stringify(`*${name}`)} could resolve to tracker authority and is ambiguous`
+    );
+  };
 
   for (const record of lineRecords(raw)) {
     const withoutBom = record.text.replace(/^\uFEFF/, "");
@@ -330,10 +416,37 @@ function trackerCandidates(raw) {
     }
     const scanned = tokenizeYamlLine(record.text, lexicalState);
     lexicalState = scanned.state;
-    for (let count = trackerKeyCount(scanned.tokens); count > 0; count -= 1) candidates.push(record);
+    recordDocumentAnchors(scanned.tokens, documentState);
+    for (
+      let count = trackerKeyCount(scanned.tokens, documentState.anchors, ambiguousAlias);
+      count > 0;
+      count -= 1
+    ) candidates.push(record);
+
+    if (documentState.explicitKeyPending) {
+      const node = firstNodeToken(scanned.tokens);
+      if (node) {
+        const anchored = node.type === "alias" ? documentState.anchors.get(node.name) : null;
+        const value = resolveAliasValue(node, documentState.anchors);
+        if (value === "tracker") candidates.push(record);
+        else if (node.type === "alias" && !anchored) ambiguousAlias(node.name);
+        documentState.explicitKeyPending = false;
+      }
+    }
+    const last = scanned.tokens[scanned.tokens.length - 1];
+    if (last && last.type === "?") documentState.explicitKeyPending = true;
+
+    for (let index = 0; index < scanned.tokens.length - 2; index += 1) {
+      const [key, colon, alias] = scanned.tokens.slice(index, index + 3);
+      if (key.type === "scalar" && key.value === "<<" && colon.type === ":" && alias.type === "alias" &&
+          !documentState.anchors.has(alias.name)) ambiguousAlias(alias.name);
+    }
     if (!lexicalState.quote && lexicalState.flowDepth === 0 && isBlockScalarHeader(scanned.tokens)) {
       blockScalarParentIndent = indent;
     }
+  }
+  if (lexicalState.quote || lexicalState.flowDepth !== 0 || documentState.explicitKeyPending) {
+    throw new ConfigValidationError(configPath, "the YAML lexical structure is incomplete at end of file");
   }
   return candidates;
 }
@@ -362,7 +475,7 @@ function inspectConfig(raw, configPath = "backlog/config.yml") {
     throw new ConfigValidationError(configPath, "the config could not be read as text");
   }
 
-  const candidates = trackerCandidates(raw);
+  const candidates = trackerCandidates(raw, configPath);
   if (candidates.length === 0) {
     return Object.freeze({ kind: "legacy", tracker: undefined });
   }
@@ -412,8 +525,15 @@ function isGithubRemote(remote) {
   const value = String(remote || "").trim();
   if (!value) return false;
   const component = "[A-Za-z0-9_.-]+";
-  if (new RegExp(`^git@github\\.com:${component}/${component}(?:\\.git)?$`).test(value)) {
-    return true;
+  const scp = value.match(/^git@([^:]+):(.+)$/);
+  if (scp && scp[1].toLowerCase() === "github.com") {
+    const parts = scp[2].split("/");
+    const repo = (parts[1] || "").replace(/\.git$/, "");
+    return parts.length === 2 &&
+      new RegExp(`^${component}$`).test(parts[0]) &&
+      new RegExp(`^${component}$`).test(repo) &&
+      ![".", ".."].includes(parts[0]) &&
+      ![".", ".."].includes(repo);
   }
   try {
     const parsed = new URL(value);

--- a/skills/dev-backlog/scripts/setup-dev-backlog.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.js
@@ -15,6 +15,16 @@ const readline = require("node:readline/promises");
 const ALLOWED_TRACKERS = Object.freeze(["github", "local"]);
 const MINIMUM_DIRECTORIES = Object.freeze(["sprints", "tasks", "completed"]);
 
+function shellQuote(value) {
+  const text = String(value);
+  if (/^[A-Za-z0-9_./:=@+-]+$/.test(text)) return text;
+  return `'${text.replaceAll("'", `'"'"'`)}'`;
+}
+
+function setupCommand(args = []) {
+  return [shellQuote(process.execPath), shellQuote(__filename), ...args.map(shellQuote)].join(" ");
+}
+
 class SetupError extends Error {
   constructor(message, options = {}) {
     super(message, options);
@@ -28,7 +38,7 @@ class ConfigValidationError extends SetupError {
     super(
       `Invalid tracker configuration in ${configPath}: ${reason}. ` +
         `Expected exactly one top-level "tracker: github" or "tracker: local" line. ` +
-        `Repair the file, then rerun: node setup-dev-backlog.js --tracker github --non-interactive.`
+        `Repair the file, then rerun: ${setupCommand(["--tracker", "github", "--non-interactive"])}.`
     );
     this.name = "ConfigValidationError";
     this.configPath = configPath;
@@ -64,13 +74,18 @@ function parseArgs(argv = process.argv.slice(2)) {
     help: false,
   };
   let positionalProjectName;
+  let trackerFlagSeen = false;
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === "--tracker") {
+      if (trackerFlagSeen) throw new SetupError("--tracker may be supplied only once.");
+      trackerFlagSeen = true;
       options.tracker = takeValue(argv, index, "--tracker");
       index += 1;
     } else if (arg.startsWith("--tracker=")) {
+      if (trackerFlagSeen) throw new SetupError("--tracker may be supplied only once.");
+      trackerFlagSeen = true;
       options.tracker = arg.slice("--tracker=".length);
     } else if (arg === "--project-name") {
       options.projectName = takeValue(argv, index, "--project-name");
@@ -128,16 +143,36 @@ function lineRecords(raw) {
 function looksLikeTrackerDeclaration(line) {
   if (!line.trim() || line.trimStart().startsWith("#")) return false;
   return (
-    /^\s*tracker\b/.test(line) ||
+    /^\uFEFF?\s*tracker\s*:/.test(line) ||
     /^\s*["']tracker["']\s*:/.test(line) ||
     /^\s*-\s*tracker\s*:/.test(line) ||
     /[{,]\s*tracker\s*:/.test(line)
   );
 }
 
+function trackerCandidates(raw) {
+  const candidates = [];
+  let blockScalarParentIndent = null;
+
+  for (const record of lineRecords(raw)) {
+    const withoutBom = record.text.replace(/^\uFEFF/, "");
+    const trimmed = withoutBom.trim();
+    const indent = withoutBom.match(/^[ \t]*/)[0].length;
+    if (blockScalarParentIndent !== null) {
+      if (!trimmed || indent > blockScalarParentIndent) continue;
+      blockScalarParentIndent = null;
+    }
+    if (looksLikeTrackerDeclaration(record.text)) candidates.push(record);
+    if (/^\s*(?:[^#][^:]*):[ \t]*[>|](?:[1-9][+-]?|[+-][1-9]?)?\s*(?:#.*)?$/.test(withoutBom)) {
+      blockScalarParentIndent = indent;
+    }
+  }
+  return candidates;
+}
+
 function parseValidTrackerLine(record) {
   const match = record.text.match(
-    /^tracker:([ \t]*)(?:(["'])(github|local)\2|(github|local))([ \t]*(?:#.*)?)$/
+    /^\uFEFF?tracker:([ \t]*)(?:(["'])(github|local)\2|(github|local))([ \t]*(?:#.*)?)$/
   );
   if (!match) return null;
 
@@ -159,7 +194,7 @@ function inspectConfig(raw, configPath = "backlog/config.yml") {
     throw new ConfigValidationError(configPath, "the config could not be read as text");
   }
 
-  const candidates = lineRecords(raw).filter((record) => looksLikeTrackerDeclaration(record.text));
+  const candidates = trackerCandidates(raw);
   if (candidates.length === 0) {
     return Object.freeze({ kind: "legacy", tracker: undefined });
   }
@@ -356,6 +391,29 @@ function ensureMinimumDirectories(backlogDir, fsApi) {
   return { backlogCreated, created };
 }
 
+function validateExistingStructure(backlogDir, configPath, fsApi) {
+  if (fsApi.existsSync(backlogDir)) {
+    const backlogStat = fsApi.lstatSync(backlogDir);
+    if (backlogStat.isSymbolicLink() || !backlogStat.isDirectory()) {
+      throw new SetupError(`Refusing unsafe backlog path: ${backlogDir} must be a real directory.`);
+    }
+  }
+  if (fsApi.existsSync(configPath)) {
+    const configStat = fsApi.lstatSync(configPath);
+    if (configStat.isSymbolicLink() || !configStat.isFile()) {
+      throw new SetupError(`Refusing unsafe config path: ${configPath} must be a regular file.`);
+    }
+  }
+  for (const name of MINIMUM_DIRECTORIES) {
+    const directory = path.join(backlogDir, name);
+    if (!fsApi.existsSync(directory)) continue;
+    const stat = fsApi.lstatSync(directory);
+    if (stat.isSymbolicLink() || !stat.isDirectory()) {
+      throw new SetupError(`Refusing unsafe backlog path: ${directory} must be a real directory.`);
+    }
+  }
+}
+
 function rollbackCreatedDirectories(backlogDir, structure, fsApi) {
   for (const name of [...structure.created].reverse()) {
     try {
@@ -380,7 +438,17 @@ function defaultProjectName(cwd) {
 function refusalMessage() {
   return (
     "Fresh non-interactive setup requires an explicit tracker. " +
-    "Recommended safe rerun: node setup-dev-backlog.js --tracker local --non-interactive"
+    `Recommended safe rerun: ${setupCommand(["--tracker", "local", "--non-interactive"])}`
+  );
+}
+
+function legacyLocalRefusalMessage() {
+  const pin = setupCommand(["--non-interactive"]);
+  const switchTracker = setupCommand(["--tracker", "local", "--non-interactive"]);
+  return (
+    "Existing tracker-less config has legacy GitHub authority and cannot switch directly to local. " +
+    `First pin compatibility with ${pin}; then explicitly switch with ${switchTracker}. ` +
+    "This setup does not migrate task files."
   );
 }
 
@@ -389,6 +457,7 @@ async function runSetup(options = {}, dependencies = {}) {
   const cwd = path.resolve(options.cwd || process.cwd());
   const backlogDir = path.join(cwd, "backlog");
   const configPath = path.join(backlogDir, "config.yml");
+  validateExistingStructure(backlogDir, configPath, fsApi);
   const configExists = fsApi.existsSync(configPath);
   let raw;
   let configState;
@@ -406,15 +475,18 @@ async function runSetup(options = {}, dependencies = {}) {
   let selection;
   let selectionSource;
   let recommendationEvidence;
-  if (options.tracker !== undefined) {
+  if (configState && configState.kind === "legacy" && options.tracker === "local") {
+    throw new SetupError(legacyLocalRefusalMessage());
+  }
+  if (configState && configState.kind === "legacy") {
+    selection = "github";
+    selectionSource = "legacy-pin";
+  } else if (options.tracker !== undefined) {
     selection = options.tracker;
     selectionSource = "explicit";
   } else if (configState && configState.kind === "selected") {
     selection = configState.tracker;
     selectionSource = "preserved";
-  } else if (configState && configState.kind === "legacy") {
-    selection = "github";
-    selectionSource = "legacy-pin";
   } else {
     const interactive = !options.nonInteractive && (
       dependencies.isInteractive !== undefined
@@ -462,10 +534,11 @@ async function runSetup(options = {}, dependencies = {}) {
     if (recommendationEvidence) {
       github = githubAvailabilityFromEvidence(recommendationEvidence);
     } else {
-      const availability = dependencies.checkGithubAvailability || checkGithubAvailability;
-      github = availability({
-        cwd,
-        execFileSync: dependencies.execFileSync || childProcess.execFileSync,
+      github = Object.freeze({
+        available: undefined,
+        checked: false,
+        fallbackAttempted: false,
+        repair: "verify with gh auth status --hostname github.com; repair with gh auth login --hostname github.com",
       });
     }
   }
@@ -499,9 +572,11 @@ function printHumanResult(result, output = process.stdout) {
   if (result.evidence) {
     output.write(`Recommendation evidence: ${evidenceSummary(result.evidence)}\n`);
   }
-  if (result.github && !result.github.available) {
+  if (result.github && result.github.available === false) {
     output.write(`GitHub tracker remains selected but is unavailable: ${result.github.reason}.\n`);
     output.write(`Repair: ${result.github.repair}. No local fallback was attempted.\n`);
+  } else if (result.github && result.github.checked === false) {
+    output.write(`GitHub tracker remains selected without provider probing. If unavailable, ${result.github.repair}.\n`);
   }
 }
 

--- a/skills/dev-backlog/scripts/setup-dev-backlog.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.js
@@ -140,85 +140,185 @@ function lineRecords(raw) {
   return records;
 }
 
-function scanYamlLine(line, carriedQuote = null) {
-  const visible = [...line];
-  let quote = carriedQuote;
-  let quotedTrackerKey = false;
+function consumeQuotedToken(line, start, quote) {
+  let raw = "";
+  for (let index = start + 1; index < line.length; index += 1) {
+    if (quote === "'" && line[index] === "'" && line[index + 1] === "'") {
+      raw += "''";
+      index += 1;
+    } else if (quote === '"' && line[index] === "\\" && index + 1 < line.length) {
+      raw += line.slice(index, index + 2);
+      index += 1;
+    } else if (line[index] === quote) {
+      return { closed: true, end: index + 1, raw };
+    } else {
+      raw += line[index];
+    }
+  }
+  return { closed: false, end: line.length, raw };
+}
 
-  for (let index = 0; index < line.length; index += 1) {
-    if (quote) {
-      visible[index] = " ";
-      if (quote === "'" && line[index] === "'" && line[index + 1] === "'") {
-        visible[index + 1] = " ";
-        index += 1;
-      } else if (quote === '"' && line[index] === "\\") {
-        if (index + 1 < line.length) {
-          visible[index + 1] = " ";
-          index += 1;
-        }
-      } else if (line[index] === quote) {
-        quote = null;
+function decodeDoubleQuotedScalar(raw) {
+  const simpleEscapes = Object.freeze({
+    "0": "\0", a: "\x07", b: "\b", t: "\t", n: "\n", v: "\v", f: "\f",
+    r: "\r", e: "\x1b", " ": " ", '"': '"', "/": "/", "\\": "\\",
+  });
+  let decoded = "";
+  for (let index = 0; index < raw.length; index += 1) {
+    if (raw[index] !== "\\") {
+      decoded += raw[index];
+      continue;
+    }
+    const escape = raw[index + 1];
+    if (Object.hasOwn(simpleEscapes, escape)) {
+      decoded += simpleEscapes[escape];
+      index += 1;
+      continue;
+    }
+    const width = escape === "x" ? 2 : escape === "u" ? 4 : escape === "U" ? 8 : 0;
+    const digits = raw.slice(index + 2, index + 2 + width);
+    if (!width || digits.length !== width || !/^[0-9A-Fa-f]+$/.test(digits)) return null;
+    const codePoint = Number.parseInt(digits, 16);
+    if (codePoint > 0x10ffff) return null;
+    decoded += String.fromCodePoint(codePoint);
+    index += width + 1;
+  }
+  return decoded;
+}
+
+function isColonIndicator(line, index) {
+  const next = line[index + 1];
+  return next === undefined || /[ \t\r\n,\[\]{}]/.test(next);
+}
+
+function tokenizeYamlLine(line, state = {}) {
+  const tokens = [];
+  let index = 0;
+  let carriedQuote = state.quote || null;
+  let flowDepth = state.flowDepth || 0;
+  let nodeBoundary = flowDepth > 0 ? Boolean(state.nodeBoundary) : true;
+
+  if (carriedQuote) {
+    const continuation = consumeQuotedToken(line, -1, carriedQuote);
+    if (!continuation.closed) {
+      return { tokens, state: { quote: carriedQuote, flowDepth, nodeBoundary: false } };
+    }
+    index = continuation.end;
+    carriedQuote = null;
+    nodeBoundary = false;
+  }
+
+  while (index < line.length) {
+    if (/[ \t\uFEFF]/.test(line[index])) {
+      index += 1;
+      continue;
+    }
+    if (line[index] === "#") break;
+
+    const char = line[index];
+    if (nodeBoundary && (char === "'" || char === '"')) {
+      const quoted = consumeQuotedToken(line, index, char);
+      if (!quoted.closed) {
+        return { tokens, state: { quote: char, flowDepth, nodeBoundary: false } };
       }
+      const value = char === "'"
+        ? quoted.raw.replaceAll("''", "'")
+        : decodeDoubleQuotedScalar(quoted.raw);
+      tokens.push({ type: "scalar", value, quoted: true });
+      index = quoted.end;
+      nodeBoundary = false;
       continue;
     }
 
-    if (line[index] === "#") {
-      visible.fill(" ", index);
-      break;
-    }
-    if (line[index] !== "'" && line[index] !== '"') continue;
-
-    const opening = line[index];
-    const start = index;
-    let content = "";
-    visible[index] = " ";
-    quote = opening;
-    for (index += 1; index < line.length; index += 1) {
-      visible[index] = " ";
-      if (opening === "'" && line[index] === "'" && line[index + 1] === "'") {
-        content += "'";
-        visible[index + 1] = " ";
-        index += 1;
-      } else if (opening === '"' && line[index] === "\\") {
-        if (index + 1 < line.length) {
-          content += line[index + 1];
-          visible[index + 1] = " ";
-          index += 1;
-        }
-      } else if (line[index] === opening) {
-        quote = null;
-        break;
+    if (nodeBoundary && (char === "&" || char === "!")) {
+      const start = index;
+      if (char === "!" && line[index + 1] === "<") {
+        const close = line.indexOf(">", index + 2);
+        index = close === -1 ? line.length : close + 1;
       } else {
-        content += line[index];
+        while (index < line.length && !/[ \t,\[\]{}]/.test(line[index])) index += 1;
       }
+      tokens.push({ type: "property", value: line.slice(start, index) });
+      continue;
     }
 
-    if (!quote && content === "tracker") {
-      let after = index + 1;
-      while (after < line.length && /[ \t]/.test(line[after])) after += 1;
-      const prefix = visible.slice(0, start).join("").replace(/^\uFEFF/, "");
-      const mappingBoundary = /^\s*(?:-\s*)?$/.test(prefix) || /(?:^|[{,])\s*$/.test(prefix);
-      if (line[after] === ":" && mappingBoundary) quotedTrackerKey = true;
+    if (char === "{" || char === "[") {
+      tokens.push({ type: char });
+      flowDepth += 1;
+      nodeBoundary = true;
+      index += 1;
+      continue;
     }
+    if (char === "}" || char === "]") {
+      tokens.push({ type: char });
+      flowDepth = Math.max(0, flowDepth - 1);
+      nodeBoundary = false;
+      index += 1;
+      continue;
+    }
+    if (flowDepth > 0 && char === ",") {
+      tokens.push({ type: "," });
+      nodeBoundary = true;
+      index += 1;
+      continue;
+    }
+    if (char === ":" && isColonIndicator(line, index)) {
+      tokens.push({ type: ":" });
+      nodeBoundary = true;
+      index += 1;
+      continue;
+    }
+    if (nodeBoundary && char === "?" && /[ \t]/.test(line[index + 1] || "")) {
+      tokens.push({ type: "?" });
+      index += 1;
+      continue;
+    }
+    if (nodeBoundary && char === "-" && (line[index + 1] === undefined || /[ \t]/.test(line[index + 1]))) {
+      tokens.push({ type: "-" });
+      index += 1;
+      continue;
+    }
+
+    const start = index;
+    while (index < line.length) {
+      const current = line[index];
+      if (current === "#" || current === "{" || current === "[" || current === "}" || current === "]") break;
+      if (flowDepth > 0 && current === ",") break;
+      if (current === ":" && isColonIndicator(line, index)) break;
+      index += 1;
+    }
+    const value = line.slice(start, index).trim();
+    if (value) tokens.push({ type: "scalar", value, quoted: false });
+    nodeBoundary = false;
+    if (index === start) index += 1;
   }
 
-  return { visible: visible.join(""), carriedQuote: quote, quotedTrackerKey };
+  return { tokens, state: { quote: null, flowDepth, nodeBoundary } };
 }
 
-function looksLikeTrackerDeclaration(visible, quotedTrackerKey) {
-  if (quotedTrackerKey) return true;
-  if (!visible.trim()) return false;
-  return (
-    /^\uFEFF?\s*tracker\s*:/.test(visible) ||
-    /^\s*-\s*tracker\s*:/.test(visible) ||
-    /(?:^|[{,])\s*tracker\s*:/.test(visible)
-  );
+function trackerKeyCount(tokens) {
+  let count = 0;
+  for (let index = 0; index < tokens.length; index += 1) {
+    if (tokens[index].type !== "scalar" || tokens[index].value !== "tracker") continue;
+    const next = tokens[index + 1];
+    const previous = tokens[index - 1];
+    if ((next && next.type === ":") || (previous && previous.type === "?")) count += 1;
+  }
+  return count;
+}
+
+function isBlockScalarHeader(tokens) {
+  const last = tokens[tokens.length - 1];
+  if (!last || last.type !== "scalar" || !/^[>|](?:[1-9][+-]?|[+-][1-9]?)?$/.test(last.value)) {
+    return false;
+  }
+  return tokens.some((token) => token.type === ":");
 }
 
 function trackerCandidates(raw) {
   const candidates = [];
   let blockScalarParentIndent = null;
-  let carriedQuote = null;
+  let lexicalState = { quote: null, flowDepth: 0, nodeBoundary: true };
 
   for (const record of lineRecords(raw)) {
     const withoutBom = record.text.replace(/^\uFEFF/, "");
@@ -228,13 +328,10 @@ function trackerCandidates(raw) {
       if (!trimmed || indent > blockScalarParentIndent) continue;
       blockScalarParentIndent = null;
     }
-    const scanned = scanYamlLine(record.text, carriedQuote);
-    carriedQuote = scanned.carriedQuote;
-    if (looksLikeTrackerDeclaration(scanned.visible, scanned.quotedTrackerKey)) candidates.push(record);
-    if (
-      !carriedQuote &&
-      /:\s*(?:(?:[&!][^\s,\[\]{}]+)\s+)*(?:[>|](?:[1-9][+-]?|[+-][1-9]?)?)\s*$/.test(scanned.visible.replace(/^\uFEFF/, ""))
-    ) {
+    const scanned = tokenizeYamlLine(record.text, lexicalState);
+    lexicalState = scanned.state;
+    for (let count = trackerKeyCount(scanned.tokens); count > 0; count -= 1) candidates.push(record);
+    if (!lexicalState.quote && lexicalState.flowDepth === 0 && isBlockScalarHeader(scanned.tokens)) {
       blockScalarParentIndent = indent;
     }
   }
@@ -315,16 +412,20 @@ function isGithubRemote(remote) {
   const value = String(remote || "").trim();
   if (!value) return false;
   const component = "[A-Za-z0-9_.-]+";
-  if (new RegExp(`^[^@\\s]+@github\\.com:${component}/${component}(?:\\.git)?$`, "i").test(value)) {
+  if (new RegExp(`^git@github\\.com:${component}/${component}(?:\\.git)?$`).test(value)) {
     return true;
   }
   try {
     const parsed = new URL(value);
-    const allowedProtocol = new Set(["http:", "https:", "ssh:", "git:"]);
+    const host = parsed.hostname.toLowerCase();
+    const standardHttps = parsed.protocol === "https:" && host === "github.com" &&
+      parsed.port === "" && parsed.username === "" && parsed.password === "";
+    const standardSsh = parsed.protocol === "ssh:" && host === "github.com" &&
+      parsed.port === "" && parsed.username === "git" && parsed.password === "";
+    const sshOver443 = parsed.protocol === "ssh:" && host === "ssh.github.com" &&
+      parsed.port === "443" && parsed.username === "git" && parsed.password === "";
     return (
-      allowedProtocol.has(parsed.protocol) &&
-      parsed.hostname.toLowerCase() === "github.com" &&
-      parsed.port === "" &&
+      (standardHttps || standardSsh || sshOver443) &&
       parsed.search === "" &&
       parsed.hash === "" &&
       new RegExp(`^/${component}/${component}(?:\\.git)?$`).test(parsed.pathname)

--- a/skills/dev-backlog/scripts/setup-dev-backlog.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.js
@@ -1,0 +1,567 @@
+#!/usr/bin/env node
+
+/**
+ * Idempotent, tracker-aware dev-backlog setup.
+ *
+ * The config file is treated as text. Setup validates and edits only one
+ * top-level tracker scalar; it never parses and reserializes user YAML.
+ */
+
+const childProcess = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+const readline = require("node:readline/promises");
+
+const ALLOWED_TRACKERS = Object.freeze(["github", "local"]);
+const MINIMUM_DIRECTORIES = Object.freeze(["sprints", "tasks", "completed"]);
+
+class SetupError extends Error {
+  constructor(message, options = {}) {
+    super(message, options);
+    this.name = "SetupError";
+    this.exitCode = options.exitCode || 1;
+  }
+}
+
+class ConfigValidationError extends SetupError {
+  constructor(configPath, reason) {
+    super(
+      `Invalid tracker configuration in ${configPath}: ${reason}. ` +
+        `Expected exactly one top-level "tracker: github" or "tracker: local" line. ` +
+        `Repair the file, then rerun: node setup-dev-backlog.js --tracker github --non-interactive.`
+    );
+    this.name = "ConfigValidationError";
+    this.configPath = configPath;
+  }
+}
+
+function usage() {
+  return [
+    "Usage: setup-dev-backlog.js [project-name] [options]",
+    "",
+    "Options:",
+    "  --tracker github|local  Select the canonical task tracker",
+    "  --non-interactive       Never prompt (required with --tracker when fresh)",
+    "  --project-name NAME     Project name for a fresh config",
+    "  --json                  Print structured output",
+    "  --help                  Show this help",
+  ].join("\n");
+}
+
+function takeValue(argv, index, flag) {
+  if (index + 1 >= argv.length || argv[index + 1].startsWith("--")) {
+    throw new SetupError(`${flag} requires a value.\n${usage()}`);
+  }
+  return argv[index + 1];
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const options = {
+    tracker: undefined,
+    nonInteractive: false,
+    json: false,
+    projectName: undefined,
+    help: false,
+  };
+  let positionalProjectName;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--tracker") {
+      options.tracker = takeValue(argv, index, "--tracker");
+      index += 1;
+    } else if (arg.startsWith("--tracker=")) {
+      options.tracker = arg.slice("--tracker=".length);
+    } else if (arg === "--project-name") {
+      options.projectName = takeValue(argv, index, "--project-name");
+      index += 1;
+    } else if (arg.startsWith("--project-name=")) {
+      options.projectName = arg.slice("--project-name=".length);
+    } else if (arg === "--non-interactive") {
+      options.nonInteractive = true;
+    } else if (arg === "--json") {
+      options.json = true;
+    } else if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else if (arg.startsWith("-")) {
+      throw new SetupError(`Unknown option: ${arg}.\n${usage()}`);
+    } else if (positionalProjectName === undefined) {
+      positionalProjectName = arg;
+    } else {
+      throw new SetupError(`Unexpected argument: ${arg}.\n${usage()}`);
+    }
+  }
+
+  if (options.projectName !== undefined && positionalProjectName !== undefined) {
+    throw new SetupError("Project name may be supplied either positionally or with --project-name, not both.");
+  }
+  options.projectName = options.projectName ?? positionalProjectName;
+
+  if (options.tracker !== undefined && !ALLOWED_TRACKERS.includes(options.tracker)) {
+    throw new SetupError(
+      `Invalid --tracker value ${JSON.stringify(options.tracker)}; expected github or local.`
+    );
+  }
+  if (options.projectName !== undefined && options.projectName.length === 0) {
+    throw new SetupError("--project-name requires a non-empty value.");
+  }
+  return options;
+}
+
+function lineRecords(raw) {
+  const records = [];
+  const pattern = /([^\r\n]*)(\r\n|\n|\r|$)/g;
+  let match;
+  while ((match = pattern.exec(raw)) !== null) {
+    if (match[0] === "" && match.index === raw.length) break;
+    records.push({
+      text: match[1],
+      newline: match[2],
+      start: match.index,
+      end: match.index + match[1].length,
+    });
+    if (match[2] === "") break;
+  }
+  return records;
+}
+
+function looksLikeTrackerDeclaration(line) {
+  if (!line.trim() || line.trimStart().startsWith("#")) return false;
+  return (
+    /^\s*tracker\b/.test(line) ||
+    /^\s*["']tracker["']\s*:/.test(line) ||
+    /^\s*-\s*tracker\s*:/.test(line) ||
+    /[{,]\s*tracker\s*:/.test(line)
+  );
+}
+
+function parseValidTrackerLine(record) {
+  const match = record.text.match(
+    /^tracker:([ \t]*)(?:(["'])(github|local)\2|(github|local))([ \t]*(?:#.*)?)$/
+  );
+  if (!match) return null;
+
+  const tracker = match[3] || match[4];
+  const colon = record.text.indexOf(":");
+  const quoteLength = match[2] ? 1 : 0;
+  const scalarStart = record.start + colon + 1 + match[1].length + quoteLength;
+  return {
+    tracker,
+    scalarStart,
+    scalarEnd: scalarStart + tracker.length,
+    lineStart: record.start,
+    lineEnd: record.end,
+  };
+}
+
+function inspectConfig(raw, configPath = "backlog/config.yml") {
+  if (typeof raw !== "string") {
+    throw new ConfigValidationError(configPath, "the config could not be read as text");
+  }
+
+  const candidates = lineRecords(raw).filter((record) => looksLikeTrackerDeclaration(record.text));
+  if (candidates.length === 0) {
+    return Object.freeze({ kind: "legacy", tracker: undefined });
+  }
+  if (candidates.length > 1) {
+    throw new ConfigValidationError(configPath, "duplicate or ambiguous tracker declarations were found");
+  }
+
+  const parsed = parseValidTrackerLine(candidates[0]);
+  if (!parsed) {
+    const nested = /^\s+/.test(candidates[0].text) || /^\s*-/.test(candidates[0].text);
+    throw new ConfigValidationError(
+      configPath,
+      nested
+        ? "tracker must be a single top-level scalar, not nested"
+        : "the tracker value is missing, malformed, quoted as a key, or unsupported"
+    );
+  }
+  return Object.freeze({ kind: "selected", ...parsed });
+}
+
+function detectNewline(raw) {
+  const match = raw.match(/\r\n|\n|\r/);
+  return match ? match[0] : "\n";
+}
+
+function mutateTrackerText(raw, state, selection) {
+  if (!ALLOWED_TRACKERS.includes(selection)) {
+    throw new SetupError(`Invalid tracker selection ${JSON.stringify(selection)}.`);
+  }
+  if (state.kind === "selected") {
+    if (state.tracker === selection) return raw;
+    return raw.slice(0, state.scalarStart) + selection + raw.slice(state.scalarEnd);
+  }
+  if (state.kind !== "legacy") {
+    throw new SetupError("Cannot mutate an unvalidated tracker config state.");
+  }
+
+  const newline = detectNewline(raw);
+  if (raw.length === 0) return `tracker: ${selection}${newline}`;
+  const hasFinalNewline = /(?:\r\n|\n|\r)$/.test(raw);
+  return hasFinalNewline
+    ? `${raw}tracker: ${selection}${newline}`
+    : `${raw}${newline}tracker: ${selection}`;
+}
+
+function isGithubRemote(remote) {
+  const value = String(remote || "").trim();
+  if (!value) return false;
+  if (/^(?:[^@\s]+@)?github\.com:[^/\s]+\/[^/\s]+(?:\.git)?\/?$/i.test(value)) {
+    return true;
+  }
+  try {
+    const parsed = new URL(value);
+    return (
+      parsed.hostname.toLowerCase() === "github.com" &&
+      parsed.pathname.split("/").filter(Boolean).length >= 2
+    );
+  } catch {
+    return false;
+  }
+}
+
+function commandFailedBecauseMissing(error) {
+  return error && (error.code === "ENOENT" || error.errno === -2);
+}
+
+function collectGithubEvidence({
+  cwd = process.cwd(),
+  execFileSync = childProcess.execFileSync,
+} = {}) {
+  let remote = "missing";
+  try {
+    const rawRemote = execFileSync(
+      "git",
+      ["config", "--get", "remote.origin.url"],
+      { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }
+    );
+    remote = isGithubRemote(rawRemote) ? "github" : "non-github";
+  } catch {
+    remote = "missing";
+  }
+
+  let cli = "available";
+  let auth = "authenticated";
+  try {
+    execFileSync(
+      "gh",
+      ["auth", "status", "--hostname", "github.com"],
+      { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }
+    );
+  } catch (error) {
+    if (commandFailedBecauseMissing(error)) {
+      cli = "missing";
+      auth = "not-checked";
+    } else {
+      cli = "available";
+      auth = "unauthenticated";
+    }
+  }
+
+  const recommendation = remote === "github" && auth === "authenticated"
+    ? "github"
+    : "local";
+  return Object.freeze({ recommendation, remote, cli, auth });
+}
+
+function githubAvailabilityFromEvidence(evidence) {
+  const problems = [];
+  const repairs = [];
+  if (evidence.remote !== "github") {
+    problems.push(evidence.remote === "missing" ? "GitHub origin not found" : "origin is not GitHub");
+    repairs.push(
+      evidence.remote === "missing"
+        ? "git remote add origin <github-url>"
+        : "git remote set-url origin <github-url>"
+    );
+  }
+  if (evidence.cli === "missing") {
+    problems.push("gh CLI not found");
+    repairs.push("install GitHub CLI from https://cli.github.com/ and run gh auth login --hostname github.com");
+  } else if (evidence.auth !== "authenticated") {
+    problems.push("gh is not authenticated for github.com");
+    repairs.push("gh auth login --hostname github.com");
+  }
+
+  if (problems.length === 0) {
+    return Object.freeze({ available: true, evidence });
+  }
+  return Object.freeze({
+    available: false,
+    evidence,
+    reason: problems.join("; "),
+    repair: repairs.join("; "),
+    fallbackAttempted: false,
+  });
+}
+
+function checkGithubAvailability(options) {
+  return githubAvailabilityFromEvidence(collectGithubEvidence(options));
+}
+
+function freshConfig(projectName, tracker) {
+  return [
+    `project_name: ${JSON.stringify(projectName)}`,
+    `tracker: ${tracker}`,
+    'task_prefix: "BACK"',
+    'default_status: "To Do"',
+    'statuses: ["To Do", "In Progress", "Done"]',
+    "",
+  ].join("\n");
+}
+
+function tempPathFor(targetPath) {
+  const nonce = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  return path.join(path.dirname(targetPath), `.${path.basename(targetPath)}.${nonce}.tmp`);
+}
+
+function atomicPublish(targetPath, content, { fs: fsApi = fs } = {}) {
+  const targetExists = fsApi.existsSync(targetPath);
+  if (targetExists) {
+    const current = fsApi.readFileSync(targetPath, "utf8");
+    if (current === content) return Object.freeze({ changed: false, created: false });
+  }
+
+  const tempPath = tempPathFor(targetPath);
+  try {
+    fsApi.writeFileSync(tempPath, content, { encoding: "utf8", flag: "wx" });
+    if (targetExists && typeof fsApi.chmodSync === "function") {
+      fsApi.chmodSync(tempPath, fsApi.statSync(targetPath).mode);
+    }
+    fsApi.renameSync(tempPath, targetPath);
+  } catch (error) {
+    try {
+      if (fsApi.existsSync(tempPath)) fsApi.unlinkSync(tempPath);
+    } catch {
+      // Preserve the publication error. A best-effort cleanup was attempted.
+    }
+    throw error;
+  }
+  return Object.freeze({ changed: true, created: !targetExists });
+}
+
+function ensureMinimumDirectories(backlogDir, fsApi) {
+  const backlogCreated = !fsApi.existsSync(backlogDir);
+  const created = [];
+  fsApi.mkdirSync(backlogDir, { recursive: true });
+  for (const name of MINIMUM_DIRECTORIES) {
+    const directory = path.join(backlogDir, name);
+    if (!fsApi.existsSync(directory)) {
+      fsApi.mkdirSync(directory);
+      created.push(name);
+    }
+  }
+  return { backlogCreated, created };
+}
+
+function rollbackCreatedDirectories(backlogDir, structure, fsApi) {
+  for (const name of [...structure.created].reverse()) {
+    try {
+      fsApi.rmdirSync(path.join(backlogDir, name));
+    } catch {
+      // A concurrent writer made it non-empty or removed it; never delete content.
+    }
+  }
+  if (structure.backlogCreated) {
+    try {
+      fsApi.rmdirSync(backlogDir);
+    } catch {
+      // Preserve anything that appeared concurrently.
+    }
+  }
+}
+
+function defaultProjectName(cwd) {
+  return path.basename(path.resolve(cwd)) || "project";
+}
+
+function refusalMessage() {
+  return (
+    "Fresh non-interactive setup requires an explicit tracker. " +
+    "Recommended safe rerun: node setup-dev-backlog.js --tracker local --non-interactive"
+  );
+}
+
+async function runSetup(options = {}, dependencies = {}) {
+  const fsApi = dependencies.fs || fs;
+  const cwd = path.resolve(options.cwd || process.cwd());
+  const backlogDir = path.join(cwd, "backlog");
+  const configPath = path.join(backlogDir, "config.yml");
+  const configExists = fsApi.existsSync(configPath);
+  let raw;
+  let configState;
+
+  // The entire tracker situation is read and validated before mkdir or temp creation.
+  if (configExists) {
+    raw = fsApi.readFileSync(configPath, "utf8");
+    configState = inspectConfig(raw, configPath);
+  }
+
+  if (options.tracker !== undefined && !ALLOWED_TRACKERS.includes(options.tracker)) {
+    throw new SetupError(`Invalid tracker selection ${JSON.stringify(options.tracker)}; expected github or local.`);
+  }
+
+  let selection;
+  let selectionSource;
+  let recommendationEvidence;
+  if (options.tracker !== undefined) {
+    selection = options.tracker;
+    selectionSource = "explicit";
+  } else if (configState && configState.kind === "selected") {
+    selection = configState.tracker;
+    selectionSource = "preserved";
+  } else if (configState && configState.kind === "legacy") {
+    selection = "github";
+    selectionSource = "legacy-pin";
+  } else {
+    const interactive = !options.nonInteractive && (
+      dependencies.isInteractive !== undefined
+        ? dependencies.isInteractive
+        : Boolean(process.stdin.isTTY && process.stdout.isTTY)
+    );
+    if (!interactive) throw new SetupError(refusalMessage());
+
+    recommendationEvidence = collectGithubEvidence({
+      cwd,
+      execFileSync: dependencies.execFileSync || childProcess.execFileSync,
+    });
+    if (typeof dependencies.prompt !== "function") {
+      throw new SetupError("Interactive setup requires a prompt boundary.");
+    }
+    const answer = String(await dependencies.prompt({
+      recommendation: recommendationEvidence.recommendation,
+      evidence: recommendationEvidence,
+    }) || "").trim().toLowerCase();
+    selection = answer || recommendationEvidence.recommendation;
+    if (!ALLOWED_TRACKERS.includes(selection)) {
+      throw new SetupError(`Invalid tracker choice ${JSON.stringify(answer)}; enter github or local.`);
+    }
+    selectionSource = selection === recommendationEvidence.recommendation
+      ? "recommended"
+      : "interactive-choice";
+  }
+
+  const projectName = options.projectName || defaultProjectName(cwd);
+  const nextRaw = configExists
+    ? mutateTrackerText(raw, configState, selection)
+    : freshConfig(projectName, selection);
+
+  const structure = ensureMinimumDirectories(backlogDir, fsApi);
+  let publication;
+  try {
+    publication = atomicPublish(configPath, nextRaw, { fs: fsApi });
+  } catch (error) {
+    rollbackCreatedDirectories(backlogDir, structure, fsApi);
+    throw error;
+  }
+
+  let github;
+  if (selection === "github") {
+    if (recommendationEvidence) {
+      github = githubAvailabilityFromEvidence(recommendationEvidence);
+    } else {
+      const availability = dependencies.checkGithubAvailability || checkGithubAvailability;
+      github = availability({
+        cwd,
+        execFileSync: dependencies.execFileSync || childProcess.execFileSync,
+      });
+    }
+  }
+
+  return Object.freeze({
+    action: "setup-dev-backlog",
+    projectName,
+    selection,
+    selectionSource,
+    configPath,
+    configChanged: publication.changed,
+    configCreated: publication.created,
+    createdDirectories: structure.created,
+    evidence: recommendationEvidence,
+    github,
+  });
+}
+
+function evidenceSummary(evidence) {
+  return `origin=${evidence.remote}, gh=${evidence.cli}, auth=${evidence.auth}`;
+}
+
+function printHumanResult(result, output = process.stdout) {
+  output.write(`Tracker: ${result.selection} (${result.selectionSource})\n`);
+  output.write(`${result.configCreated ? "Created" : result.configChanged ? "Updated" : "Preserved"}: ${result.configPath}\n`);
+  if (result.createdDirectories.length > 0) {
+    output.write(`Created directories: ${result.createdDirectories.join(", ")}\n`);
+  } else {
+    output.write("Backlog directories already complete.\n");
+  }
+  if (result.evidence) {
+    output.write(`Recommendation evidence: ${evidenceSummary(result.evidence)}\n`);
+  }
+  if (result.github && !result.github.available) {
+    output.write(`GitHub tracker remains selected but is unavailable: ${result.github.reason}.\n`);
+    output.write(`Repair: ${result.github.repair}. No local fallback was attempted.\n`);
+  }
+}
+
+async function promptForTracker({ recommendation, evidence }) {
+  process.stdout.write(
+    `Recommended tracker: ${recommendation} (${evidenceSummary(evidence)}).\n`
+  );
+  const terminal = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    return await terminal.question(
+      `Tracker [github/local] (default: ${recommendation}): `
+    );
+  } finally {
+    terminal.close();
+  }
+}
+
+async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    process.stdout.write(`${usage()}\n`);
+    return 0;
+  }
+  const result = await runSetup(options, { prompt: promptForTracker });
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  } else {
+    printHumanResult(result);
+  }
+  return 0;
+}
+
+if (require.main === module) {
+  main().then(
+    (code) => {
+      process.exitCode = code;
+    },
+    (error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`setup-dev-backlog: ${message}\n`);
+      process.exitCode = error && Number.isInteger(error.exitCode) ? error.exitCode : 1;
+    }
+  );
+}
+
+module.exports = {
+  ALLOWED_TRACKERS,
+  MINIMUM_DIRECTORIES,
+  ConfigValidationError,
+  SetupError,
+  atomicPublish,
+  checkGithubAvailability,
+  collectGithubEvidence,
+  freshConfig,
+  githubAvailabilityFromEvidence,
+  inspectConfig,
+  isGithubRemote,
+  main,
+  mutateTrackerText,
+  parseArgs,
+  printHumanResult,
+  runSetup,
+};

--- a/skills/dev-backlog/scripts/setup-dev-backlog.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.js
@@ -197,6 +197,7 @@ function tokenizeYamlLine(line, state = {}) {
   let carriedQuote = state.quote || null;
   let flowDepth = state.flowDepth || 0;
   let nodeBoundary = flowDepth > 0 ? Boolean(state.nodeBoundary) : true;
+  let keyAllowed = flowDepth > 0 ? Boolean(state.keyAllowed) : true;
 
   if (carriedQuote) {
     let continuationStart = -1;
@@ -215,6 +216,7 @@ function tokenizeYamlLine(line, state = {}) {
           quote: { char: carriedQuote.char, raw: continuation.raw },
           flowDepth,
           nodeBoundary: false,
+          keyAllowed: false,
         },
       };
     }
@@ -225,6 +227,7 @@ function tokenizeYamlLine(line, state = {}) {
     index = continuation.end;
     carriedQuote = null;
     nodeBoundary = false;
+    keyAllowed = false;
   }
 
   while (index < line.length) {
@@ -246,6 +249,7 @@ function tokenizeYamlLine(line, state = {}) {
       tokens.push({ type: "scalar", value, quoted: true });
       index = quoted.end;
       nodeBoundary = false;
+      keyAllowed = false;
       continue;
     }
 
@@ -260,7 +264,6 @@ function tokenizeYamlLine(line, state = {}) {
       tokens.push({
         type: "property",
         value: line.slice(start, index),
-        anchor: char === "&" ? line.slice(start + 1, index) : null,
       });
       continue;
     }
@@ -271,6 +274,7 @@ function tokenizeYamlLine(line, state = {}) {
       while (index < line.length && /[A-Za-z0-9_-]/.test(line[index])) index += 1;
       tokens.push({ type: "alias", name: line.slice(start, index) });
       nodeBoundary = false;
+      keyAllowed = false;
       continue;
     }
 
@@ -278,6 +282,7 @@ function tokenizeYamlLine(line, state = {}) {
       tokens.push({ type: char });
       flowDepth += 1;
       nodeBoundary = true;
+      keyAllowed = true;
       index += 1;
       continue;
     }
@@ -285,22 +290,26 @@ function tokenizeYamlLine(line, state = {}) {
       tokens.push({ type: char });
       flowDepth = Math.max(0, flowDepth - 1);
       nodeBoundary = false;
+      keyAllowed = false;
       index += 1;
       continue;
     }
     if (flowDepth > 0 && char === ",") {
       tokens.push({ type: "," });
       nodeBoundary = true;
+      keyAllowed = true;
       index += 1;
       continue;
     }
     if (char === ":" && isColonIndicator(line, index)) {
       tokens.push({ type: ":" });
       nodeBoundary = true;
+      keyAllowed = false;
       index += 1;
       continue;
     }
-    if (nodeBoundary && char === "?" && (line[index + 1] === undefined || /[ \t]/.test(line[index + 1]))) {
+    if (nodeBoundary && keyAllowed && char === "?" &&
+        (line[index + 1] === undefined || /[ \t]/.test(line[index + 1]))) {
       tokens.push({ type: "?" });
       index += 1;
       continue;
@@ -308,6 +317,7 @@ function tokenizeYamlLine(line, state = {}) {
     if (nodeBoundary && char === "-" && (line[index + 1] === undefined || /[ \t]/.test(line[index + 1]))) {
       tokens.push({ type: "-" });
       index += 1;
+      keyAllowed = true;
       continue;
     }
 
@@ -322,68 +332,21 @@ function tokenizeYamlLine(line, state = {}) {
     const value = line.slice(start, index).trim();
     if (value) tokens.push({ type: "scalar", value, quoted: false });
     nodeBoundary = false;
+    keyAllowed = false;
     if (index === start) index += 1;
   }
 
-  return { tokens, state: { quote: null, flowDepth, nodeBoundary } };
+  return { tokens, state: { quote: null, flowDepth, nodeBoundary, keyAllowed } };
 }
 
-function resolveAliasValue(token, anchors) {
-  if (token.type !== "alias") return token.type === "scalar" ? token.value : undefined;
-  const anchored = anchors.get(token.name);
-  return anchored && anchored.kind === "scalar" ? anchored.value : undefined;
-}
-
-function trackerKeyCount(tokens, anchors, onAmbiguousAlias) {
+function trackerKeyCount(tokens) {
   let count = 0;
   for (let index = 0; index < tokens.length; index += 1) {
-    if (tokens[index].type !== "scalar" && tokens[index].type !== "alias") continue;
+    if (tokens[index].type !== "scalar" || tokens[index].value !== "tracker") continue;
     const next = tokens[index + 1];
-    const previous = tokens[index - 1];
-    const keyPosition = (next && next.type === ":") || (previous && previous.type === "?");
-    if (!keyPosition) continue;
-    const anchored = tokens[index].type === "alias" ? anchors.get(tokens[index].name) : null;
-    const value = resolveAliasValue(tokens[index], anchors);
-    if (value === "tracker") count += 1;
-    else if (tokens[index].type === "alias" && !anchored) onAmbiguousAlias(tokens[index].name);
+    if (next && next.type === ":") count += 1;
   }
   return count;
-}
-
-function firstNodeToken(tokens, start = 0) {
-  return tokens.slice(start).find((token) => token.type === "scalar" || token.type === "alias" || token.type === "{" || token.type === "[");
-}
-
-function recordDocumentAnchors(tokens, documentState) {
-  const pending = [...documentState.pendingAnchors];
-  documentState.pendingAnchors.length = 0;
-  if (pending.length > 0) {
-    const node = firstNodeToken(tokens);
-    if (node) {
-      const value = resolveAliasValue(node, documentState.anchors);
-      for (const name of pending) {
-        documentState.anchors.set(name, node.type === "scalar" || node.type === "alias"
-          ? { kind: "scalar", value }
-          : { kind: "collection" });
-      }
-    } else {
-      documentState.pendingAnchors.push(...pending);
-    }
-  }
-  for (let index = 0; index < tokens.length; index += 1) {
-    const token = tokens[index];
-    if (token.type === "property" && token.anchor) {
-      const node = firstNodeToken(tokens, index + 1);
-      if (node) {
-        const value = resolveAliasValue(node, documentState.anchors);
-        documentState.anchors.set(token.anchor, node.type === "scalar" || node.type === "alias"
-          ? { kind: "scalar", value }
-          : { kind: "collection" });
-      } else {
-        documentState.pendingAnchors.push(token.anchor);
-      }
-    }
-  }
 }
 
 function isBlockScalarHeader(tokens) {
@@ -397,14 +360,9 @@ function isBlockScalarHeader(tokens) {
 function trackerCandidates(raw, configPath) {
   const candidates = [];
   let blockScalarParentIndent = null;
-  let lexicalState = { quote: null, flowDepth: 0, nodeBoundary: true };
-  const documentState = { anchors: new Map(), pendingAnchors: [], explicitKeyPending: false };
-  const ambiguousAlias = (name) => {
-    throw new ConfigValidationError(
-      configPath,
-      `alias ${JSON.stringify(`*${name}`)} could resolve to tracker authority and is ambiguous`
-    );
-  };
+  let lexicalState = { quote: null, flowDepth: 0, nodeBoundary: true, keyAllowed: true };
+  let contentSeen = false;
+  let leadingDocumentMarkerSeen = false;
 
   for (const record of lineRecords(raw)) {
     const withoutBom = record.text.replace(/^\uFEFF/, "");
@@ -416,36 +374,48 @@ function trackerCandidates(raw, configPath) {
     }
     const scanned = tokenizeYamlLine(record.text, lexicalState);
     lexicalState = scanned.state;
-    recordDocumentAnchors(scanned.tokens, documentState);
-    for (
-      let count = trackerKeyCount(scanned.tokens, documentState.anchors, ambiguousAlias);
-      count > 0;
-      count -= 1
-    ) candidates.push(record);
+    const marker = scanned.tokens.length === 1 && scanned.tokens[0].type === "scalar" &&
+      !scanned.tokens[0].quoted ? scanned.tokens[0].value : null;
+    if (marker === "---") {
+      if (contentSeen || leadingDocumentMarkerSeen) {
+        throw new ConfigValidationError(configPath, "multiple YAML documents are unsupported");
+      }
+      leadingDocumentMarkerSeen = true;
+      continue;
+    }
+    if (marker === "...") {
+      throw new ConfigValidationError(configPath, "YAML document end markers are unsupported");
+    }
+    if (scanned.tokens.length > 0) contentSeen = true;
 
-    if (documentState.explicitKeyPending) {
-      const node = firstNodeToken(scanned.tokens);
-      if (node) {
-        const anchored = node.type === "alias" ? documentState.anchors.get(node.name) : null;
-        const value = resolveAliasValue(node, documentState.anchors);
-        if (value === "tracker") candidates.push(record);
-        else if (node.type === "alias" && !anchored) ambiguousAlias(node.name);
-        documentState.explicitKeyPending = false;
+    if (scanned.tokens.some((token) => token.type === "?")) {
+      throw new ConfigValidationError(
+        configPath,
+        "explicit mapping keys are authority-obscuring and unsupported"
+      );
+    }
+    for (let index = 0; index < scanned.tokens.length; index += 1) {
+      const token = scanned.tokens[index];
+      const next = scanned.tokens[index + 1];
+      if (token.type === "alias" && next && next.type === ":") {
+        throw new ConfigValidationError(
+          configPath,
+          "alias mapping keys are authority-obscuring and unsupported"
+        );
+      }
+      if (token.type === "scalar" && token.value === "<<" && next && next.type === ":") {
+        throw new ConfigValidationError(
+          configPath,
+          "YAML merge keys are authority-obscuring and unsupported"
+        );
       }
     }
-    const last = scanned.tokens[scanned.tokens.length - 1];
-    if (last && last.type === "?") documentState.explicitKeyPending = true;
-
-    for (let index = 0; index < scanned.tokens.length - 2; index += 1) {
-      const [key, colon, alias] = scanned.tokens.slice(index, index + 3);
-      if (key.type === "scalar" && key.value === "<<" && colon.type === ":" && alias.type === "alias" &&
-          !documentState.anchors.has(alias.name)) ambiguousAlias(alias.name);
-    }
+    for (let count = trackerKeyCount(scanned.tokens); count > 0; count -= 1) candidates.push(record);
     if (!lexicalState.quote && lexicalState.flowDepth === 0 && isBlockScalarHeader(scanned.tokens)) {
       blockScalarParentIndent = indent;
     }
   }
-  if (lexicalState.quote || lexicalState.flowDepth !== 0 || documentState.explicitKeyPending) {
+  if (lexicalState.quote || lexicalState.flowDepth !== 0) {
     throw new ConfigValidationError(configPath, "the YAML lexical structure is incomplete at end of file");
   }
   return candidates;
@@ -541,7 +511,7 @@ function isGithubRemote(remote) {
     const standardHttps = parsed.protocol === "https:" && host === "github.com" &&
       parsed.port === "" && parsed.username === "" && parsed.password === "";
     const standardSsh = parsed.protocol === "ssh:" && host === "github.com" &&
-      parsed.port === "" && parsed.username === "git" && parsed.password === "";
+      (parsed.port === "" || parsed.port === "22") && parsed.username === "git" && parsed.password === "";
     const sshOver443 = parsed.protocol === "ssh:" && host === "ssh.github.com" &&
       parsed.port === "443" && parsed.username === "git" && parsed.password === "";
     return (

--- a/skills/dev-backlog/scripts/setup-dev-backlog.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.js
@@ -162,6 +162,7 @@ function decodeDoubleQuotedScalar(raw) {
   const simpleEscapes = Object.freeze({
     "0": "\0", a: "\x07", b: "\b", t: "\t", n: "\n", v: "\v", f: "\f",
     r: "\r", e: "\x1b", " ": " ", '"': '"', "/": "/", "\\": "\\",
+    N: "\u0085", _: "\u00a0", L: "\u2028", P: "\u2029",
   });
   let decoded = "";
   for (let index = 0; index < raw.length; index += 1) {
@@ -195,9 +196,9 @@ function tokenizeYamlLine(line, state = {}) {
   const tokens = [];
   let index = 0;
   let carriedQuote = state.quote || null;
-  let flowDepth = state.flowDepth || 0;
-  let nodeBoundary = flowDepth > 0 ? Boolean(state.nodeBoundary) : true;
-  let keyAllowed = flowDepth > 0 ? Boolean(state.keyAllowed) : true;
+  const flowStack = [...(state.flowStack || [])];
+  let nodeBoundary = flowStack.length > 0 ? Boolean(state.nodeBoundary) : true;
+  let keyAllowed = flowStack.length > 0 ? Boolean(state.keyAllowed) : true;
 
   if (carriedQuote) {
     let continuationStart = -1;
@@ -214,7 +215,7 @@ function tokenizeYamlLine(line, state = {}) {
         tokens,
         state: {
           quote: { char: carriedQuote.char, raw: continuation.raw },
-          flowDepth,
+          flowStack,
           nodeBoundary: false,
           keyAllowed: false,
         },
@@ -223,6 +224,9 @@ function tokenizeYamlLine(line, state = {}) {
     const value = carriedQuote.char === "'"
       ? continuation.raw.replaceAll("''", "'")
       : decodeDoubleQuotedScalar(continuation.raw);
+    if (value === null) {
+      return { tokens, state: { quote: null, flowStack, error: "invalid double-quoted escape" } };
+    }
     tokens.push({ type: "scalar", value, quoted: true });
     index = continuation.end;
     carriedQuote = null;
@@ -241,11 +245,17 @@ function tokenizeYamlLine(line, state = {}) {
     if (nodeBoundary && (char === "'" || char === '"')) {
       const quoted = consumeQuotedToken(line, index, char);
       if (!quoted.closed) {
-        return { tokens, state: { quote: { char, raw: quoted.raw }, flowDepth, nodeBoundary: false } };
+        return {
+          tokens,
+          state: { quote: { char, raw: quoted.raw }, flowStack, nodeBoundary: false, keyAllowed: false },
+        };
       }
       const value = char === "'"
         ? quoted.raw.replaceAll("''", "'")
         : decodeDoubleQuotedScalar(quoted.raw);
+      if (value === null) {
+        return { tokens, state: { quote: null, flowStack, error: "invalid double-quoted escape" } };
+      }
       tokens.push({ type: "scalar", value, quoted: true });
       index = quoted.end;
       nodeBoundary = false;
@@ -257,7 +267,10 @@ function tokenizeYamlLine(line, state = {}) {
       const start = index;
       if (char === "!" && line[index + 1] === "<") {
         const close = line.indexOf(">", index + 2);
-        index = close === -1 ? line.length : close + 1;
+        if (close === -1) {
+          return { tokens, state: { quote: null, flowStack, error: "unterminated verbatim tag" } };
+        }
+        index = close + 1;
       } else {
         while (index < line.length && !/[ \t,\[\]{}]/.test(line[index])) index += 1;
       }
@@ -280,21 +293,25 @@ function tokenizeYamlLine(line, state = {}) {
 
     if (nodeBoundary && (char === "{" || char === "[")) {
       tokens.push({ type: char });
-      flowDepth += 1;
+      flowStack.push(char);
       nodeBoundary = true;
       keyAllowed = true;
       index += 1;
       continue;
     }
-    if (flowDepth > 0 && (char === "}" || char === "]")) {
+    if (char === "}" || char === "]") {
+      const expected = char === "}" ? "{" : "[";
+      if (flowStack[flowStack.length - 1] !== expected) {
+        return { tokens, state: { quote: null, flowStack, error: "stray or mismatched flow delimiter" } };
+      }
       tokens.push({ type: char });
-      flowDepth = Math.max(0, flowDepth - 1);
+      flowStack.pop();
       nodeBoundary = false;
       keyAllowed = false;
       index += 1;
       continue;
     }
-    if (flowDepth > 0 && char === ",") {
+    if (flowStack.length > 0 && char === ",") {
       tokens.push({ type: "," });
       nodeBoundary = true;
       keyAllowed = true;
@@ -324,8 +341,8 @@ function tokenizeYamlLine(line, state = {}) {
     const start = index;
     while (index < line.length) {
       const current = line[index];
-      if (current === "#" || (flowDepth > 0 && /[{}\[\]]/.test(current))) break;
-      if (flowDepth > 0 && current === ",") break;
+      if (current === "#" || (flowStack.length > 0 && /[{}\[\]]/.test(current))) break;
+      if (flowStack.length > 0 && current === ",") break;
       if (current === ":" && isColonIndicator(line, index)) break;
       index += 1;
     }
@@ -336,7 +353,7 @@ function tokenizeYamlLine(line, state = {}) {
     if (index === start) index += 1;
   }
 
-  return { tokens, state: { quote: null, flowDepth, nodeBoundary, keyAllowed } };
+  return { tokens, state: { quote: null, flowStack, nodeBoundary, keyAllowed } };
 }
 
 function trackerKeyCount(tokens) {
@@ -360,7 +377,7 @@ function isBlockScalarHeader(tokens) {
 function trackerCandidates(raw, configPath) {
   const candidates = [];
   let blockScalarParentIndent = null;
-  let lexicalState = { quote: null, flowDepth: 0, nodeBoundary: true, keyAllowed: true };
+  let lexicalState = { quote: null, flowStack: [], nodeBoundary: true, keyAllowed: true };
   let contentSeen = false;
   let leadingDocumentMarkerSeen = false;
 
@@ -372,20 +389,23 @@ function trackerCandidates(raw, configPath) {
       if (!trimmed || indent > blockScalarParentIndent) continue;
       blockScalarParentIndent = null;
     }
-    const scanned = tokenizeYamlLine(record.text, lexicalState);
-    lexicalState = scanned.state;
-    const marker = scanned.tokens.length === 1 && scanned.tokens[0].type === "scalar" &&
-      !scanned.tokens[0].quoted ? scanned.tokens[0].value : null;
-    if (marker === "---") {
-      if (contentSeen || leadingDocumentMarkerSeen) {
-        throw new ConfigValidationError(configPath, "multiple YAML documents are unsupported");
+    const atDocumentBoundary = !lexicalState.quote && lexicalState.flowStack.length === 0;
+    const documentMarker = atDocumentBoundary
+      ? record.text.match(/^\uFEFF?(---|\.\.\.)(?:[ \t]*(?:#.*)?)?$/)
+      : null;
+    if (documentMarker) {
+      if (documentMarker[1] === "..." || contentSeen || leadingDocumentMarkerSeen) {
+        throw new ConfigValidationError(configPath, "multiple or ended YAML documents are unsupported");
       }
       leadingDocumentMarkerSeen = true;
       continue;
     }
-    if (marker === "...") {
-      throw new ConfigValidationError(configPath, "YAML document end markers are unsupported");
+    if (atDocumentBoundary && /^\uFEFF?%YAML(?:[ \t]|$)/.test(record.text)) {
+      throw new ConfigValidationError(configPath, "YAML directives are unsupported");
     }
+    const scanned = tokenizeYamlLine(record.text, lexicalState);
+    lexicalState = scanned.state;
+    if (lexicalState.error) throw new ConfigValidationError(configPath, lexicalState.error);
     if (scanned.tokens.length > 0) contentSeen = true;
 
     if (scanned.tokens.some((token) => token.type === "?")) {
@@ -403,7 +423,7 @@ function trackerCandidates(raw, configPath) {
           "alias mapping keys are authority-obscuring and unsupported"
         );
       }
-      if (token.type === "scalar" && token.value === "<<" && next && next.type === ":") {
+      if (token.type === "scalar" && !token.quoted && token.value === "<<" && next && next.type === ":") {
         throw new ConfigValidationError(
           configPath,
           "YAML merge keys are authority-obscuring and unsupported"
@@ -411,11 +431,11 @@ function trackerCandidates(raw, configPath) {
       }
     }
     for (let count = trackerKeyCount(scanned.tokens); count > 0; count -= 1) candidates.push(record);
-    if (!lexicalState.quote && lexicalState.flowDepth === 0 && isBlockScalarHeader(scanned.tokens)) {
+    if (!lexicalState.quote && lexicalState.flowStack.length === 0 && isBlockScalarHeader(scanned.tokens)) {
       blockScalarParentIndent = indent;
     }
   }
-  if (lexicalState.quote || lexicalState.flowDepth !== 0) {
+  if (lexicalState.quote || lexicalState.flowStack.length !== 0) {
     throw new ConfigValidationError(configPath, "the YAML lexical structure is incomplete at end of file");
   }
   return candidates;

--- a/skills/dev-backlog/scripts/setup-dev-backlog.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.js
@@ -140,19 +140,85 @@ function lineRecords(raw) {
   return records;
 }
 
-function looksLikeTrackerDeclaration(line) {
-  if (!line.trim() || line.trimStart().startsWith("#")) return false;
+function scanYamlLine(line, carriedQuote = null) {
+  const visible = [...line];
+  let quote = carriedQuote;
+  let quotedTrackerKey = false;
+
+  for (let index = 0; index < line.length; index += 1) {
+    if (quote) {
+      visible[index] = " ";
+      if (quote === "'" && line[index] === "'" && line[index + 1] === "'") {
+        visible[index + 1] = " ";
+        index += 1;
+      } else if (quote === '"' && line[index] === "\\") {
+        if (index + 1 < line.length) {
+          visible[index + 1] = " ";
+          index += 1;
+        }
+      } else if (line[index] === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (line[index] === "#") {
+      visible.fill(" ", index);
+      break;
+    }
+    if (line[index] !== "'" && line[index] !== '"') continue;
+
+    const opening = line[index];
+    const start = index;
+    let content = "";
+    visible[index] = " ";
+    quote = opening;
+    for (index += 1; index < line.length; index += 1) {
+      visible[index] = " ";
+      if (opening === "'" && line[index] === "'" && line[index + 1] === "'") {
+        content += "'";
+        visible[index + 1] = " ";
+        index += 1;
+      } else if (opening === '"' && line[index] === "\\") {
+        if (index + 1 < line.length) {
+          content += line[index + 1];
+          visible[index + 1] = " ";
+          index += 1;
+        }
+      } else if (line[index] === opening) {
+        quote = null;
+        break;
+      } else {
+        content += line[index];
+      }
+    }
+
+    if (!quote && content === "tracker") {
+      let after = index + 1;
+      while (after < line.length && /[ \t]/.test(line[after])) after += 1;
+      const prefix = visible.slice(0, start).join("").replace(/^\uFEFF/, "");
+      const mappingBoundary = /^\s*(?:-\s*)?$/.test(prefix) || /(?:^|[{,])\s*$/.test(prefix);
+      if (line[after] === ":" && mappingBoundary) quotedTrackerKey = true;
+    }
+  }
+
+  return { visible: visible.join(""), carriedQuote: quote, quotedTrackerKey };
+}
+
+function looksLikeTrackerDeclaration(visible, quotedTrackerKey) {
+  if (quotedTrackerKey) return true;
+  if (!visible.trim()) return false;
   return (
-    /^\uFEFF?\s*tracker\s*:/.test(line) ||
-    /^\s*["']tracker["']\s*:/.test(line) ||
-    /^\s*-\s*tracker\s*:/.test(line) ||
-    /[{,]\s*tracker\s*:/.test(line)
+    /^\uFEFF?\s*tracker\s*:/.test(visible) ||
+    /^\s*-\s*tracker\s*:/.test(visible) ||
+    /(?:^|[{,])\s*tracker\s*:/.test(visible)
   );
 }
 
 function trackerCandidates(raw) {
   const candidates = [];
   let blockScalarParentIndent = null;
+  let carriedQuote = null;
 
   for (const record of lineRecords(raw)) {
     const withoutBom = record.text.replace(/^\uFEFF/, "");
@@ -162,8 +228,13 @@ function trackerCandidates(raw) {
       if (!trimmed || indent > blockScalarParentIndent) continue;
       blockScalarParentIndent = null;
     }
-    if (looksLikeTrackerDeclaration(record.text)) candidates.push(record);
-    if (/^\s*(?:[^#][^:]*):[ \t]*[>|](?:[1-9][+-]?|[+-][1-9]?)?\s*(?:#.*)?$/.test(withoutBom)) {
+    const scanned = scanYamlLine(record.text, carriedQuote);
+    carriedQuote = scanned.carriedQuote;
+    if (looksLikeTrackerDeclaration(scanned.visible, scanned.quotedTrackerKey)) candidates.push(record);
+    if (
+      !carriedQuote &&
+      /:\s*(?:(?:[&!][^\s,\[\]{}]+)\s+)*(?:[>|](?:[1-9][+-]?|[+-][1-9]?)?)\s*$/.test(scanned.visible.replace(/^\uFEFF/, ""))
+    ) {
       blockScalarParentIndent = indent;
     }
   }
@@ -243,14 +314,20 @@ function mutateTrackerText(raw, state, selection) {
 function isGithubRemote(remote) {
   const value = String(remote || "").trim();
   if (!value) return false;
-  if (/^(?:[^@\s]+@)?github\.com:[^/\s]+\/[^/\s]+(?:\.git)?\/?$/i.test(value)) {
+  const component = "[A-Za-z0-9_.-]+";
+  if (new RegExp(`^[^@\\s]+@github\\.com:${component}/${component}(?:\\.git)?$`, "i").test(value)) {
     return true;
   }
   try {
     const parsed = new URL(value);
+    const allowedProtocol = new Set(["http:", "https:", "ssh:", "git:"]);
     return (
+      allowedProtocol.has(parsed.protocol) &&
       parsed.hostname.toLowerCase() === "github.com" &&
-      parsed.pathname.split("/").filter(Boolean).length >= 2
+      parsed.port === "" &&
+      parsed.search === "" &&
+      parsed.hash === "" &&
+      new RegExp(`^/${component}/${component}(?:\\.git)?$`).test(parsed.pathname)
     );
   } catch {
     return false;
@@ -353,7 +430,11 @@ function tempPathFor(targetPath) {
 }
 
 function atomicPublish(targetPath, content, { fs: fsApi = fs } = {}) {
-  const targetExists = fsApi.existsSync(targetPath);
+  const targetStat = lstatIfPresent(targetPath, fsApi);
+  if (targetStat && (targetStat.isSymbolicLink() || !targetStat.isFile())) {
+    throw new SetupError(`Refusing unsafe config path: ${targetPath} must be a regular file.`);
+  }
+  const targetExists = Boolean(targetStat);
   if (targetExists) {
     const current = fsApi.readFileSync(targetPath, "utf8");
     if (current === content) return Object.freeze({ changed: false, created: false });
@@ -378,40 +459,57 @@ function atomicPublish(targetPath, content, { fs: fsApi = fs } = {}) {
 }
 
 function ensureMinimumDirectories(backlogDir, fsApi) {
-  const backlogCreated = !fsApi.existsSync(backlogDir);
-  const created = [];
-  fsApi.mkdirSync(backlogDir, { recursive: true });
-  for (const name of MINIMUM_DIRECTORIES) {
-    const directory = path.join(backlogDir, name);
-    if (!fsApi.existsSync(directory)) {
-      fsApi.mkdirSync(directory);
-      created.push(name);
+  const structure = { backlogCreated: false, created: [] };
+  try {
+    if (!lstatIfPresent(backlogDir, fsApi)) {
+      fsApi.mkdirSync(backlogDir);
+      structure.backlogCreated = true;
     }
+    for (const name of MINIMUM_DIRECTORIES) {
+      const directory = path.join(backlogDir, name);
+      if (!lstatIfPresent(directory, fsApi)) {
+        fsApi.mkdirSync(directory);
+        structure.created.push(name);
+      }
+    }
+    return structure;
+  } catch (error) {
+    rollbackCreatedDirectories(backlogDir, structure, fsApi);
+    throw error;
   }
-  return { backlogCreated, created };
+}
+
+function lstatIfPresent(targetPath, fsApi) {
+  try {
+    return fsApi.lstatSync(targetPath);
+  } catch (error) {
+    if (error && error.code === "ENOENT") return null;
+    throw error;
+  }
 }
 
 function validateExistingStructure(backlogDir, configPath, fsApi) {
-  if (fsApi.existsSync(backlogDir)) {
-    const backlogStat = fsApi.lstatSync(backlogDir);
+  const backlogStat = lstatIfPresent(backlogDir, fsApi);
+  if (backlogStat) {
     if (backlogStat.isSymbolicLink() || !backlogStat.isDirectory()) {
       throw new SetupError(`Refusing unsafe backlog path: ${backlogDir} must be a real directory.`);
     }
   }
-  if (fsApi.existsSync(configPath)) {
-    const configStat = fsApi.lstatSync(configPath);
+  const configStat = lstatIfPresent(configPath, fsApi);
+  if (configStat) {
     if (configStat.isSymbolicLink() || !configStat.isFile()) {
       throw new SetupError(`Refusing unsafe config path: ${configPath} must be a regular file.`);
     }
   }
   for (const name of MINIMUM_DIRECTORIES) {
     const directory = path.join(backlogDir, name);
-    if (!fsApi.existsSync(directory)) continue;
-    const stat = fsApi.lstatSync(directory);
+    const stat = lstatIfPresent(directory, fsApi);
+    if (!stat) continue;
     if (stat.isSymbolicLink() || !stat.isDirectory()) {
       throw new SetupError(`Refusing unsafe backlog path: ${directory} must be a real directory.`);
     }
   }
+  return { configExists: Boolean(configStat) };
 }
 
 function rollbackCreatedDirectories(backlogDir, structure, fsApi) {
@@ -457,8 +555,8 @@ async function runSetup(options = {}, dependencies = {}) {
   const cwd = path.resolve(options.cwd || process.cwd());
   const backlogDir = path.join(cwd, "backlog");
   const configPath = path.join(backlogDir, "config.yml");
-  validateExistingStructure(backlogDir, configPath, fsApi);
-  const configExists = fsApi.existsSync(configPath);
+  const structureState = validateExistingStructure(backlogDir, configPath, fsApi);
+  const configExists = structureState.configExists;
   let raw;
   let configState;
 

--- a/skills/dev-backlog/scripts/setup-dev-backlog.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.js
@@ -180,11 +180,51 @@ function decodeDoubleQuotedScalar(raw) {
     const digits = raw.slice(index + 2, index + 2 + width);
     if (!width || digits.length !== width || !/^[0-9A-Fa-f]+$/.test(digits)) return null;
     const codePoint = Number.parseInt(digits, 16);
-    if (codePoint > 0x10ffff) return null;
+    if (codePoint > 0x10ffff || (codePoint >= 0xd800 && codePoint <= 0xdfff)) return null;
     decoded += String.fromCodePoint(codePoint);
     index += width + 1;
   }
   return decoded;
+}
+
+function isYamlPrintableCodePoint(codePoint) {
+  return codePoint === 0x09 || codePoint === 0x0a || codePoint === 0x0d ||
+    (codePoint >= 0x20 && codePoint <= 0x7e) || codePoint === 0x85 ||
+    (codePoint >= 0xa0 && codePoint <= 0xd7ff) ||
+    (codePoint >= 0xe000 && codePoint <= 0xfffd) ||
+    (codePoint >= 0x10000 && codePoint <= 0x10ffff);
+}
+
+function validateYamlPrintable(raw, configPath) {
+  for (let index = 0; index < raw.length; index += 1) {
+    const first = raw.charCodeAt(index);
+    let codePoint = first;
+    if (first >= 0xd800 && first <= 0xdbff) {
+      const second = raw.charCodeAt(index + 1);
+      if (!(second >= 0xdc00 && second <= 0xdfff)) {
+        throw new ConfigValidationError(configPath, "an unpaired raw surrogate is not YAML-printable");
+      }
+      codePoint = ((first - 0xd800) * 0x400) + (second - 0xdc00) + 0x10000;
+      index += 1;
+    } else if (first >= 0xdc00 && first <= 0xdfff) {
+      throw new ConfigValidationError(configPath, "an unpaired raw surrogate is not YAML-printable");
+    }
+    if (!isYamlPrintableCodePoint(codePoint)) {
+      throw new ConfigValidationError(
+        configPath,
+        `character U+${codePoint.toString(16).toUpperCase().padStart(4, "0")} is not YAML-printable`
+      );
+    }
+  }
+}
+
+function validAnchorOrAliasName(name) {
+  return /^[\p{L}\p{N}_.-]+$/u.test(name);
+}
+
+function validTagToken(tag) {
+  if (tag.length <= 1 || /%(?![0-9A-Fa-f]{2})/.test(tag)) return false;
+  return /^!(?:![^\s!,\[\]{}]+|[^\s!,\[\]{}]+(?:![^\s!,\[\]{}]+)?)$/u.test(tag);
 }
 
 function isColonIndicator(line, index) {
@@ -270,9 +310,20 @@ function tokenizeYamlLine(line, state = {}) {
         if (close === -1) {
           return { tokens, state: { quote: null, flowStack, error: "unterminated verbatim tag" } };
         }
+        const tag = line.slice(index + 2, close);
+        if (!tag || /[\s<>]/.test(tag) || /%(?![0-9A-Fa-f]{2})/.test(tag)) {
+          return { tokens, state: { quote: null, flowStack, error: "invalid verbatim tag spelling" } };
+        }
         index = close + 1;
       } else {
         while (index < line.length && !/[ \t,\[\]{}]/.test(line[index])) index += 1;
+        const property = line.slice(start, index);
+        const valid = char === "&"
+          ? validAnchorOrAliasName(property.slice(1))
+          : validTagToken(property);
+        if (!valid) {
+          return { tokens, state: { quote: null, flowStack, error: "invalid tag or anchor spelling" } };
+        }
       }
       tokens.push({
         type: "property",
@@ -284,8 +335,12 @@ function tokenizeYamlLine(line, state = {}) {
     if (nodeBoundary && char === "*") {
       const start = index + 1;
       index = start;
-      while (index < line.length && /[A-Za-z0-9_-]/.test(line[index])) index += 1;
-      tokens.push({ type: "alias", name: line.slice(start, index) });
+      while (index < line.length && !/[ \t,\[\]{}:]/.test(line[index])) index += 1;
+      const name = line.slice(start, index);
+      if (!validAnchorOrAliasName(name)) {
+        return { tokens, state: { quote: null, flowStack, error: "invalid alias spelling" } };
+      }
+      tokens.push({ type: "alias", name });
       nodeBoundary = false;
       keyAllowed = false;
       continue;
@@ -400,7 +455,7 @@ function trackerCandidates(raw, configPath) {
       leadingDocumentMarkerSeen = true;
       continue;
     }
-    if (atDocumentBoundary && /^\uFEFF?%YAML(?:[ \t]|$)/.test(record.text)) {
+    if (!lexicalState.quote && /^\uFEFF?%/.test(record.text)) {
       throw new ConfigValidationError(configPath, "YAML directives are unsupported");
     }
     const scanned = tokenizeYamlLine(record.text, lexicalState);
@@ -464,6 +519,7 @@ function inspectConfig(raw, configPath = "backlog/config.yml") {
   if (typeof raw !== "string") {
     throw new ConfigValidationError(configPath, "the config could not be read as text");
   }
+  validateYamlPrintable(raw, configPath);
 
   const candidates = trackerCandidates(raw, configPath);
   if (candidates.length === 0) {

--- a/skills/dev-backlog/scripts/setup-dev-backlog.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.js
@@ -498,7 +498,7 @@ function trackerCandidates(raw, configPath) {
 
 function parseValidTrackerLine(record) {
   const match = record.text.match(
-    /^\uFEFF?tracker:([ \t]*)(?:(["'])(github|local)\2|(github|local))([ \t]*(?:#.*)?)$/
+    /^\uFEFF?tracker:([ \t]*)(?:(["'])(github|local)\2|(github|local))((?:[ \t]+#.*|[ \t]*))$/
   );
   if (!match) return null;
 

--- a/skills/dev-backlog/scripts/setup-dev-backlog.test.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.test.js
@@ -225,6 +225,47 @@ describe("tracker config state machine", () => {
     }
   });
 
+  it("tracks cross-line explicit keys and anchored alias keys as tracker authority", () => {
+    for (const declaration of [
+      "?\n  tracker\n: github",
+      '?\n  "tracker"\n: github',
+      '?\n  "track\\\n    er"\n: github',
+      "key_name: &authority tracker\n*authority: github",
+      "key_name: &authority\n  tracker\n*authority: github",
+    ]) {
+      assert.throws(
+        () => inspectConfig(`${declaration}\ntracker: local\n`, "/repo/backlog/config.yml"),
+        ConfigValidationError,
+        declaration
+      );
+    }
+  });
+
+  it("preserves unrelated anchors and aliases but rejects unresolved authority aliases", () => {
+    for (const raw of [
+      "key_name: &other something\n*other: value\ntracker: local\n",
+      "base: &base {other: value}\n<<: *base\ntracker: local\n",
+    ]) {
+      assert.equal(inspectConfig(raw, "/repo/backlog/config.yml").tracker, "local");
+    }
+    for (const raw of [
+      "*unknown: value\ntracker: local\n",
+      "<<: *unknown\ntracker: local\n",
+    ]) {
+      assert.throws(() => inspectConfig(raw, "/repo/backlog/config.yml"), /ambiguous/);
+    }
+  });
+
+  it("rejects incomplete quoted, flow, and explicit-key lexical state at EOF", () => {
+    for (const raw of [
+      'note: "unterminated\ntracker: local\n',
+      "mapping: {other: value\ntracker: local\n",
+      "tracker: local\n?\n",
+    ]) {
+      assert.throws(() => inspectConfig(raw, "/repo/backlog/config.yml"), /incomplete/);
+    }
+  });
+
   it("recognizes a BOM-prefixed top-level tracker without disturbing the BOM", () => {
     const raw = "\uFEFFtracker: github\r\nother: yes";
     const state = inspectConfig(raw, "/repo/backlog/config.yml");
@@ -252,6 +293,7 @@ describe("provider evidence", () => {
       "https://github.com/owner/repo.git",
       "ssh://git@github.com/owner/repo.git",
       "git@github.com:owner/repo.git",
+      "git@GitHub.COM:owner/repo.git",
       "ssh://git@ssh.github.com:443/owner/repo.git",
     ]) assert.equal(isGithubRemote(remote), true, remote);
 
@@ -276,6 +318,13 @@ describe("provider evidence", () => {
       "ssh://git@ssh.github.com/owner/repo.git",
       "ssh://alice@ssh.github.com:443/owner/repo.git",
       "git@github.com:owner/repo/issues",
+      "git@github.com:./repo.git",
+      "git@github.com:../repo.git",
+      "git@github.com:owner/..",
+      "git@github.com:owner/.",
+      "git@github.com:/repo.git",
+      "git@github.com:owner/",
+      "git@github.com:owner/../repo.git",
     ]) assert.equal(isGithubRemote(remote), false, remote);
   });
 

--- a/skills/dev-backlog/scripts/setup-dev-backlog.test.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.test.js
@@ -192,6 +192,19 @@ describe("tracker config state machine", () => {
     }
   });
 
+  it("does not open quote state for apostrophes or embedded quotes in plain scalars", () => {
+    const raw = [
+      "note: don't hide the authority",
+      'message: say "tracker: github" plainly',
+      "tracker: local",
+      "",
+    ].join("\n");
+    const state = inspectConfig(raw, "/repo/backlog/config.yml");
+    assert.equal(state.kind, "selected");
+    assert.equal(state.tracker, "local");
+    assert.equal(mutateTrackerText(raw, state, "local"), raw);
+  });
+
   it("fails closed on actual top-level, nested, sequence, and flow tracker declarations", () => {
     for (const declaration of [
       "tracker: github",
@@ -199,6 +212,13 @@ describe("tracker config state machine", () => {
       "- tracker: github",
       "mapping: {tracker: github}",
       "mapping: {'tracker': github}",
+      "items: [tracker: github]",
+      "&authority tracker: github",
+      "!authority tracker: github",
+      "? tracker\n: github",
+      'mapping: {"track\\x65r": github}',
+      "mapping: {emoji: 😀, tracker: github}",
+      "mapping: [\n  {emoji: 😀,\n   tracker: github}\n]",
     ]) {
       const raw = `${declaration}\ntracker: local\n`;
       assert.throws(() => inspectConfig(raw, "/repo/backlog/config.yml"), ConfigValidationError);
@@ -230,14 +250,15 @@ describe("provider evidence", () => {
   it("accepts only exact github.com remote hosts", () => {
     for (const remote of [
       "https://github.com/owner/repo.git",
-      "http://github.com/owner/repo",
       "ssh://git@github.com/owner/repo.git",
       "git@github.com:owner/repo.git",
-      "git://github.com/owner/repo.git",
-      "https://user:secret@github.com/owner/repo.git",
+      "ssh://git@ssh.github.com:443/owner/repo.git",
     ]) assert.equal(isGithubRemote(remote), true, remote);
 
     for (const remote of [
+      "http://github.com/owner/repo.git",
+      "git://github.com/owner/repo.git",
+      "https://user:secret@github.com/owner/repo.git",
       "https://github.com.evil.test/owner/repo.git",
       "git@github.com.evil.test:owner/repo.git",
       "https://github.com/owner",
@@ -247,6 +268,13 @@ describe("provider evidence", () => {
       "https://github.com/owner/repo#readme",
       "ftp://github.com/owner/repo.git",
       "github.com/owner/repo",
+      "github.com:owner/repo.git",
+      "alice@github.com:owner/repo.git",
+      "GIT@github.com:owner/repo.git",
+      "ssh://alice@github.com/owner/repo.git",
+      "ssh://github.com/owner/repo.git",
+      "ssh://git@ssh.github.com/owner/repo.git",
+      "ssh://alice@ssh.github.com:443/owner/repo.git",
       "git@github.com:owner/repo/issues",
     ]) assert.equal(isGithubRemote(remote), false, remote);
   });
@@ -266,7 +294,7 @@ describe("provider evidence", () => {
         expected: { recommendation: "local", remote: "github", cli: "available", auth: "unauthenticated" },
       },
       {
-        input: { remote: "https://user:token@github.com/owner/repo.git", gh: "missing" },
+        input: { remote: "ssh://git@ssh.github.com:443/owner/repo.git", gh: "missing" },
         expected: { recommendation: "local", remote: "github", cli: "missing", auth: "not-checked" },
       },
       {

--- a/skills/dev-backlog/scripts/setup-dev-backlog.test.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.test.js
@@ -120,6 +120,30 @@ describe("tracker config state machine", () => {
     );
   });
 
+  it("requires whitespace before tracker comments and matches runtime selection", (t) => {
+    for (const raw of [
+      "tracker: local\n",
+      "tracker: local \t\n",
+      "tracker: local # comment\n",
+      "tracker: 'local'\t# comment\n",
+      'tracker: "github"  # comment\n',
+    ]) assert.ok(inspectConfig(raw, "/repo/backlog/config.yml").tracker);
+
+    for (const tracker of ["local", "github"]) {
+      const raw = `tracker: ${tracker}#not-a-comment\n`;
+      assert.throws(() => inspectConfig(raw, "/repo/backlog/config.yml"), ConfigValidationError);
+
+      const root = makeRoot(t, `setup-runtime-comment-${tracker}-`);
+      writeConfig(root, raw);
+      assert.throws(
+        () => resolveConfiguredTracker(readConfig(path.join(root, "backlog")), {
+          backlogDir: path.join(root, "backlog"),
+        }),
+        /Invalid tracker configuration/
+      );
+    }
+  });
+
   it("rejects invalid, missing-value, duplicate, nested, and ambiguous tracker forms", () => {
     const cases = [
       "tracker: gitlab\n",

--- a/skills/dev-backlog/scripts/setup-dev-backlog.test.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.test.js
@@ -262,13 +262,17 @@ describe("tracker config state machine", () => {
       "<<: [*one, *two]",
       "mapping: {<<: *unknown}",
       "base: &base {other: value}\n<<: *base",
-      "!!merge '<<': *unknown",
     ]) {
       assert.throws(
         () => inspectConfig(`${merge}\ntracker: local\n`, "/repo/backlog/config.yml"),
         /merge keys/
       );
     }
+    for (const raw of [
+      "'<<': *unknown\ntracker: local\n",
+      '"<<": *unknown\ntracker: local\n',
+      "mapping: {'<<': *unknown}\ntracker: local\n",
+    ]) assert.equal(inspectConfig(raw, "/repo/backlog/config.yml").tracker, "local");
   });
 
   it("allows only one optional leading YAML document marker", () => {
@@ -282,7 +286,30 @@ describe("tracker config state machine", () => {
     for (const raw of [
       "note: |\n  ---\n  ...\ntracker: local\n",
       'note: "---\n  ..."\ntracker: local\n',
+      "note: continued\n  ---\ntracker: local\n",
+      "note: continued\n  ...\ntracker: local\n",
     ]) assert.equal(inspectConfig(raw, "/repo/backlog/config.yml").tracker, "local");
+  });
+
+  it("requires exact matching flow delimiters across lines", () => {
+    assert.equal(
+      inspectConfig("mapping: {items: [one,\n  two]}\ntracker: local\n", "/repo/backlog/config.yml").tracker,
+      "local"
+    );
+    for (const raw of [
+      "mapping: ]\ntracker: local\n",
+      "mapping: {items: [one}}\ntracker: local\n",
+      "mapping: {items: one]\ntracker: local\n",
+      "mapping: {items: [one]\ntracker: local\n",
+    ]) assert.throws(() => inspectConfig(raw, "/repo/backlog/config.yml"), /flow delimiter|incomplete/);
+  });
+
+  it("rejects incomplete tags, invalid quoted escapes, and YAML directives", () => {
+    for (const raw of [
+      "note: !<unterminated\ntracker: local\n",
+      'note: "bad\\q"\ntracker: local\n',
+      "%YAML 1.2\n---\ntracker: local\n",
+    ]) assert.throws(() => inspectConfig(raw, "/repo/backlog/config.yml"), ConfigValidationError);
   });
 
   it("rejects incomplete quoted, flow, and explicit-key lexical state at EOF", () => {

--- a/skills/dev-backlog/scripts/setup-dev-backlog.test.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.test.js
@@ -160,6 +160,51 @@ describe("tracker config state machine", () => {
     assert.equal(mutateTrackerText(raw, state, "local"), raw.replace("tracker: github", "tracker: local"));
   });
 
+  it("preserves tracker text inside quoted-key block scalars and multiline quoted scalars", () => {
+    const fixtures = [
+      [
+        '"note:with:colons": &copy !text |-2',
+        "    tracker: local",
+        "    literal text",
+        "tracker: github",
+        "",
+      ].join("\n"),
+      [
+        "note: 'first line",
+        "  tracker: local",
+        "  still quoted'",
+        "tracker: github",
+        "",
+      ].join("\n"),
+      [
+        'note: "first line',
+        "  tracker: local",
+        '  still quoted"',
+        "tracker: github",
+        "",
+      ].join("\n"),
+    ];
+
+    for (const raw of fixtures) {
+      const state = inspectConfig(raw, "/repo/backlog/config.yml");
+      assert.equal(state.tracker, "github");
+      assert.equal(mutateTrackerText(raw, state, "local"), raw.replace(/tracker: github/, "tracker: local"));
+    }
+  });
+
+  it("fails closed on actual top-level, nested, sequence, and flow tracker declarations", () => {
+    for (const declaration of [
+      "tracker: github",
+      "  tracker: github",
+      "- tracker: github",
+      "mapping: {tracker: github}",
+      "mapping: {'tracker': github}",
+    ]) {
+      const raw = `${declaration}\ntracker: local\n`;
+      assert.throws(() => inspectConfig(raw, "/repo/backlog/config.yml"), ConfigValidationError);
+    }
+  });
+
   it("recognizes a BOM-prefixed top-level tracker without disturbing the BOM", () => {
     const raw = "\uFEFFtracker: github\r\nother: yes";
     const state = inspectConfig(raw, "/repo/backlog/config.yml");
@@ -183,11 +228,27 @@ describe("CLI argument boundary", () => {
 
 describe("provider evidence", () => {
   it("accepts only exact github.com remote hosts", () => {
-    assert.equal(isGithubRemote("https://github.com/owner/repo.git"), true);
-    assert.equal(isGithubRemote("git@github.com:owner/repo.git"), true);
-    assert.equal(isGithubRemote("https://user:secret@github.com/owner/repo.git"), true);
-    assert.equal(isGithubRemote("https://github.com.evil.test/owner/repo.git"), false);
-    assert.equal(isGithubRemote("git@github.com.evil.test:owner/repo.git"), false);
+    for (const remote of [
+      "https://github.com/owner/repo.git",
+      "http://github.com/owner/repo",
+      "ssh://git@github.com/owner/repo.git",
+      "git@github.com:owner/repo.git",
+      "git://github.com/owner/repo.git",
+      "https://user:secret@github.com/owner/repo.git",
+    ]) assert.equal(isGithubRemote(remote), true, remote);
+
+    for (const remote of [
+      "https://github.com.evil.test/owner/repo.git",
+      "git@github.com.evil.test:owner/repo.git",
+      "https://github.com/owner",
+      "https://github.com/owner/repo/issues",
+      "https://github.com/owner/repo.git/extra",
+      "https://github.com/owner/repo.git?tab=readme",
+      "https://github.com/owner/repo#readme",
+      "ftp://github.com/owner/repo.git",
+      "github.com/owner/repo",
+      "git@github.com:owner/repo/issues",
+    ]) assert.equal(isGithubRemote(remote), false, remote);
   });
 
   it("recommends github only for the usable-origin/authenticated matrix cell", () => {
@@ -503,6 +564,27 @@ describe("setup filesystem behavior", () => {
       /unsafe backlog path/
     );
     assert.deepEqual(fs.readdirSync(outside), []);
+  });
+
+  it("rolls back directories created before an intermediate mkdir failure", async (t) => {
+    const root = makeRoot(t);
+    const fsApi = {
+      ...fs,
+      mkdirSync(directory, options) {
+        if (directory === path.join(root, "backlog", "tasks")) {
+          throw new Error("injected mkdir failure");
+        }
+        return fs.mkdirSync(directory, options);
+      },
+    };
+    await assert.rejects(
+      runSetup(
+        { cwd: root, tracker: "local", nonInteractive: true },
+        { fs: fsApi, execFileSync: noProviderCalls() }
+      ),
+      /injected mkdir failure/
+    );
+    assert.equal(fs.existsSync(path.join(root, "backlog")), false);
   });
 });
 

--- a/skills/dev-backlog/scripts/setup-dev-backlog.test.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.test.js
@@ -4,6 +4,8 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 const { spawnSync } = require("node:child_process");
+const { readConfig } = require("./lib.js");
+const { resolveConfiguredTracker } = require("./tracker.js");
 
 const {
   ConfigValidationError,
@@ -173,6 +175,38 @@ describe("provider evidence", () => {
       assert.doesNotMatch(JSON.stringify(evidence), /token|SECRET/i);
     }
   });
+
+  it("uses sanitized evidence only to recommend a fresh interactive choice", async (t) => {
+    for (const row of [
+      {
+        input: { remote: "git@github.com:owner/repo.git", gh: "authenticated" },
+        expected: "github",
+      },
+      {
+        input: { remote: "https://example.com/owner/repo.git", gh: "authenticated" },
+        expected: "local",
+      },
+    ]) {
+      const root = makeRoot(t, `setup-interactive-${row.expected}-`);
+      const mock = evidenceExec(row.input);
+      let promptInput;
+      const result = await runSetup(
+        { cwd: root, projectName: "interactive" },
+        {
+          isInteractive: true,
+          execFileSync: mock.execFileSync,
+          prompt: (input) => {
+            promptInput = input;
+            return "";
+          },
+        }
+      );
+      assert.equal(result.selection, row.expected);
+      assert.equal(result.selectionSource, "recommended");
+      assert.equal(promptInput.recommendation, row.expected);
+      assert.doesNotMatch(JSON.stringify(promptInput), /SECRET-TOKEN/);
+    }
+  });
 });
 
 describe("setup filesystem behavior", () => {
@@ -190,6 +224,10 @@ describe("setup filesystem behavior", () => {
     ]);
     const raw = fs.readFileSync(path.join(root, "backlog/config.yml"), "utf8");
     assert.deepEqual(raw.match(/^tracker:\s*local\s*$/gm), ["tracker: local"]);
+    const resolved = resolveConfiguredTracker(readConfig(path.join(root, "backlog")), {
+      backlogDir: path.join(root, "backlog"),
+    });
+    assert.equal(resolved.tracker, "local");
   });
 
   it("creates a fresh explicit github setup and reports repair without fallback", async (t) => {
@@ -262,6 +300,33 @@ describe("setup filesystem behavior", () => {
     );
   });
 
+  it("preserves an existing github selection when evidence degrades and only reports repair", async (t) => {
+    const root = makeRoot(t);
+    writeConfig(root, "project_name: stable\ntracker: github\n# tail\n");
+    for (const name of ["tasks", "sprints", "completed"]) {
+      fs.mkdirSync(path.join(root, "backlog", name));
+    }
+    const configPath = path.join(root, "backlog/config.yml");
+    const before = fs.statSync(configPath);
+    const mock = evidenceExec({
+      remote: "https://example.com/owner/repo.git",
+      gh: "missing",
+    });
+    const result = await runSetup(
+      { cwd: root, nonInteractive: true },
+      { execFileSync: mock.execFileSync }
+    );
+    const after = fs.statSync(configPath);
+    assert.equal(result.selection, "github");
+    assert.equal(result.selectionSource, "preserved");
+    assert.equal(result.github.available, false);
+    assert.equal(result.github.fallbackAttempted, false);
+    assert.match(result.github.repair, /GitHub CLI/);
+    assert.equal(after.ino, before.ino);
+    assert.equal(after.mtimeMs, before.mtimeMs);
+    assert.equal(fs.readFileSync(configPath, "utf8"), "project_name: stable\ntracker: github\n# tail\n");
+  });
+
   it("repairs partial structure while preserving all user files and reruns as a true no-op", async (t) => {
     const root = makeRoot(t);
     writeConfig(root, "project_name: partial\ntracker: local\n");
@@ -286,6 +351,25 @@ describe("setup filesystem behavior", () => {
       { execFileSync: noProviderCalls() }
     );
     assert.deepEqual(snapshotTree(path.join(root, "backlog")), repaired);
+  });
+
+  it("adds a missing config without changing task, sprint, or completed names/bytes/metadata", async (t) => {
+    const root = makeRoot(t);
+    for (const name of ["tasks", "sprints", "completed"]) {
+      fs.mkdirSync(path.join(root, "backlog", name), { recursive: true });
+    }
+    fs.writeFileSync(path.join(root, "backlog/tasks/BACK-7.md"), "task\r\nbytes");
+    fs.writeFileSync(path.join(root, "backlog/sprints/sprint.md"), "sprint bytes\n");
+    fs.writeFileSync(path.join(root, "backlog/completed/BACK-3.md"), "completed bytes");
+    const before = snapshotTree(path.join(root, "backlog"));
+
+    await runSetup(
+      { cwd: root, tracker: "local", nonInteractive: true, projectName: "partial" },
+      { execFileSync: noProviderCalls() }
+    );
+    const after = snapshotTree(path.join(root, "backlog"));
+    for (const key of Object.keys(before)) assert.deepEqual(after[key], before[key]);
+    assert.equal(after["config.yml"].type, "file");
   });
 
   it("fails malformed or duplicate tracker config before directories or temp files", async (t) => {
@@ -370,5 +454,20 @@ describe("CLI and compatibility wrapper", () => {
     const raw = fs.readFileSync(path.join(root, "backlog/config.yml"), "utf8");
     assert.match(raw, /^project_name: "wrapper-demo"$/m);
     assert.deepEqual(raw.match(/^tracker:\s*github\s*$/gm), ["tracker: github"]);
+  });
+
+  it("init.sh preserves an existing local selection without provider probing", (t) => {
+    const root = makeRoot(t);
+    writeConfig(root, "project_name: existing\ntracker: local\n# keep\n");
+    for (const name of ["tasks", "sprints", "completed"]) {
+      fs.mkdirSync(path.join(root, "backlog", name));
+    }
+    const before = snapshotTree(path.join(root, "backlog"));
+    const run = spawnSync("bash", [INIT, "ignored-new-name"], {
+      cwd: root,
+      encoding: "utf8",
+    });
+    assert.equal(run.status, 0, run.stderr);
+    assert.deepEqual(snapshotTree(path.join(root, "backlog")), before);
   });
 });

--- a/skills/dev-backlog/scripts/setup-dev-backlog.test.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.test.js
@@ -225,13 +225,13 @@ describe("tracker config state machine", () => {
     }
   });
 
-  it("tracks cross-line explicit keys and anchored alias keys as tracker authority", () => {
+  it("rejects every explicit mapping key as authority-obscuring syntax", () => {
     for (const declaration of [
       "?\n  tracker\n: github",
       '?\n  "tracker"\n: github',
       '?\n  "track\\\n    er"\n: github',
-      "key_name: &authority tracker\n*authority: github",
-      "key_name: &authority\n  tracker\n*authority: github",
+      "?\n  unrelated\n: value",
+      "&key_property ?\n  unrelated\n: value",
     ]) {
       assert.throws(
         () => inspectConfig(`${declaration}\ntracker: local\n`, "/repo/backlog/config.yml"),
@@ -241,29 +241,61 @@ describe("tracker config state machine", () => {
     }
   });
 
-  it("preserves unrelated anchors and aliases but rejects unresolved authority aliases", () => {
+  it("preserves anchor and alias values but rejects every alias mapping key", () => {
     for (const raw of [
-      "key_name: &other something\n*other: value\ntracker: local\n",
-      "base: &base {other: value}\n<<: *base\ntracker: local\n",
+      "key_name: &other something\ncopy: *other\ntracker: local\n",
+      "note: &empty\ntracker: local\nnote2: *empty\n",
     ]) {
       assert.equal(inspectConfig(raw, "/repo/backlog/config.yml").tracker, "local");
     }
     for (const raw of [
       "*unknown: value\ntracker: local\n",
-      "<<: *unknown\ntracker: local\n",
+      "key_name: &known something\n*known: value\ntracker: local\n",
     ]) {
-      assert.throws(() => inspectConfig(raw, "/repo/backlog/config.yml"), /ambiguous/);
+      assert.throws(() => inspectConfig(raw, "/repo/backlog/config.yml"), /alias mapping keys/);
     }
+  });
+
+  it("rejects every merge-key value shape and preserves ordinary alias values", () => {
+    for (const merge of [
+      "<<: *unknown",
+      "<<: [*one, *two]",
+      "mapping: {<<: *unknown}",
+      "base: &base {other: value}\n<<: *base",
+      "!!merge '<<': *unknown",
+    ]) {
+      assert.throws(
+        () => inspectConfig(`${merge}\ntracker: local\n`, "/repo/backlog/config.yml"),
+        /merge keys/
+      );
+    }
+  });
+
+  it("allows only one optional leading YAML document marker", () => {
+    assert.equal(inspectConfig("---\ntracker: local\n", "/repo/backlog/config.yml").tracker, "local");
+    for (const raw of [
+      "tracker: local\n---\n",
+      "---\n---\ntracker: local\n",
+      "---\ntracker: local\n...\n",
+    ]) assert.throws(() => inspectConfig(raw, "/repo/backlog/config.yml"), /document/);
+
+    for (const raw of [
+      "note: |\n  ---\n  ...\ntracker: local\n",
+      'note: "---\n  ..."\ntracker: local\n',
+    ]) assert.equal(inspectConfig(raw, "/repo/backlog/config.yml").tracker, "local");
   });
 
   it("rejects incomplete quoted, flow, and explicit-key lexical state at EOF", () => {
     for (const raw of [
       'note: "unterminated\ntracker: local\n',
       "mapping: {other: value\ntracker: local\n",
-      "tracker: local\n?\n",
     ]) {
       assert.throws(() => inspectConfig(raw, "/repo/backlog/config.yml"), /incomplete/);
     }
+    assert.throws(
+      () => inspectConfig("tracker: local\n?\n", "/repo/backlog/config.yml"),
+      /explicit mapping keys/
+    );
   });
 
   it("recognizes a BOM-prefixed top-level tracker without disturbing the BOM", () => {
@@ -292,6 +324,7 @@ describe("provider evidence", () => {
     for (const remote of [
       "https://github.com/owner/repo.git",
       "ssh://git@github.com/owner/repo.git",
+      "ssh://git@github.com:22/owner/repo.git",
       "git@github.com:owner/repo.git",
       "git@GitHub.COM:owner/repo.git",
       "ssh://git@ssh.github.com:443/owner/repo.git",

--- a/skills/dev-backlog/scripts/setup-dev-backlog.test.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.test.js
@@ -507,6 +507,30 @@ describe("provider evidence", () => {
 });
 
 describe("setup filesystem behavior", () => {
+  it("preserves separated tracker comments through setup and runtime resolution", async (t) => {
+    for (const [line, expected] of [
+      ["tracker: local # keep\n", "local"],
+      ["tracker: 'local'\t# keep\n", "local"],
+      ['tracker: "github"  # keep\n', "github"],
+    ]) {
+      const root = makeRoot(t, `setup-runtime-separated-${expected}-`);
+      writeConfig(root, line);
+      for (const name of ["tasks", "sprints", "completed"]) {
+        fs.mkdirSync(path.join(root, "backlog", name));
+      }
+      const before = snapshotTree(path.join(root, "backlog"));
+      await runSetup(
+        { cwd: root, nonInteractive: true },
+        { execFileSync: noProviderCalls(), checkGithubAvailability: noProviderCalls() }
+      );
+      assert.deepEqual(snapshotTree(path.join(root, "backlog")), before);
+      assert.equal(fs.readFileSync(path.join(root, "backlog/config.yml"), "utf8"), line);
+      assert.equal(resolveConfiguredTracker(readConfig(path.join(root, "backlog")), {
+        backlogDir: path.join(root, "backlog"),
+      }).tracker, expected);
+    }
+  });
+
   it("creates a fresh explicit local setup without any provider call", async (t) => {
     const root = makeRoot(t);
     const result = await runSetup(

--- a/skills/dev-backlog/scripts/setup-dev-backlog.test.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.test.js
@@ -309,7 +309,36 @@ describe("tracker config state machine", () => {
       "note: !<unterminated\ntracker: local\n",
       'note: "bad\\q"\ntracker: local\n',
       "%YAML 1.2\n---\ntracker: local\n",
+      "%TAG ! tag:example.com,2026:\ntracker: local\n",
+      "%FOO bar\ntracker: local\n",
+      "note: &\ntracker: local\n",
+      "note: !\ntracker: local\n",
+      "note: *\ntracker: local\n",
+      "note: !<>\ntracker: local\n",
+      'note: "bad\\uD800"\ntracker: local\n',
+      'note: "bad\\U00110000"\ntracker: local\n',
     ]) assert.throws(() => inspectConfig(raw, "/repo/backlog/config.yml"), ConfigValidationError);
+  });
+
+  it("rejects non-printable raw YAML while preserving valid Unicode and escapes", () => {
+    for (const character of ["\0", "\x01", "\x7f", "\u0080", "\ufffe", "\uffff", "\ud800", "\udc00"]) {
+      assert.throws(
+        () => inspectConfig(`note: ${character}\ntracker: local\n`, "/repo/backlog/config.yml"),
+        /YAML-printable|surrogate/
+      );
+    }
+    const valid = [
+      "note: &한글 값",
+      "copy: *한글",
+      "tagged: !<tag:example.com,2026:value> 값",
+      "local: !foo 값",
+      "standard: !!str 값",
+      'escaped: "\\N \\u263A \\U0001F600"',
+      "raw: 😀",
+      "tracker: local",
+      "",
+    ].join("\n");
+    assert.equal(inspectConfig(valid, "/repo/backlog/config.yml").tracker, "local");
   });
 
   it("rejects incomplete quoted, flow, and explicit-key lexical state at EOF", () => {

--- a/skills/dev-backlog/scripts/setup-dev-backlog.test.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.test.js
@@ -531,6 +531,41 @@ describe("setup filesystem behavior", () => {
     }
   });
 
+  it("keeps tracker authority across block and multiline scalar content", async (t) => {
+    const root = makeRoot(t, "setup-runtime-physical-scalars-");
+    const raw = [
+      "tracker: local",
+      "literal: |",
+      "  tracker: github",
+      "folded: >-",
+      "  tracker: github",
+      "single: 'first line",
+      "  tracker: github",
+      "  it''s still quoted",
+      "  last line'",
+      'double: "first \\"still quoted',
+      "  tracker: github",
+      '  last line"',
+      'task_prefix: "REAL"',
+      "",
+    ].join("\n");
+    writeConfig(root, raw);
+    for (const name of ["tasks", "sprints", "completed"]) {
+      fs.mkdirSync(path.join(root, "backlog", name));
+    }
+    const before = snapshotTree(path.join(root, "backlog"));
+    await runSetup(
+      { cwd: root, nonInteractive: true },
+      { execFileSync: noProviderCalls() }
+    );
+    assert.deepEqual(snapshotTree(path.join(root, "backlog")), before);
+    const config = readConfig(path.join(root, "backlog"));
+    assert.equal(config.task_prefix, "REAL");
+    assert.equal(resolveConfiguredTracker(config, {
+      backlogDir: path.join(root, "backlog"),
+    }).tracker, "local");
+  });
+
   it("creates a fresh explicit local setup without any provider call", async (t) => {
     const root = makeRoot(t);
     const result = await runSetup(

--- a/skills/dev-backlog/scripts/setup-dev-backlog.test.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.test.js
@@ -11,7 +11,9 @@ const {
   ConfigValidationError,
   collectGithubEvidence,
   inspectConfig,
+  isGithubRemote,
   mutateTrackerText,
+  parseArgs,
   runSetup,
 } = require("./setup-dev-backlog.js");
 
@@ -141,9 +143,53 @@ describe("tracker config state machine", () => {
       );
     }
   });
+
+  it("ignores tracker-like unknown keys and block scalar text", () => {
+    const raw = [
+      "project_name: preserved",
+      "tracker-options: manual",
+      "note: |",
+      "  tracker: local",
+      "  literal text",
+      "tracker: github",
+      "",
+    ].join("\n");
+    const state = inspectConfig(raw, "/repo/backlog/config.yml");
+    assert.equal(state.kind, "selected");
+    assert.equal(state.tracker, "github");
+    assert.equal(mutateTrackerText(raw, state, "local"), raw.replace("tracker: github", "tracker: local"));
+  });
+
+  it("recognizes a BOM-prefixed top-level tracker without disturbing the BOM", () => {
+    const raw = "\uFEFFtracker: github\r\nother: yes";
+    const state = inspectConfig(raw, "/repo/backlog/config.yml");
+    assert.equal(state.tracker, "github");
+    assert.equal(mutateTrackerText(raw, state, "local"), "\uFEFFtracker: local\r\nother: yes");
+  });
+});
+
+describe("CLI argument boundary", () => {
+  it("rejects every duplicate tracker flag spelling, even when values agree", () => {
+    for (const argv of [
+      ["--tracker", "local", "--tracker", "github"],
+      ["--tracker=local", "--tracker=local"],
+      ["--tracker", "github", "--tracker=local"],
+      ["--tracker=github", "--tracker", "github"],
+    ]) {
+      assert.throws(() => parseArgs(argv), /only once/);
+    }
+  });
 });
 
 describe("provider evidence", () => {
+  it("accepts only exact github.com remote hosts", () => {
+    assert.equal(isGithubRemote("https://github.com/owner/repo.git"), true);
+    assert.equal(isGithubRemote("git@github.com:owner/repo.git"), true);
+    assert.equal(isGithubRemote("https://user:secret@github.com/owner/repo.git"), true);
+    assert.equal(isGithubRemote("https://github.com.evil.test/owner/repo.git"), false);
+    assert.equal(isGithubRemote("git@github.com.evil.test:owner/repo.git"), false);
+  });
+
   it("recommends github only for the usable-origin/authenticated matrix cell", () => {
     const matrix = [
       {
@@ -230,18 +276,16 @@ describe("setup filesystem behavior", () => {
     assert.equal(resolved.tracker, "local");
   });
 
-  it("creates a fresh explicit github setup and reports repair without fallback", async (t) => {
+  it("creates a fresh explicit github setup without probing and emits static repair guidance", async (t) => {
     const root = makeRoot(t);
-    const mock = evidenceExec({ remote: "https://github.com/o/r", gh: "unauthenticated" });
     const result = await runSetup(
       { cwd: root, tracker: "github", nonInteractive: true, projectName: "demo" },
-      { execFileSync: mock.execFileSync }
+      { execFileSync: noProviderCalls(), checkGithubAvailability: noProviderCalls() }
     );
 
     assert.equal(result.selection, "github");
-    assert.equal(result.github.available, false);
+    assert.equal(result.github.checked, false);
     assert.match(result.github.repair, /gh auth login --hostname github\.com/);
-    assert.doesNotMatch(JSON.stringify(result), /SECRET-TOKEN/);
     assert.match(fs.readFileSync(path.join(root, "backlog/config.yml"), "utf8"), /^tracker: github$/m);
   });
 
@@ -265,7 +309,7 @@ describe("setup filesystem behavior", () => {
     writeConfig(root, "project_name: legacy\n# exact comment\ntask_prefix: BACK\n");
     const result = await runSetup(
       { cwd: root, nonInteractive: true },
-      { execFileSync: noProviderCalls(), checkGithubAvailability: () => ({ available: true }) }
+      { execFileSync: noProviderCalls(), checkGithubAvailability: noProviderCalls() }
     );
     assert.equal(result.selection, "github");
     assert.equal(result.selectionSource, "legacy-pin");
@@ -273,6 +317,28 @@ describe("setup filesystem behavior", () => {
       fs.readFileSync(path.join(root, "backlog/config.yml"), "utf8"),
       "project_name: legacy\n# exact comment\ntask_prefix: BACK\ntracker: github\n"
     );
+  });
+
+  it("fails closed before reinterpreting legacy GitHub mirrors as local", async (t) => {
+    const root = makeRoot(t);
+    writeConfig(root, "project_name: legacy\n# exact comment\ntask_prefix: BACK\n");
+    fs.mkdirSync(path.join(root, "backlog/tasks"));
+    fs.writeFileSync(path.join(root, "backlog/tasks/BACK-42.md"), "---\nid: 42\n---\nlegacy mirror\n");
+    const before = snapshotTree(root);
+
+    await assert.rejects(
+      runSetup(
+        { cwd: root, tracker: "local", nonInteractive: true },
+        { execFileSync: noProviderCalls(), checkGithubAvailability: noProviderCalls() }
+      ),
+      (error) => {
+        assert.match(error.message, /legacy GitHub authority/);
+        assert.match(error.message, /--non-interactive/);
+        assert.match(error.message, /--tracker.*local/);
+        return true;
+      }
+    );
+    assert.deepEqual(snapshotTree(root), before);
   });
 
   it("keeps an existing choice immutable across remote/auth changes unless explicit", async (t) => {
@@ -292,7 +358,7 @@ describe("setup filesystem behavior", () => {
 
     await runSetup(
       { cwd: root, tracker: "github", nonInteractive: true },
-      { checkGithubAvailability: () => ({ available: true }) }
+      { execFileSync: noProviderCalls(), checkGithubAvailability: noProviderCalls() }
     );
     assert.equal(
       fs.readFileSync(configPath, "utf8"),
@@ -300,7 +366,7 @@ describe("setup filesystem behavior", () => {
     );
   });
 
-  it("preserves an existing github selection when evidence degrades and only reports repair", async (t) => {
+  it("preserves an existing github selection with zero provider probes and static repair guidance", async (t) => {
     const root = makeRoot(t);
     writeConfig(root, "project_name: stable\ntracker: github\n# tail\n");
     for (const name of ["tasks", "sprints", "completed"]) {
@@ -308,20 +374,16 @@ describe("setup filesystem behavior", () => {
     }
     const configPath = path.join(root, "backlog/config.yml");
     const before = fs.statSync(configPath);
-    const mock = evidenceExec({
-      remote: "https://example.com/owner/repo.git",
-      gh: "missing",
-    });
     const result = await runSetup(
       { cwd: root, nonInteractive: true },
-      { execFileSync: mock.execFileSync }
+      { execFileSync: noProviderCalls(), checkGithubAvailability: noProviderCalls() }
     );
     const after = fs.statSync(configPath);
     assert.equal(result.selection, "github");
     assert.equal(result.selectionSource, "preserved");
-    assert.equal(result.github.available, false);
+    assert.equal(result.github.checked, false);
     assert.equal(result.github.fallbackAttempted, false);
-    assert.match(result.github.repair, /GitHub CLI/);
+    assert.match(result.github.repair, /gh auth login/);
     assert.equal(after.ino, before.ino);
     assert.equal(after.mtimeMs, before.mtimeMs);
     assert.equal(fs.readFileSync(configPath, "utf8"), "project_name: stable\ntracker: github\n# tail\n");
@@ -418,6 +480,29 @@ describe("setup filesystem behavior", () => {
       assert.equal(realFs.readFileSync(configPath, "utf8"), original);
       assert.deepEqual(realFs.readdirSync(path.dirname(configPath)), ["config.yml"]);
     }
+  });
+
+  it("preserves config mode across an atomic tracker replacement", async (t) => {
+    const root = makeRoot(t);
+    writeConfig(root, "project_name: mode\ntracker: local\n");
+    const configPath = path.join(root, "backlog/config.yml");
+    fs.chmodSync(configPath, 0o640);
+    await runSetup(
+      { cwd: root, tracker: "github", nonInteractive: true },
+      { execFileSync: noProviderCalls(), checkGithubAvailability: noProviderCalls() }
+    );
+    assert.equal(fs.statSync(configPath).mode & 0o777, 0o640);
+  });
+
+  it("rejects symlinked backlog/config paths before mutation", async (t) => {
+    const root = makeRoot(t);
+    const outside = makeRoot(t, "setup-outside-");
+    fs.symlinkSync(outside, path.join(root, "backlog"));
+    await assert.rejects(
+      runSetup({ cwd: root, tracker: "local", nonInteractive: true }),
+      /unsafe backlog path/
+    );
+    assert.deepEqual(fs.readdirSync(outside), []);
   });
 });
 

--- a/skills/dev-backlog/scripts/setup-dev-backlog.test.js
+++ b/skills/dev-backlog/scripts/setup-dev-backlog.test.js
@@ -1,0 +1,374 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const {
+  ConfigValidationError,
+  collectGithubEvidence,
+  inspectConfig,
+  mutateTrackerText,
+  runSetup,
+} = require("./setup-dev-backlog.js");
+
+const SCRIPT = path.join(__dirname, "setup-dev-backlog.js");
+const INIT = path.join(__dirname, "init.sh");
+
+function makeRoot(t, prefix = "setup-dev-backlog-") {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+
+function writeConfig(root, raw) {
+  const backlog = path.join(root, "backlog");
+  fs.mkdirSync(backlog, { recursive: true });
+  fs.writeFileSync(path.join(backlog, "config.yml"), raw);
+}
+
+function snapshotTree(root) {
+  const output = {};
+  function walk(current, relative = "") {
+    if (!fs.existsSync(current)) return;
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const full = path.join(current, entry.name);
+      const key = path.join(relative, entry.name);
+      const stat = fs.lstatSync(full);
+      output[key] = {
+        type: entry.isDirectory() ? "directory" : "file",
+        ino: stat.ino,
+        mtimeMs: stat.mtimeMs,
+        bytes: entry.isFile() ? fs.readFileSync(full).toString("base64") : null,
+      };
+      if (entry.isDirectory()) walk(full, key);
+    }
+  }
+  walk(root);
+  return output;
+}
+
+function noProviderCalls() {
+  return () => {
+    throw new Error("provider command must not be called");
+  };
+}
+
+function evidenceExec({ remote, gh = "authenticated", secret = "SECRET-TOKEN" } = {}) {
+  const calls = [];
+  const execFileSync = (command, args) => {
+    calls.push([command, ...args]);
+    if (command === "git") {
+      if (remote === undefined) {
+        const error = new Error(`no origin ${secret}`);
+        error.status = 1;
+        throw error;
+      }
+      return remote;
+    }
+    if (gh === "missing") {
+      const error = new Error(`spawn gh ENOENT ${secret}`);
+      error.code = "ENOENT";
+      throw error;
+    }
+    if (gh === "unauthenticated") {
+      const error = new Error(`auth failed ${secret}`);
+      error.status = 1;
+      throw error;
+    }
+    return "github.com logged in";
+  };
+  return { calls, execFileSync, secret };
+}
+
+describe("tracker config state machine", () => {
+  it("accepts one valid top-level tracker and preserves it without explicit intent", () => {
+    const raw = "# owner note\ntracker: local\ntask_prefix: BACK\n";
+    const state = inspectConfig(raw, "/repo/backlog/config.yml");
+    assert.equal(state.kind, "selected");
+    assert.equal(state.tracker, "local");
+    assert.equal(mutateTrackerText(raw, state, "local"), raw);
+  });
+
+  it("pins a legacy config once while preserving CRLF and no-final-newline shape", () => {
+    const crlf = "project_name: old\r\n# retained\r\ntask_prefix: BACK\r\n";
+    const crlfState = inspectConfig(crlf, "/repo/backlog/config.yml");
+    assert.equal(
+      mutateTrackerText(crlf, crlfState, "github"),
+      "project_name: old\r\n# retained\r\ntask_prefix: BACK\r\ntracker: github\r\n"
+    );
+
+    const noFinal = "project_name: old\n# retained";
+    const noFinalState = inspectConfig(noFinal, "/repo/backlog/config.yml");
+    assert.equal(
+      mutateTrackerText(noFinal, noFinalState, "github"),
+      "project_name: old\n# retained\ntracker: github"
+    );
+  });
+
+  it("changes only the selected scalar and preserves spacing, quoting, and comments", () => {
+    const raw = "project_name: x\r\ntracker:  'github'  # keep this\r\nother: yes";
+    const state = inspectConfig(raw, "/repo/backlog/config.yml");
+    assert.equal(
+      mutateTrackerText(raw, state, "local"),
+      "project_name: x\r\ntracker:  'local'  # keep this\r\nother: yes"
+    );
+  });
+
+  it("rejects invalid, missing-value, duplicate, nested, and ambiguous tracker forms", () => {
+    const cases = [
+      "tracker: gitlab\n",
+      "tracker:\n",
+      "tracker: github\ntracker: local\n",
+      "provider:\n  tracker: local\n",
+      "tracker : local\n",
+      "\"tracker\": local\n",
+    ];
+    for (const raw of cases) {
+      assert.throws(
+        () => inspectConfig(raw, "/repo/backlog/config.yml"),
+        (error) => {
+          assert.ok(error instanceof ConfigValidationError);
+          assert.match(error.message, /\/repo\/backlog\/config\.yml/);
+          assert.match(error.message, /github/);
+          assert.match(error.message, /local/);
+          assert.match(error.message, /--tracker/);
+          return true;
+        }
+      );
+    }
+  });
+});
+
+describe("provider evidence", () => {
+  it("recommends github only for the usable-origin/authenticated matrix cell", () => {
+    const matrix = [
+      {
+        input: { remote: "git@github.com:owner/repo.git", gh: "authenticated" },
+        expected: { recommendation: "github", remote: "github", cli: "available", auth: "authenticated" },
+      },
+      {
+        input: { remote: "https://gitlab.com/owner/repo.git", gh: "authenticated" },
+        expected: { recommendation: "local", remote: "non-github", cli: "available", auth: "authenticated" },
+      },
+      {
+        input: { remote: "https://github.com/owner/repo.git", gh: "unauthenticated" },
+        expected: { recommendation: "local", remote: "github", cli: "available", auth: "unauthenticated" },
+      },
+      {
+        input: { remote: "https://user:token@github.com/owner/repo.git", gh: "missing" },
+        expected: { recommendation: "local", remote: "github", cli: "missing", auth: "not-checked" },
+      },
+      {
+        input: { remote: undefined, gh: "authenticated" },
+        expected: { recommendation: "local", remote: "missing", cli: "available", auth: "authenticated" },
+      },
+    ];
+
+    for (const row of matrix) {
+      const mock = evidenceExec(row.input);
+      const evidence = collectGithubEvidence({ cwd: "/repo", execFileSync: mock.execFileSync });
+      assert.deepEqual(evidence, row.expected);
+      assert.doesNotMatch(JSON.stringify(evidence), /token|SECRET/i);
+    }
+  });
+});
+
+describe("setup filesystem behavior", () => {
+  it("creates a fresh explicit local setup without any provider call", async (t) => {
+    const root = makeRoot(t);
+    const result = await runSetup(
+      { cwd: root, tracker: "local", nonInteractive: true, projectName: "demo" },
+      { execFileSync: noProviderCalls() }
+    );
+
+    assert.equal(result.selection, "local");
+    assert.equal(result.selectionSource, "explicit");
+    assert.deepEqual(fs.readdirSync(path.join(root, "backlog")).sort(), [
+      "completed", "config.yml", "sprints", "tasks",
+    ]);
+    const raw = fs.readFileSync(path.join(root, "backlog/config.yml"), "utf8");
+    assert.deepEqual(raw.match(/^tracker:\s*local\s*$/gm), ["tracker: local"]);
+  });
+
+  it("creates a fresh explicit github setup and reports repair without fallback", async (t) => {
+    const root = makeRoot(t);
+    const mock = evidenceExec({ remote: "https://github.com/o/r", gh: "unauthenticated" });
+    const result = await runSetup(
+      { cwd: root, tracker: "github", nonInteractive: true, projectName: "demo" },
+      { execFileSync: mock.execFileSync }
+    );
+
+    assert.equal(result.selection, "github");
+    assert.equal(result.github.available, false);
+    assert.match(result.github.repair, /gh auth login --hostname github\.com/);
+    assert.doesNotMatch(JSON.stringify(result), /SECRET-TOKEN/);
+    assert.match(fs.readFileSync(path.join(root, "backlog/config.yml"), "utf8"), /^tracker: github$/m);
+  });
+
+  it("refuses fresh non-interactive setup before mutation and prints a rerun command", async (t) => {
+    const root = makeRoot(t);
+    await assert.rejects(
+      runSetup(
+        { cwd: root, nonInteractive: true, projectName: "demo" },
+        { execFileSync: noProviderCalls() }
+      ),
+      (error) => {
+        assert.match(error.message, /--tracker local --non-interactive/);
+        return true;
+      }
+    );
+    assert.equal(fs.existsSync(path.join(root, "backlog")), false);
+  });
+
+  it("pins an existing legacy config to github without consulting live evidence", async (t) => {
+    const root = makeRoot(t);
+    writeConfig(root, "project_name: legacy\n# exact comment\ntask_prefix: BACK\n");
+    const result = await runSetup(
+      { cwd: root, nonInteractive: true },
+      { execFileSync: noProviderCalls(), checkGithubAvailability: () => ({ available: true }) }
+    );
+    assert.equal(result.selection, "github");
+    assert.equal(result.selectionSource, "legacy-pin");
+    assert.equal(
+      fs.readFileSync(path.join(root, "backlog/config.yml"), "utf8"),
+      "project_name: legacy\n# exact comment\ntask_prefix: BACK\ntracker: github\n"
+    );
+  });
+
+  it("keeps an existing choice immutable across remote/auth changes unless explicit", async (t) => {
+    const root = makeRoot(t);
+    writeConfig(root, "project_name: stable\ntracker: local\n# tail\n");
+    const configPath = path.join(root, "backlog/config.yml");
+    const before = fs.statSync(configPath);
+    const result = await runSetup(
+      { cwd: root, nonInteractive: true },
+      { execFileSync: noProviderCalls() }
+    );
+    const after = fs.statSync(configPath);
+    assert.equal(result.selection, "local");
+    assert.equal(result.selectionSource, "preserved");
+    assert.equal(after.ino, before.ino);
+    assert.equal(after.mtimeMs, before.mtimeMs);
+
+    await runSetup(
+      { cwd: root, tracker: "github", nonInteractive: true },
+      { checkGithubAvailability: () => ({ available: true }) }
+    );
+    assert.equal(
+      fs.readFileSync(configPath, "utf8"),
+      "project_name: stable\ntracker: github\n# tail\n"
+    );
+  });
+
+  it("repairs partial structure while preserving all user files and reruns as a true no-op", async (t) => {
+    const root = makeRoot(t);
+    writeConfig(root, "project_name: partial\ntracker: local\n");
+    fs.mkdirSync(path.join(root, "backlog/tasks"));
+    fs.mkdirSync(path.join(root, "backlog/sprints"));
+    fs.writeFileSync(path.join(root, "backlog/tasks/BACK-1.md"), "task bytes\r\n");
+    fs.writeFileSync(path.join(root, "backlog/sprints/current.md"), "sprint bytes");
+    const before = snapshotTree(path.join(root, "backlog"));
+
+    await runSetup(
+      { cwd: root, nonInteractive: true },
+      { execFileSync: noProviderCalls() }
+    );
+    const repaired = snapshotTree(path.join(root, "backlog"));
+    for (const key of ["config.yml", "tasks", "tasks/BACK-1.md", "sprints", "sprints/current.md"]) {
+      assert.deepEqual(repaired[key], before[key]);
+    }
+    assert.equal(repaired.completed.type, "directory");
+
+    await runSetup(
+      { cwd: root, nonInteractive: true },
+      { execFileSync: noProviderCalls() }
+    );
+    assert.deepEqual(snapshotTree(path.join(root, "backlog")), repaired);
+  });
+
+  it("fails malformed or duplicate tracker config before directories or temp files", async (t) => {
+    for (const [index, raw] of ["tracker: gitlab\n", "tracker: local\ntracker: github\n"].entries()) {
+      const root = makeRoot(t, `setup-invalid-${index}-`);
+      writeConfig(root, raw);
+      const before = snapshotTree(root);
+      await assert.rejects(
+        runSetup({ cwd: root, nonInteractive: true }),
+        ConfigValidationError
+      );
+      assert.deepEqual(snapshotTree(root), before);
+      assert.deepEqual(fs.readdirSync(path.join(root, "backlog")), ["config.yml"]);
+    }
+  });
+
+  it("cleans temp files and preserves the original on injected write/rename failures", async (t) => {
+    for (const failure of ["write", "rename"]) {
+      const root = makeRoot(t, `setup-atomic-${failure}-`);
+      const original = "project_name: atomic\ntracker: local\n# untouched\n";
+      writeConfig(root, original);
+      const configPath = path.join(root, "backlog/config.yml");
+      const realFs = fs;
+      const fsApi = {
+        ...realFs,
+        writeFileSync(file, content, options) {
+          if (failure === "write" && path.basename(file).includes(".tmp")) {
+            realFs.writeFileSync(file, "partial", options);
+            throw new Error("injected write failure");
+          }
+          return realFs.writeFileSync(file, content, options);
+        },
+        renameSync(from, to) {
+          if (failure === "rename") throw new Error("injected rename failure");
+          return realFs.renameSync(from, to);
+        },
+      };
+
+      await assert.rejects(
+        runSetup(
+          { cwd: root, tracker: "github", nonInteractive: true },
+          { fs: fsApi, checkGithubAvailability: () => ({ available: true }) }
+        ),
+        /injected/
+      );
+      assert.equal(realFs.readFileSync(configPath, "utf8"), original);
+      assert.deepEqual(realFs.readdirSync(path.dirname(configPath)), ["config.yml"]);
+    }
+  });
+});
+
+describe("CLI and compatibility wrapper", () => {
+  it("spawns the Node CLI for fresh explicit setup and structured output", (t) => {
+    const root = makeRoot(t);
+    const run = spawnSync(
+      process.execPath,
+      [SCRIPT, "--tracker", "local", "--non-interactive", "--json", "--project-name", "cli-demo"],
+      { cwd: root, encoding: "utf8" }
+    );
+    assert.equal(run.status, 0, run.stderr);
+    const result = JSON.parse(run.stdout);
+    assert.equal(result.selection, "local");
+    assert.equal(result.projectName, "cli-demo");
+    assert.match(fs.readFileSync(path.join(root, "backlog/config.yml"), "utf8"), /^tracker: local$/m);
+  });
+
+  it("CLI refusal is actionable and leaves no filesystem mutation", (t) => {
+    const root = makeRoot(t);
+    const run = spawnSync(process.execPath, [SCRIPT, "--non-interactive"], {
+      cwd: root,
+      encoding: "utf8",
+    });
+    assert.notEqual(run.status, 0);
+    assert.match(run.stderr, /--tracker local --non-interactive/);
+    assert.equal(fs.existsSync(path.join(root, "backlog")), false);
+  });
+
+  it("init.sh preserves the legacy project-name interface and fresh github meaning", (t) => {
+    const root = makeRoot(t);
+    const run = spawnSync("bash", [INIT, "wrapper-demo"], { cwd: root, encoding: "utf8" });
+    assert.equal(run.status, 0, run.stderr);
+    const raw = fs.readFileSync(path.join(root, "backlog/config.yml"), "utf8");
+    assert.match(raw, /^project_name: "wrapper-demo"$/m);
+    assert.deepEqual(raw.match(/^tracker:\s*github\s*$/gm), ["tracker: github"]);
+  });
+});


### PR DESCRIPTION
## Summary

- add an idempotent `setup-dev-backlog.js` entrypoint with explicit `github` and `local` tracker selection
- preserve existing and legacy authority without environment-driven switching
- keep configuration and user task/sprint content byte-stable through atomic, fail-closed setup
- align the shared runtime config reader with accepted commented, block, and multiline scalar forms

## Validation

- `node --test skills/dev-backlog/scripts/setup-dev-backlog.integration.test.js` (17/17)
- `node --test skills/*/scripts/*.test.js` (639 pass, 1 existing opt-in skip)
- `bash skills/dev-backlog/scripts/smoke-test.sh` (155/155)
- component lint, capabilities doctor strict, backlog doctor, and `git diff --check`
- independent relay review: LGTM at `26482d6`

Closes #277
