### PR TITLE
feat: prove github and local tracker cycles end to end (#278)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ PR relationships, sprint/progress mirrors, comments, or closing-keyword links.
 Those requests fail before side effects with actionable remediation; JSON-capable
 commands return the same structured error contract.
 
+For task `list`, `read`, `create`, `update`, and `close`, the stable invocation
+boundary is the configured adapter exported by `scripts/tracker.js`. Operators
+and agents resolve it with the target `backlogDir` and call those methods in
+either mode; the exact procedure and signatures are documented in
+[the process guide](skills/dev-backlog/references/process.md#required-core-lifecycle-invocation-boundary).
+
 ### Upgrade behavior
 
 There is zero automatic migration. A repository whose existing

--- a/README.md
+++ b/README.md
@@ -3,23 +3,25 @@
 [![CI](https://github.com/sungjunlee/dev-backlog/actions/workflows/test.yml/badge.svg)](https://github.com/sungjunlee/dev-backlog/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
-GitHub Issues stay the source of truth. Sprint files become the execution hub that both you and your AI agent read during a coding session.
+Choose one canonical task tracker per repository: GitHub Issues or an offline
+local Markdown store. Sprint files remain the execution hub that both you and
+your AI agent read during a coding session.
 
 dev-backlog adds a local sprint file that carries the plan, decisions, and progress across tasks and sessions. Claude Code, Codex, and humans all read the same file.
 
-No new server. No hidden state. No need to abandon GitHub Issues.
+No new server. No hidden state. Existing GitHub repositories keep their current
+behavior without migration.
 
 README.md is the product overview and human quick start. The agent execution contract, sprint-file rules, and full script reference live in [skills/dev-backlog/SKILL.md](skills/dev-backlog/SKILL.md).
 
 ```text
-GitHub Issues (source of truth)
+backlog/config.yml: tracker: github | local
         |
-        | gh CLI (explicit sync)
-        v
-backlog/
-  tasks/       thin issue mirror (AI reads without API)
-  sprints/     execution hub: plan, context, progress
-  completed/   archived done tasks
+        +-- github -> GitHub Issues (canonical) -> tasks/ mirrors
+        |
+        `-- local  -> tasks/ + completed/ (canonical, no gh)
+
+backlog/sprints/     execution hub: plan, context, progress
         ^
         |
   Claude Code / Codex / Human
@@ -31,9 +33,9 @@ backlog/
 
 | Capability | What changes |
 |------------|--------------|
-| GitHub stays the source of truth | Collaborators keep using issues, milestones, labels, and PR links |
+| One canonical tracker | Explicit `github` or fully offline `local`; runtime never switches it |
 | One active sprint file | The human and the agent read the same execution plan |
-| Thin local task mirror | AI can read issue details without another API round trip |
+| Mode-aware task files | GitHub mirrors in `github`; canonical tasks in `local` |
 | Explicit sync | Pull and refresh when you choose, not behind your back |
 | `[ ]` / `[~]` / `[x]` plan states | Delegated work stays visible in the sprint file, not buried in PR tabs |
 | `context-hook.sh` | Claude Code can get a one-line sprint summary before edits |
@@ -51,7 +53,7 @@ npx skills add sungjunlee/dev-backlog -g -y
 ### Prerequisites
 
 - [Claude Code](https://claude.ai/code) or [Codex](https://chatgpt.com/codex)
-- [`gh` CLI](https://cli.github.com/) authenticated with `gh auth login`
+- [`gh` CLI](https://cli.github.com/) authenticated with `gh auth login` (GitHub mode only)
 - Git
 - Node.js 18+
 
@@ -67,8 +69,9 @@ Run these commands from the project you want to manage, not from the `dev-backlo
 The examples below assume you have this repo available at `/path/to/dev-backlog`. If you installed the skill with `npx skills add`, use the installed skill path instead.
 
 ```bash
-# 1. Bootstrap backlog/
-bash /path/to/dev-backlog/skills/dev-backlog/scripts/init.sh
+# 1. Choose the canonical tracker and bootstrap backlog/
+node /path/to/dev-backlog/skills/dev-backlog/scripts/setup-dev-backlog.js \
+  --tracker github --non-interactive
 
 # 2. Pull open GitHub issues into backlog/tasks/
 node /path/to/dev-backlog/skills/dev-backlog/scripts/sync-pull.js --dry-run
@@ -87,6 +90,25 @@ bash /path/to/dev-backlog/skills/dev-backlog/scripts/status.sh
 # 5. Close the sprint when the work is done
 bash /path/to/dev-backlog/skills/dev-backlog/scripts/sprint-close.sh backlog
 ```
+
+For a fully offline repository, choose `--tracker local` instead. Create and
+update canonical tasks through the configured tracker lifecycle, use normalized
+refs such as `BACK-1` in the Plan, and run the same `status`, `next`, and
+`sprint-close` commands. Local mode deliberately does not invent milestones,
+PR relationships, sprint/progress mirrors, comments, or closing-keyword links.
+Those requests fail before side effects with actionable remediation; JSON-capable
+commands return the same structured error contract.
+
+### Upgrade behavior
+
+There is zero automatic migration. A repository whose existing
+`backlog/config.yml` has no `tracker:` key continues in GitHub mode with its
+existing `#N`, numeric `issue_number`, task-mirror, milestone, mirror, progress,
+comment, and closing behavior. Run `setup-dev-backlog.js` to pin that legacy
+GitHub authority before making any later explicit switch. Setup never migrates
+task files and runtime never chooses a tracker from availability or failure.
+The implementation-level contract and proof map live in
+[docs/tracker-adapter-design.md](docs/tracker-adapter-design.md).
 
 Then use the skill during your coding session:
 
@@ -157,14 +179,14 @@ Users can log in and access protected API endpoints.
 
 ## Daily Workflow
 
-1. Pull GitHub issues into `backlog/tasks/`.
-2. Generate or update the active sprint file.
+1. Read the configured tracker; in GitHub mode, explicitly pull issues into `backlog/tasks/`.
+2. Create or read canonical tasks and generate the active sprint file.
 3. Read the sprint before you code.
 4. Work batch by batch, not issue by issue across ten tabs.
 5. Update `Running Context` and `Progress` as you learn things.
 6. Close the sprint explicitly when the work is really done.
 
-This is simple on purpose. The issue tracker handles collaboration. The sprint file handles execution.
+The configured tracker handles task truth. The sprint file handles execution.
 
 ## Optional extensions
 
@@ -296,9 +318,9 @@ This keeps Codex focused on one execution file, not ten browser tabs and stale i
 
 | Decision | Why |
 |----------|-----|
-| GitHub Issues are the source of truth | Collaborators already live there |
+| Exactly one tracker owns task truth | GitHub collaboration and offline local work share one core lifecycle without becoming co-authoritative |
 | Sprint files are the execution hub | One file carries plan, context, and progress across sessions |
-| Task files stay thin | Sync cache only; decisions belong in the sprint file |
+| Task-file authority is mode-specific | Thin mirrors in GitHub mode; canonical active/completed files in local mode |
 | `_context.md` holds cross-sprint knowledge | Sprint files stay local to the sprint, project memory stays shared |
 | Sync is always explicit | No background process mutates your local state behind your back |
 | Task-file format is Backlog.md-compatible | `tasks/` follows the [Backlog.md](https://github.com/MrLesk/Backlog.md) task format; `sprints/` and `gh` sync are dev-backlog additions |

--- a/docs/tracker-adapter-design.md
+++ b/docs/tracker-adapter-design.md
@@ -1,10 +1,10 @@
 # Tracker Adapter Design Contract
 
-Status: accepted target design for issue #272. Runtime evidence was inventoried
-at commit `019a6ec`. Issues #273-#275 now implement configured selection,
-tracker-neutral references, and the GitHub adapter wiring described below.
-Local persistence (#276) remains future work. GitHub remains the compatibility
-baseline.
+Status: implemented foundation with dual-mode acceptance proof on issue #278's
+implementation branch. Runtime evidence was originally inventoried at commit
+`019a6ec`; merged issues #273-#277 provide selection, identity, GitHub wiring,
+local persistence, and setup. GitHub remains the compatibility baseline. O8/O9
+stay active until the proof branch is merged and recorded.
 
 This document froze the smallest tracker boundary that can support another
 canonical task store without weakening existing GitHub behavior. The #272
@@ -13,7 +13,7 @@ foundation state is recorded separately below. These changes do not persist
 local tasks, alter setup, or rewrite command, Markdown, JSON, sprint, or
 task-mirror compatibility surfaces.
 
-## Runtime Adapter State (#273-#275)
+## Runtime Adapter State (#273-#278)
 
 `backlog/config.yml` selects one `tracker`, initially `github` or `local`.
 Repositories without that key use `github` as a deterministic compatibility
@@ -35,15 +35,40 @@ task store, allocates collision-safe parent IDs under an exclusive lock with
 atomic same-filesystem publication, preserves human body/AC bytes on
 metadata-only updates, archives on close without overwrite, reports no optional
 capabilities, and never invokes `gh` or falls back. In local mode these task
-files are canonical; GitHub mode continues to treat them as mirrors. Wiring the
-existing GitHub-oriented orchestration flows (sync, mirror, progress, triage,
-setup) onto local and the dual-mode documentation sweep remain #277/#278 work.
+files are canonical; GitHub mode continues to treat them as mirrors.
+`setup-dev-backlog.js` (#277) persists a deliberate choice without reserializing
+user YAML or migrating tasks. Issue #278 adds the offline dual-mode executable
+proof and aligns the public documentation with this runtime.
 
-## Current Runtime Evidence
+### Shared unsupported-capability boundary
 
-Everything in this section describes the runtime at `019a6ec`, before the
-tracker seam exists. The current runtime has no configured tracker resolver:
-GitHub Issues are task truth, production callers either execute `gh` directly
+`tracker.js` owns `UnsupportedTrackerCapabilityError` and its serializer. The
+stable code is `TRACKER_CAPABILITY_UNSUPPORTED`; serialized errors contain
+exactly `code`, `tracker`, `capability`, `message`, and `remediation`. A public
+JSON command wraps that shape once as `{ "error": ... }`, writes it to stdout,
+and exits non-zero. Human commands write the same message and remediation to
+stderr. Capability gates run before provider/filesystem effects and never
+change `backlog/config.yml` or resolve another tracker.
+
+### Dual-mode executable proof (#278)
+
+`skills/dev-backlog/scripts/tracker-cycle.acceptance.test.js` is the release
+proof. Its table-driven `github` and `local` rows cross real temporary-file and
+CLI/subprocess boundaries without network access. The GitHub row starts with a
+tracker-less legacy config, records fake-`gh` argv, and freezes `#N`, numeric
+`issue_number`, task mirror bytes/body preservation, milestone, sprint mirror,
+progress/PR/comment, close, and final read/list behavior without rewriting the
+config. The local row performs explicit setup, canonical create, normalized
+Plan orientation, read/update/body preservation, Done archive, sprint close,
+and final read/list with an execution-trap `gh` that records zero calls. A
+capability table covers all six optional features plus representative JSON and
+human public boundaries.
+
+## Pre-Seam Baseline Inventory
+
+Everything in this historical inventory describes the runtime at `019a6ec`, before the
+tracker seam existed. That baseline had no configured tracker resolver:
+GitHub Issues were task truth, production callers either executed `gh` directly
 or call GitHub-specific helpers, sprint Plan items use numeric `#N` references,
 and task mirrors encode the same number in `BACK-N`-style names and IDs.
 
@@ -252,25 +277,30 @@ removing or silently changing an existing field is not.
 
 ## Verification Map
 
-This map is the handoff contract for the three later foundation issues. It
-does not authorize local persistence (#276) or setup automation (#277).
+This map records the implemented foundation leaves and their proof ownership.
 
 | Later issue | Frozen sections it must satisfy | Required verification evidence |
 | --- | --- | --- |
 | #273 — configured selection and core seam | “Accepted Target Design”, “Required Tracker Interface”, exact “Failure and authority semantics”, and the exported-helper row of the Compatibility Matrix. | Unit tests for `github`/`local`/invalid/absent selection, unavailable configured adapter, capability report, unsupported capability error, no transient fallback, and compatibility exports. Assert the required operation set contains only availability, capabilities, list/read/create/update/close and identity exactly includes `{ tracker, id, ref, url? }`. Do not implement local storage or setup. |
 | #274 — tracker-neutral task references | “Numeric reference, renderer, and storage inventory”, normalized identity in “Required Tracker Interface”, and the task-file/Plan/status/next/sprint-state/close/mirror/progress rows of the Compatibility Matrix. | Parser/renderer golden tests for legacy `#N`, additive local `{PREFIX}-N`, exact-match collisions, invalid/mixed fixtures, byte-compatible GitHub Plan/mirror output, additive JSON identity, and retained GitHub `issue_number`. No historical rewrite and no local persistence. |
 | #275 — GitHub behavior behind the seam | “Direct `gh` invocation inventory”, “GitHub-specific helpers and injection seams”, “Optional Capabilities”, failure rules, and every GitHub behavior row of the Compatibility Matrix. | A source scan proving core callers no longer own direct GitHub task lifecycle calls; mocked golden argv/results for every inventoried call family; existing marker/content safety tests; triage/progress/mirror regression tests; full Node and smoke suites. Explicitly GitHub-scoped optional modules may still execute `gh`; capability absence must fail clearly. |
+| #276 — local canonical persistence | Required lifecycle, identity, and authority/failure semantics. | Offline lifecycle, exact identity, collision-safe allocation, body preservation, fail-closed storage, recovery, and archive tests with no GitHub calls. |
+| #277 — explicit setup | Persisted selection and zero-migration authority rules. | Fresh/legacy setup process tests, byte-idempotent config mutation, provider isolation, atomic publication, and explicit-switch refusal/repair evidence. |
+| #278 — dual-mode release proof | Compatibility Matrix, shared unsupported-capability boundary, and documentation/runtime alignment. | `tracker-cycle.acceptance.test.js` table rows, fake/trapped `gh`, exact GitHub argv/bytes/aliases, offline local lifecycle, all-capability typed errors, representative public JSON/human errors, plus repository-wide gates. |
 
-For all three issues, the repository-wide regression gate remains:
+The repository-wide regression gate is:
 
 ```bash
 git diff --check
 node --test skills/*/scripts/*.test.js
+node --test skills/dev-backlog/scripts/tracker-cycle.acceptance.test.js
+bash skills/dev-backlog/scripts/smoke-test.sh
+node skills/dev-backlog/scripts/objectives-check.js --json
 node skills/dev-backlog/scripts/component-lint.js --json
 node skills/dev-backlog/scripts/capabilities-doctor.js --json
+node skills/dev-backlog/scripts/backlog-doctor.js --json
+npx --yes skills add . -l
 ```
 
-Issue #275 additionally owns the existing smoke and mocked CLI coverage named
-in its acceptance criteria. None of #273-#275 may claim proof by adding local
-task persistence, tracker-aware setup, or a second canonical store; those are
-separate later leaves with their own acceptance criteria.
+The phase boundaries remain historical ownership boundaries; no leaf makes two
+task stores co-authoritative or retroactively rewrites GitHub repositories.

--- a/skills/dev-backlog/SKILL.md
+++ b/skills/dev-backlog/SKILL.md
@@ -1,15 +1,17 @@
 ---
 name: dev-backlog
 argument-hint: "[orient|create|plan|work|next|sync|complete] [issue-number]"
-description: Manage GitHub-Issue-backed sprint execution. Use for issue mirrors, sprint planning or closing, next-work selection, progress sync, milestone-backed backlog work, 다음 작업, 이슈 만들어, 스프린트 계획, 백로그.
-compatibility: Requires gh CLI and git. Works on Claude Code and Codex.
+description: Manage configured-tracker-backed sprint execution. Use for GitHub mirrors or offline local tasks, sprint planning or closing, next-work selection, progress sync, 다음 작업, 이슈 만들어, 스프린트 계획, 백로그.
+compatibility: Requires git and Node.js 18+; GitHub mode also requires gh CLI. Works on Claude Code and Codex.
 metadata:
   related-skills: "spec-charter, spec-grill, backlog-triage, relay, relay-plan, relay-dispatch, relay-review, relay-merge"
 ---
 
 # Dev Backlog
 
-Real job: keep GitHub Issues as the task source of truth while using `backlog/sprints/` as the local execution hub for planning, context, progress, and handoff.
+Real job: keep exactly one configured tracker as canonical task truth while
+using `backlog/sprints/` as the local execution hub for planning, context,
+progress, and handoff.
 
 README covers install and human quick start. This file is the agent execution contract: mode routing, file roles, must-do steps, and completion criteria.
 
@@ -18,31 +20,34 @@ README covers install and human quick start. This file is the agent execution co
 | User intent | Mode | Completion boundary |
 | --- | --- | --- |
 | "where are we?", "orient", "status" | `orient` | Active sprint, latest progress, and next unchecked batch are identified. |
-| "create issue", "new issue", "이슈 만들어" | `create` | GitHub issue is created, mirrored locally, and added to the current sprint Plan when in scope. |
+| "create issue", "new issue", "이슈 만들어" | `create` | A task is created in the configured canonical tracker and added to the current sprint Plan when in scope. |
 | "plan sprint", "make sprint", "start work" with no active sprint | `plan` | One active sprint file exists with Goal, ordered Plan, `objectives:`, and `component:`. |
-| "work #N", "continue", "do next batch" | `work` | Issue AC is verified, task/sprint state is updated, and GitHub receives a meaningful status signal. |
+| "work #N", "work BACK-N", "continue", "do next batch" | `work` | Task AC is verified and configured-tracker plus sprint state are updated. |
 | "next", "다음 작업" | `next` | The next actionable batch or sprint-planning need is named. |
-| "sync", "pull issues", "refresh backlog" | `sync` | GitHub/local mirrors are explicitly refreshed; no silent background sync. |
+| "sync", "pull issues", "refresh backlog" | `sync` | GitHub mirrors are explicitly refreshed; local canonical files need no provider sync. |
 | "complete", "close sprint" | `complete` | Sprint/task state is finalized and rediscovery-prone context is promoted. |
 
-If `backlog/` does not exist, bootstrap it with `mkdir -p backlog/{sprints,tasks,completed}` and create `backlog/config.yml`; see `references/file-format.md`.
+If `backlog/` does not exist, run `scripts/setup-dev-backlog.js --tracker
+github|local --non-interactive`; see `references/file-format.md`. Never infer a
+tracker from availability.
 
-Related skills (none required for the core cycle above — dev-backlog runs a full sprint from GitHub Issues alone): when installed, `spec-charter` (`spec/charter.md`), `spec-system-map` (`spec/system-map.md`), and `spec-grill` (`spec/capabilities.md`) ship with craftkit (`npx skills add sungjunlee/craftkit`) and supply the optional spec axis; [`backlog-triage`](../backlog-triage/SKILL.md) provides advisory backlog review before sprint planning. Degradation when they are absent is specified in `references/spec-fallback.md`.
+Related skills (none required for either core cycle): when installed, `spec-charter` (`spec/charter.md`), `spec-system-map` (`spec/system-map.md`), and `spec-grill` (`spec/capabilities.md`) ship with craftkit (`npx skills add sungjunlee/craftkit`) and supply the optional spec axis; [`backlog-triage`](../backlog-triage/SKILL.md) provides advisory backlog review before sprint planning. Degradation when they are absent is specified in `references/spec-fallback.md`.
 
 ## Core Contracts
 
 ```
-GitHub (source of truth — what to do)
-  Issues, Milestones, Labels, Comments, PR links
-       ↕  gh CLI (sync is always explicit)
-Local (execution hub — how to do it)
-  backlog/sprints/   <- working files: plan, context, notes, progress
-  backlog/tasks/     <- thin GitHub issue mirrors and AC checkboxes
+backlog/config.yml (one tracker: github | local)
+  github -> GitHub Issues canonical; backlog/tasks/ are explicit mirrors
+  local  -> backlog/tasks/ + completed/ are canonical; zero provider calls
+
+backlog/sprints/ <- shared execution hub in both modes
 ```
 
 - Exactly one sprint file may have `status: active`; scripts warn/refuse ambiguous active sprint state.
 - Start every session by reading `backlog/sprints/_context.md` and the active sprint file when present.
-- Keep task files thin. AC checkboxes may update there; decisions, progress, and cross-task context stay in the sprint file.
+- Task files are thin mirrors in GitHub mode and canonical records in local mode. In both modes, decisions, progress, and cross-task context stay in the sprint file.
+- A missing `tracker:` key is the zero-migration GitHub compatibility default. Runtime failure never changes the selected tracker.
+- Optional provider capabilities are not part of the core lifecycle. Unsupported requests fail before effects through the shared typed error contract in `tracker.js`; public JSON surfaces emit one structured error and human surfaces include the same remediation.
 - Completed sprints stay as the permanent execution record.
 - Backlog-side file boundaries live in `references/backlog-boundaries.md`. Spec-axis boundaries and how `objectives:`/`component:` degrade when spec files are absent live in `references/spec-fallback.md` (in-bundle, always resolvable); their durable authoring home is craftkit's `spec-charter` skill, consulted when installed. Sprint `objectives:` reference charter Objective IDs, and `component:` is one primary capability handle from `spec/capabilities.md`.
 
@@ -56,7 +61,7 @@ One active sprint file in `backlog/sprints/YYYY-MM-<topic>.md` carries:
 | `objectives: [O1]` | Charter Objective IDs advanced by the sprint | IDs exist and are actionable; omit the field entirely when no charter exists (see `references/spec-fallback.md`). |
 | `component: "slug"` | Primary capability and relay-Learnings routing handle | Resolves to one capability whose `## Learnings` block receives relay-merge entries; omit the field entirely when no capabilities file exists. |
 | `## Goal` | Sprint-level success statement | One sentence describing done state. |
-| `## Plan` | Ordered batches with issue refs and estimates | Every planned task has a checkbox and issue number. |
+| `## Plan` | Ordered batches with normalized task refs and estimates | Every planned task has a checkbox and complete `#N` or `{PREFIX}-N[.M]` ref. |
 | `## Running Context` | Decisions/gotchas affecting later tasks | Updated when work reveals reusable context. |
 | `## Progress` | Timestamped execution log | Updated at session/batch boundaries. |
 
@@ -75,7 +80,7 @@ Full sprint and task-file examples live in `references/file-format.md`.
 ### Orient
 
 1. Read `_context.md` if present.
-2. Find the single active sprint; if none exists, inspect open GitHub issues and route to `plan`.
+2. Find the single active sprint; if none exists, list open tasks through the configured adapter and route to `plan`.
 3. Read the active sprint's Goal, Plan, Running Context, and latest Progress.
 4. Identify the next unchecked Plan item or route to `complete` when all items are done.
 
@@ -85,12 +90,14 @@ Done when you can name the current sprint state and the next actionable batch.
 
 Follow `references/process.md` → `## Create — New Issues`.
 
-Done when the new issue exists on GitHub, has a local task mirror, and is added to the active sprint Plan when in scope.
+Done when the new task exists in the configured canonical store and is added to
+the active sprint Plan when in scope. GitHub mode may explicitly refresh its
+local mirror; local mode already wrote the canonical task file.
 
 ### Plan
 
 1. Resolve Objectives from `spec/charter.md`; fall back to legacy root `CHARTER.md`; omit the `objectives:` field entirely when both are absent (see `references/spec-fallback.md`).
-2. Pull/inspect open issues and assign the sprint milestone when applicable.
+2. List/inspect open tasks. Use milestone selection only when the configured adapter reports `milestones`; local planning writes normalized refs directly and does not fabricate one.
 3. Create one active sprint file with Goal, ordered Plan batches, estimates, dependencies, `objectives:`, and `component:`. Plan batches are execution waves: intra-batch items MUST be mutually parallel-safe (disjoint files, no ordering between them), dependent items MUST go in a later batch, and batch order is execution order.
 4. Refuse to create a second active sprint until the previous one is completed.
 
@@ -102,13 +109,15 @@ Done when the sprint file is the single active execution hub and each planned is
 2. Mark meaningful GitHub/local status before work when useful.
 3. Implement or delegate through dev-relay.
 4. Verify every AC item before checking it off.
-5. Update Plan checkbox, Running Context, Progress, and GitHub issue comments/labels as appropriate.
+5. Update Plan checkbox, Running Context, Progress, and neutral task state. Use comments/PR relationships only after their capability gates succeed.
 
-Done when verified work is reflected in task AC, sprint progress, and GitHub state.
+Done when verified work is reflected in task AC, sprint progress, and the configured canonical task state.
 
 ### Complete
 
-Per issue: all AC checked, implementation merged or committed with `Fixes #N`, Plan checked, and Progress updated.
+Per task: all AC checked, implementation merged or committed, Plan checked, and
+Progress updated. `Fixes #N` and provider closing links apply only when GitHub's
+`closing-semantics` capability is intentionally used.
 
 For a whole sprint:
 
@@ -124,15 +133,15 @@ Done when there is no stale active sprint or rediscovery-prone context trapped i
 
 ### Sync
 
-- Pull GitHub -> local at sprint start and when issues change.
-- Push local -> GitHub at meaningful milestones: status labels, progress comments, closing issues.
-- Never mutate GitHub silently; sync is an explicit action.
+- GitHub: pull canonical issues into mirrors at sprint start and when they change; provider writes remain explicit.
+- Local: task files are already canonical; do not call `gh` or manufacture a push/pull step.
+- Never perform background sync or switch trackers after a failure.
 
 Done when the user can tell which direction changed and what was updated.
 
 ### Next
 
-Read the active sprint and return the first unchecked actionable batch. If no active sprint exists or the sprint is done, say whether to plan the next sprint or inspect unplanned GitHub work.
+Read the active sprint and return the first unchecked actionable batch. If no active sprint exists or the sprint is done, say whether to plan the next sprint or inspect unplanned configured-tracker work.
 
 ## Script Resolution
 
@@ -149,9 +158,10 @@ node "$skill_dir/scripts/sprint-init.js" "next-sprint" --dry-run
 Core scripts (full flag inventory in `references/scripts.md`):
 
 - `scripts/init.sh` — bootstrap `backlog/`.
-- `scripts/sync-pull.js` — pull open GitHub issues into `backlog/tasks/`.
-- `scripts/sprint-init.js` — create the single active sprint skeleton; refuses a second.
-- `scripts/next.sh` / `scripts/status.sh` — next actionable batch; sprint + GitHub summary.
+- `scripts/setup-dev-backlog.js` — persist the explicit canonical tracker without migrating task files.
+- `scripts/sync-pull.js` — materialize configured open tasks; in GitHub mode, preserve legacy mirrors.
+- `scripts/sprint-init.js` — create a milestone-backed sprint when supported; local plans are authored from normalized refs.
+- `scripts/next.sh` / `scripts/status.sh` — next actionable batch and tracker-neutral sprint state.
 - `scripts/sprint-close.sh` — close the active sprint; prints the doctor/reassess summary.
 - `scripts/backlog-doctor.js` — aggregate health checks; JSON includes `reassess_signal`.
 

--- a/skills/dev-backlog/references/file-format.md
+++ b/skills/dev-backlog/references/file-format.md
@@ -53,7 +53,7 @@ Extended set (if using more granular tracking):
 ## Filename Convention
 
 ```
-{PREFIX}-{N} - {Title-Slug}.md
+{PREFIX}-{N[.M]} - {Title-Slug}.md
 ```
 
 Examples:
@@ -92,7 +92,11 @@ For manual task files or Backlog.md CLI compatibility, you can optionally add st
 
 The `<!-- AC:BEGIN/END -->` markers enable machine parsing by the Backlog.md CLI. Without them, acceptance criteria still work as plain checkboxes — the file reads fine either way.
 
-Only AC checkboxes get updated in task files during work. Everything else (notes, technical decisions, running context) lives in the sprint file.
+Configured-adapter operations may update supported frontmatter fields, and an
+explicit body update may change task-body content. Metadata-only updates
+preserve body and AC bytes. During normal execution, keep human task-body edits
+to AC checkboxes; notes, technical decisions, and running context belong in the
+sprint file.
 
 ## Sprint Frontmatter (spec-axis fields)
 

--- a/skills/dev-backlog/references/file-format.md
+++ b/skills/dev-backlog/references/file-format.md
@@ -8,7 +8,7 @@ Task files are compatible with the [Backlog.md](https://github.com/MrLesk/Backlo
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `id` | string | Yes | Unique ID matching GitHub issue: `{PREFIX}-{N}` (e.g., `BACK-42`) |
+| `id` | string | Yes | Storage ref `{PREFIX}-{N[.M]}`; a GitHub mirror derives `N` from the issue number, while local owns the ref directly |
 | `title` | string | Yes | Brief, action-oriented description |
 | `status` | string | Yes | Current state (see Status Values below) |
 
@@ -16,7 +16,7 @@ Task files are compatible with the [Backlog.md](https://github.com/MrLesk/Backlo
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `labels` | string[] | Categorization labels (maps to GitHub labels) |
+| `labels` | string[] | Categorization labels (maps to GitHub labels only in GitHub mode) |
 | `priority` | string | `low`, `medium`, `high`, `critical` |
 | `assignee` | string[] | Assigned people (`@username`) |
 
@@ -37,7 +37,7 @@ Task files are compatible with the [Backlog.md](https://github.com/MrLesk/Backlo
 
 Default set (configurable in `config.yml`):
 
-| Status | GitHub Label | Meaning |
+| Status | GitHub mapping | Meaning |
 |--------|-------------|---------|
 | `To Do` | `status:todo` | Not started |
 | `In Progress` | `status:in-progress` | Active work |
@@ -45,7 +45,7 @@ Default set (configurable in `config.yml`):
 
 Extended set (if using more granular tracking):
 
-| Status | GitHub Label | Meaning |
+| Status | GitHub mapping | Meaning |
 |--------|-------------|---------|
 | `Blocked` | `status:blocked` | Waiting on external dependency |
 | `In Review` | `status:in-review` | PR under review |
@@ -61,18 +61,24 @@ Examples:
 - `PROJ-7 - Fix-login-timeout.md`
 - `BACK-100.2 - Create-HTTP-server-module.md` (sub-task)
 
-The prefix and number come from `config.yml` (`task_prefix`) and the GitHub issue number.
+The prefix comes from `config.yml` (`task_prefix`). In GitHub mode, the numeric
+part is the issue number and the file is a mirror. In local mode, the configured
+adapter allocates the canonical local ID.
 
 ## Body Structure
 
-Task files are thin GitHub mirrors. Notes, decisions, and context go in the **sprint file** (`backlog/sprints/`), not here.
+Task files are thin GitHub mirrors when `tracker: github` and canonical task
+records when `tracker: local`. Notes, decisions, and cross-task context still go
+in the **sprint file** (`backlog/sprints/`), not here.
 
 ```markdown
 ## Description
 [Synced from GitHub issue body — includes any checkboxes from the issue]
 ```
 
-`sync-pull.js` wraps the raw GitHub issue body in `## Description`. Acceptance criteria checkboxes from the issue body appear here as-is. dev-relay and other tools read AC from whatever structure the issue body provides.
+`sync-pull.js` wraps a GitHub issue body in `## Description`. Local create stores
+the supplied body directly. Acceptance criteria checkboxes remain human-authored
+bytes in either mode; metadata-only refresh/update preserves them.
 
 For manual task files or Backlog.md CLI compatibility, you can optionally add structured AC markers:
 
@@ -111,40 +117,23 @@ statuses: ["To Do", "In Progress", "Done"]
 
 `tracker` accepts only `github` or `local`. A missing key deterministically
 defaults to `github`; runtime availability never changes that selection or
-falls back to the other adapter.
+falls back to the other adapter. This is a zero-migration upgrade rule: existing
+tracker-less repositories keep GitHub authority and all legacy files unchanged.
+`setup-dev-backlog.js` pins that authority or creates an explicit fresh choice;
+it never migrates task files.
 
 ## Local Canonical Storage (`tracker: local`)
 
-In local mode the `backlog/tasks/` and `backlog/completed/` files are the
-**canonical** task store, not GitHub mirrors. `local-tracker.js` owns every
-filesystem rule behind the seven required operations; callers only ever see the
-normalized identity `{ tracker: "local", id, ref: "{PREFIX}-{N}[.M]" }` — there
-is no fabricated `url`.
+In local mode `backlog/tasks/` and `backlog/completed/` are the **canonical**
+task store. Required list/read/create/update/close operations return normalized
+identity `{ tracker: "local", id, ref: "{PREFIX}-{N[.M]}" }` without fabricating
+a URL. Metadata-only updates preserve body/AC bytes; close writes `status: Done`
+and archives the same file. Local reports no optional provider capabilities, so
+milestones, PR relationships, mirrors, progress issues, comments, and closing
+semantics fail before filesystem or provider effects and never invoke `gh`.
 
-- **Allocation.** `create` allocates the next positive **parent** integer by
-  scanning the exact configured-prefix IDs across both `tasks/` and
-  `completed/` (so a closed `BACK-7` still reserves `7`). `BACK-1` and `BACK-11`
-  are kept distinct by exact-match parsing. An explicit decimal `id` (e.g.
-  `1.2`) creates a subtask only when that exact ID is free; decimals never
-  shift parent allocation and are not auto-created.
-- **Atomic publication.** Allocation runs inside an exclusive lock
-  (`backlog/.local-tracker.lock`); the new file is written to a same-directory
-  temp and hard-linked into place, so a colliding destination fails instead of
-  overwriting. The lock and temp are always released, including on error.
-- **Body preservation.** A metadata/state-only `update` rewrites only the
-  requested frontmatter keys and leaves the human-authored description,
-  headings, and `AC:BEGIN/END` checkbox bytes untouched. Filenames stay stable
-  even when the frontmatter `title` changes. The body is replaced only when the
-  caller supplies one explicitly.
-- **Archive on close.** `close` moves exactly one active task into
-  `backlog/completed/`, writes `status: Done`, and refuses an existing
-  destination rather than overwriting; a task that is already archived returns a
-  clear already-closed result without data loss.
-- **No provider features.** Local reports **no** optional capabilities. Any
-  milestone, PR relationship, mirror, progress-issue, comment, or
-  closing-semantics attempt fails with the existing tracker+capability error
-  before any filesystem mutation, and the runtime never invokes `gh` or falls
-  back to GitHub for explicit local.
+Filesystem allocation, publication, collision, and recovery details have one
+implementation owner: [Tracker Adapter Design Contract](../../../docs/tracker-adapter-design.md).
 
 dev-backlog also reads `task_prefix`, `default_status`, and `statuses`;
 `project_name` is retained as metadata. Other Backlog.md config fields are not

--- a/skills/dev-backlog/references/file-format.md
+++ b/skills/dev-backlog/references/file-format.md
@@ -52,7 +52,7 @@ Extended set (if using more granular tracking):
 
 ## Filename Convention
 
-```
+```text
 {PREFIX}-{N[.M]} - {Title-Slug}.md
 ```
 

--- a/skills/dev-backlog/references/integration-contract.md
+++ b/skills/dev-backlog/references/integration-contract.md
@@ -12,7 +12,7 @@ Any actor consuming dev-backlog state should treat these files as the stable rea
 
 - `backlog/sprints/*.md` with `status: active` is the active execution hub: frontmatter identifies lifecycle and routing state; `## Goal`, `## Plan`, `## Running Context`, and `## Progress` identify the current objective, work queue, reusable discoveries, and execution trace.
 - `backlog/sprints/_context.md` is cross-sprint project memory. Its sections provide durable context for future sessions and analyzers.
-- `backlog/tasks/` and `backlog/completed/` are GitHub issue mirrors. Task files carry issue bodies and local Acceptance Criteria checkboxes; sprint files remain the execution log.
+- `backlog/tasks/` and `backlog/completed/` have mode-specific authority. With `tracker: github` they are derived issue mirrors; with `tracker: local` they are the canonical active/completed task store. Task files carry bodies and Acceptance Criteria checkboxes; sprint files remain the execution log.
 - `spec/capabilities.md`, when present, is an optional capability-level learning target addressed by active sprint frontmatter `component:`.
 
 The sections below define the path, heading, checkbox, and annotation grammar. Consumers may read more prose, but they must not require additional headings or rewritten formats to orient from files alone.
@@ -29,6 +29,37 @@ bash skills/dev-backlog/scripts/next.sh --json
 Both commands emit one JSON document to stdout with `schema_version: 1`. Tracker-neutral identity is an additive schema-v1 extension: existing consumers may ignore the new fields, and no existing field or GitHub value changes. Human-readable output remains the default when `--json` is absent. Snapshots are supported through normal shell redirection only, for example `status.sh --json > sprint-state.json`; dev-backlog does not create timestamped snapshot files or maintain a snapshot store.
 
 Ambiguous active sprint state is fail-loud in JSON mode: the command exits non-zero and writes the error to stderr instead of emitting partial JSON. Missing `## ` sections degrade to empty strings or arrays as shown below.
+
+## Tracker Selection and Capability Error Surface
+
+`backlog/config.yml` selects exactly one canonical tracker. A missing key is the
+zero-migration GitHub compatibility default; availability probes and operation
+failures never select another adapter. Existing GitHub `#N`, numeric
+`issue_number`, filenames, Markdown, argv, and provider behavior remain aliases
+with unchanged values. Local Plan items use `{PREFIX}-N[.M]`, and their
+`issue_number` is `null`.
+
+Optional provider capabilities are `milestones`, `pull-request-relationships`,
+`mirrors`, `progress-issues`, `comments`, and `closing-semantics`. A configured
+tracker that does not report one must fail before effects with this serialized
+shape:
+
+```json
+{
+  "error": {
+    "code": "TRACKER_CAPABILITY_UNSUPPORTED",
+    "tracker": "local",
+    "capability": "milestones",
+    "message": "Tracker \"local\" does not support capability \"milestones\".",
+    "remediation": "Use tracker \"local\" without \"milestones\", or explicitly change backlog/config.yml to a tracker that supports it before retrying. No tracker switch was attempted."
+  }
+}
+```
+
+JSON-capable public commands emit exactly that one document to stdout and exit
+non-zero. Human boundaries emit the same `message` and `remediation` to stderr.
+`tracker.js` is the single implementation owner for the typed error and
+serializer; command entry points must not copy or reshape it.
 
 Top-level schema:
 
@@ -399,7 +430,8 @@ This allows comment upserts to stay idempotent and prevents duplicate machine co
 - **No sprint file**: actors skip sprint tracking entirely. Tasks still work standalone.
 - **No `_context.md`**: ignored silently.
 - **Missing section in sprint**: treated as empty.
-- **No task file for an issue**: actors that can access GitHub may read directly via `gh`; `dev-relay` does this today.
+- **No GitHub mirror file**: GitHub-capable actors may read the canonical issue through the configured adapter; local mode must fail a missing canonical file rather than call `gh`.
+- **Unsupported optional capability**: return the typed error above; do not fabricate an empty provider result, mutate local state, or switch trackers.
 - **No relay manifest path**: progress reporting stays backlog-only.
 
 ## Cross-Project Smoke Test

--- a/skills/dev-backlog/references/process.md
+++ b/skills/dev-backlog/references/process.md
@@ -11,6 +11,33 @@ Adapter mechanics and the compatibility proof have one implementation owner:
 2. For an existing tracker-less config, keep the deterministic GitHub default. Setup first pins that legacy GitHub authority; any later switch must be explicit.
 3. Never infer selection from `gh`, authentication, remotes, existing task files, or an operation failure. Setup does not migrate task files.
 
+## Required Core Lifecycle Invocation Boundary
+
+The official create/read/update/close boundary for operators and agents is the
+configured adapter exported by `scripts/tracker.js`. Resolve it from the target
+backlog directory; do not import `github-tracker.js` or `local-tracker.js`
+directly and do not select an adapter from runtime availability:
+
+```js
+const path = require("node:path");
+const skillDir = "/resolved/dev-backlog-skill";
+const backlogDir = "backlog"; // or the custom backlog directory in use
+const { readConfig } = require(path.join(skillDir, "scripts/lib.js"));
+const { resolveConfiguredTracker } = require(path.join(skillDir, "scripts/tracker.js"));
+
+const { adapter } = resolveConfiguredTracker(readConfig(backlogDir), { backlogDir });
+```
+
+Call `adapter.list({ state, limit })`, `adapter.read(selector)`,
+`adapter.create(input)`, `adapter.update(selector, changes)`, or
+`adapter.close(selector, options)`. Feed the returned normalized `ref` into the
+sprint Plan. GitHub selectors are `#N`; local selectors are
+`{PREFIX}-N[.M]`. These exported adapter methods are the stable core lifecycle
+API; shell/Node scripts such as `status.sh`, `sync-pull.js`, and
+`sprint-close.sh` are workflow boundaries around it, not substitutes for task
+create/read/update/close. Low-level storage and provider argv remain owned by
+the linked Tracker Adapter Design Contract.
+
 ## Orient — Starting a Session
 
 1. If `backlog/` does not exist, complete **Setup**.

--- a/skills/dev-backlog/references/process.md
+++ b/skills/dev-backlog/references/process.md
@@ -1,104 +1,100 @@
 # Process
 
-Detailed workflow for each phase. SKILL.md has the summary; this file has the full steps.
+Detailed workflow for each phase. `SKILL.md` has the summary; this file routes
+the same core cycle through the one tracker selected in `backlog/config.yml`.
+Adapter mechanics and the compatibility proof have one implementation owner:
+[Tracker Adapter Design Contract](../../../docs/tracker-adapter-design.md).
+
+## Setup — Choose Canonical Task Truth
+
+1. For a fresh repository, run `scripts/setup-dev-backlog.js --tracker github|local --non-interactive`.
+2. For an existing tracker-less config, keep the deterministic GitHub default. Setup first pins that legacy GitHub authority; any later switch must be explicit.
+3. Never infer selection from `gh`, authentication, remotes, existing task files, or an operation failure. Setup does not migrate task files.
 
 ## Orient — Starting a Session
 
-1. If `backlog/` doesn't exist → Bootstrap: `mkdir -p backlog/{sprints,tasks,completed}`
-2. Read `backlog/sprints/_context.md` if it exists — project-level knowledge.
-3. Find the active sprint: the file in `backlog/sprints/` with `status: active` in frontmatter.
-4. If no active sprint → check GitHub for open issues → proceed to **Plan — Sprint**.
-5. Read sprint file — plan, progress, running context. You now know where you are.
-6. Find where you left off: last Progress entry + first unchecked item in Plan.
-7. If all Plan items are checked → proceed to **Complete** (close sprint).
+1. If `backlog/` does not exist, complete **Setup**.
+2. Read `backlog/sprints/_context.md` when present.
+3. Find the active sprint and read Goal, Plan, Running Context, and latest Progress.
+4. If no active sprint exists, list open tasks through the configured adapter and proceed to **Plan**.
+5. Use `status.sh --json` and `next.sh --json` for normalized `tracker`/`id`/`ref` state; GitHub keeps numeric `issue_number`, local returns `null`.
+6. If all Plan items are checked, proceed to **Complete**.
 
-Two files at most (`_context.md` + active sprint), full picture.
+Two sprint files at most (`_context.md` plus active sprint) provide the execution picture; canonical task reads come from the configured adapter.
 
-## Create — New Issues
+## Create — New Tasks
 
-1. Create on GitHub: `gh issue create -t "Title" -l "labels" -m "milestone"`
-2. Pull to local task file: `gh issue view <N> --json` → write `backlog/tasks/`
-3. Add to current sprint's Plan if it belongs in this sprint
+1. Call the configured adapter's required `create` operation.
+2. Use its returned normalized ref in the current sprint Plan when in scope: GitHub `#N`, local `{PREFIX}-N[.M]`.
+3. In GitHub mode, explicitly materialize/refresh the thin task mirror with `sync-pull.js`. In local mode, create already wrote the canonical task file; do not call `gh`.
 
 ## Plan — Sprint
 
 When starting a new sprint:
 
-0. If an active sprint exists, refuse to plan a new one until the previous sprint is closed through the full **Complete** flow (`sprint-close.sh`, archive completed tasks, promote Running Context). Never flip `status:` inline to force a slot open — `sprint-init.js` enforces this refusal.
-1. If `spec/charter.md` exists, read its `active` Objectives first. If it is absent, fall back to legacy root `CHARTER.md`. Derive the sprint as the projection of those objectives onto not-yet-done work, and record the advanced Objective IDs in sprint frontmatter `objectives: [O1, O3]`. If both are absent, plan exactly as before and leave `objectives: []`.
-2. Create GitHub milestone: `gh api repos/{owner}/{repo}/milestones -f title="Sprint W13" -f due_on="2026-03-28"`
-3. Assign issues: `gh issue edit <N> --milestone "Sprint W13"`
-4. Pull issues to `backlog/tasks/`
-5. **Create sprint file** in `backlog/sprints/` — run `scripts/sprint-init.js "topic" [--milestone "Name"]` to generate the skeleton (it refuses a second active sprint), or create it manually as fallback:
-   - Set Goal (one sentence)
-   - Order issues into Batches — group small tasks that can run in one session
-   - Estimate time per task to help decide batching
-   - Note any dependencies between tasks
-   - Set `component:` to one primary capability slug from `spec/capabilities.md` when that file exists (empty string when it doesn't, or when no capability fits) — it must match exactly one `## Capability: <slug>` heading; `component-lint.js` validates it
+1. Refuse a new sprint while another is active; complete the existing sprint rather than flipping `status:` inline.
+2. Resolve optional `objectives:` and `component:` fields from the spec axis as described in `spec-fallback.md`.
+3. List open tasks from the configured adapter.
+4. GitHub mode may create/assign a milestone and run `sprint-init.js "topic" --milestone "Name"`; its `#N`, estimates, due date, argv, and JSON remain legacy-compatible.
+5. Local mode does not fabricate a milestone. Author the sprint file from normalized local refs returned by the adapter.
+6. Set a one-sentence Goal, order mutually parallel-safe work into batches, put dependencies in later batches, and record estimates where useful.
 
 ## Work — Execute a Batch
 
-**Option A: Do it yourself (Claude Code)**
-1. Read sprint file → find current batch
-2. For each issue in the batch:
-   - Update GitHub label: `gh issue edit <N> --add-label "status:in-progress"`
-   - Read task file for AC and description
-   - Do the work.
-   - Verify: run tests, confirm each AC item is met, then check off AC in the task file.
-   - Commit with `Fixes #<N>` (one commit per issue)
-   - Add to sprint file's **Running Context** when you discover something that affects later tasks
-3. When batch is done:
-   - Update sprint file Plan checkboxes
-   - Add Progress entry with date and summary
-   - Push meaningful updates to GitHub: `gh issue comment <N> --body "summary"`
+1. Read the current batch and each canonical/mirrored task's Description and AC.
+2. Update neutral task state through the configured adapter.
+3. Do the work and verify every AC before checking it off.
+4. Update the sprint Plan, Progress, and reusable Running Context.
+5. In GitHub mode, comments, PR relationships, milestones, and closing keywords are optional provider capabilities. Invoke them only after their capability gate succeeds. Local mode reports none of them and must continue with the core lifecycle without provider calls.
 
-**Option B: Delegate to Codex (via dev-relay)**
-1. Read sprint file → find current batch
-2. For each issue: extract AC from task file → Done Criteria
-3. Follow the **dev-relay** skill's dispatch process (Plan + Contract → Dispatch → Review → Merge)
-4. After each merge, update sprint file: Plan checkbox, Progress entry, Running Context
+Delegated work follows the relay Plan → Dispatch → Review → Merge flow; the
+same normalized Plan refs remain the sprint anchor in either tracker mode.
 
-Small tasks in a batch flow naturally — finish one, check it off, start the next.
+## Complete — Close Tasks and Sprint
 
-## Complete — Close Issues
+Per task:
 
-Per issue:
-1. All AC checked in task file
-2. Commit/PR with `Fixes #<N>`
-3. Check off in sprint Plan + add Progress entry
+1. Verify all AC.
+2. Commit or merge the implementation and check the Plan item.
+3. Call required `close`: GitHub closes the issue; local writes `status: Done` and archives the canonical file under `backlog/completed/`.
+4. Use `Fixes #N`, comments, or closing relationships only when GitHub capability semantics are intentionally in scope.
 
-When the whole sprint closes:
-1. Run `scripts/sprint-close.sh [backlog-dir] [--dry-run] [--close-milestone]` — it runs `backlog-doctor.js` before the status flip and prints any reassess recommendation in the close summary
-2. Set sprint `status: completed`, write a final Progress entry
-3. Move completed task files: `backlog/tasks/` → `backlog/completed/`
-4. Review Running Context — promote project-level entries to `_context.md`
-5. The sprint file becomes a permanent record. Don't delete it.
+For the whole sprint:
 
-## Sync — GitHub ↔ Local
+1. Run `scripts/sprint-close.sh [backlog-dir] [--dry-run] [--close-milestone]`. Pass `--close-milestone` only for a tracker that reports `milestones`; unsupported requests fail before doctor or file mutation.
+2. The command sets `status: completed`, appends final Progress, archives checked active task files that remain, and prints the doctor/reassess summary.
+3. Promote durable Running Context to `_context.md`; retain the sprint file as history.
 
-**Pull** (GitHub → Local): `gh issue list` → update task files. Do this at sprint start and when issues change.
-**Push** (Local → GitHub): status label updates, progress comments, closing issues. Do this at meaningful milestones.
+## Sync — Explicit and Mode-Specific
 
-See `references/github-sync.md` for detailed commands.
+- **GitHub:** `sync-pull.js` explicitly refreshes derived task mirrors. Provider writes such as labels, comments, mirrors, and Progress issues are explicit operations.
+- **Local:** task files are canonical; there is no provider pull/push and no background sync.
+- **Both:** an operation failure never changes `tracker:` or makes the other store authoritative.
 
-## Quick Fix — Single Issue, No Sprint
+See `github-sync.md` for GitHub-only command patterns.
 
-Not everything needs a sprint. For a one-off bug fix or quick task:
+## Unsupported Optional Capabilities
 
-1. `gh issue view <N>` — read the issue directly
-2. Do the work, commit with `Fixes #<N>`
-3. Done. No sprint file, no local task file needed.
+`tracker.js` owns the typed failure and serializer. The stable public error has
+`code`, `tracker`, `capability`, `message`, and `remediation`. JSON-capable
+commands emit exactly one `{ "error": ... }` document and exit non-zero; human
+boundaries show the same remediation. The gate runs before filesystem/provider
+effects and never switches trackers.
 
-If you discover it's bigger than expected, that's when you create a sprint file.
+## Quick Fix — Single Task, No Sprint
+
+Read, update, and close the task through the configured adapter. GitHub may use
+its normal issue/closing behavior; local stays entirely in canonical Markdown.
+Create a sprint only when execution context needs to span work or sessions.
 
 ## Unplanned Work — Mid-Sprint Scope Change
 
-- **Small (< 1hr):** Use Quick Fix above — no sprint file change needed.
-- **Belongs in current sprint:** Add to the Plan as a new batch at the current position. Note in Progress: "Scope change: #50 added (urgent bug from QA)"
-- **Big enough for its own sprint:** Close current sprint early → start a new one.
+- **Small (< 1hr):** use the Quick Fix path.
+- **Current sprint:** add the normalized ref as a new batch and note the scope change in Progress.
+- **Separate sprint:** close the current sprint first, then start another.
 
 ## Next — What to Work On
 
-1. Read sprint file → find first unchecked batch
-2. If current sprint is done, check GitHub for unplanned work or start next sprint
-3. Present: "Next up: Batch 3 (#43 Rate limiting + #44 Input validation, ~50min total)"
+1. Read the active sprint and find the first unchecked batch.
+2. If it is done, list configured-tracker work or start the next sprint.
+3. Present the batch with its exact normalized refs and total estimate.

--- a/skills/dev-backlog/references/scripts.md
+++ b/skills/dev-backlog/references/scripts.md
@@ -14,6 +14,7 @@ node "$skill_dir/scripts/sprint-init.js" "next-sprint" --dry-run
 
 ## Full inventory
 
+- `scripts/setup-dev-backlog.js [project-name] [--tracker github|local] [--non-interactive] [--json]` — persist one canonical tracker and minimum directories without migrating task files; fresh non-interactive setup requires an explicit tracker.
 - `scripts/init.sh [project-name]` — bootstrap `backlog/` with config and directories.
 - `scripts/next.sh` — show the next actionable batch.
 - `scripts/status.sh` — summarize sprint file + GitHub state.
@@ -27,3 +28,16 @@ node "$skill_dir/scripts/sprint-init.js" "next-sprint" --dry-run
 - `scripts/backlog-doctor.js [--json] [--stale-days N] [backlog-dir]` — aggregate backlog health checks; hard violations fail, soft execution signals warn. JSON includes top-level `reassess_signal`.
 - `scripts/sprint-mirror.js [backlog-dir] [--dry-run] [--json]` — publish the active sprint to a read-only GitHub issue mirror; explicit sync only.
 - `scripts/context-hook.sh [backlog-dir]` — one-line active-sprint summary for a Claude Code PreToolUse hook; silent when no active sprint.
+
+## Tracker routing
+
+`backlog/config.yml` is the only runtime selection authority. Missing `tracker:`
+retains legacy GitHub behavior without rewriting the config. GitHub mode uses
+`gh` and treats task files as mirrors; local mode treats task files as canonical
+and makes zero provider calls. `sprint-init`, `sprint-mirror`, and
+`progress-sync` are representative JSON-capable optional-feature boundaries:
+when unsupported, `--json` exits non-zero with the shared `{ "error": ... }`
+contract from `tracker.js`, while human mode prints the same remediation.
+
+Detailed adapter mechanics and compatibility evidence are single-sourced in
+[`docs/tracker-adapter-design.md`](../../../docs/tracker-adapter-design.md).

--- a/skills/dev-backlog/references/scripts.md
+++ b/skills/dev-backlog/references/scripts.md
@@ -16,8 +16,9 @@ node "$skill_dir/scripts/sprint-init.js" "next-sprint" --dry-run
 
 - `scripts/setup-dev-backlog.js [project-name] [--tracker github|local] [--non-interactive] [--json]` — persist one canonical tracker and minimum directories without migrating task files; fresh non-interactive setup requires an explicit tracker.
 - `scripts/init.sh [project-name]` — bootstrap `backlog/` with config and directories.
+- `scripts/tracker.js` — official programmatic core lifecycle boundary: resolve the configured adapter with `{ backlogDir }`, then call `list`, `read`, `create`, `update`, or `close` as documented in `process.md`.
 - `scripts/next.sh` — show the next actionable batch.
-- `scripts/status.sh` — summarize sprint file + GitHub state.
+- `scripts/status.sh` — summarize sprint-file state plus task state from the configured tracker.
 - `scripts/sync-pull.js [PREFIX] [--update] [--dry-run] [--json] [--limit N]` — pull open GitHub issues into `backlog/tasks/`.
 - `scripts/sprint-init.js "topic" [--milestone "Name"] [--dry-run] [--json]` — create one active sprint skeleton; refuses a second active sprint. Emits `objectives:`/`component:` only when the backing spec file exists (see `spec-fallback.md`).
 - `scripts/progress-sync.js [--month YYYY-MM] [--dry-run] [--json] [--relay-manifest PATH] [--finalize]` — sync monthly progress issue.

--- a/skills/dev-backlog/scripts/github-capabilities.test.js
+++ b/skills/dev-backlog/scripts/github-capabilities.test.js
@@ -101,6 +101,41 @@ describe("GitHub optional capability transports", () => {
       "--json", "number,title,labels,milestone",
     ]);
   });
+
+  it("renders normalized refs from a configured custom local store in human status", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "local-status-list-"));
+    const backlogDir = path.join(root, "custom-store");
+    const binDir = path.join(root, "bin");
+    fs.mkdirSync(path.join(backlogDir, "tasks"), { recursive: true });
+    fs.mkdirSync(path.join(backlogDir, "completed"));
+    fs.mkdirSync(binDir);
+    fs.writeFileSync(
+      path.join(backlogDir, "config.yml"),
+      "tracker: local\ntask_prefix: BACK\n"
+    );
+    fs.writeFileSync(
+      path.join(backlogDir, "tasks", "BACK-7.2 - custom-store-task.md"),
+      [
+        "---", "id: BACK-7.2", "title: Custom store task", "status: To Do",
+        "labels: [offline]", "priority: medium", "created_date: '2026-07-12'", "---",
+        "## Description", "Custom local task", "",
+      ].join("\n")
+    );
+    const columnPath = path.join(binDir, "column");
+    fs.writeFileSync(columnPath, "#!/bin/sh\ncat\n");
+    fs.chmodSync(columnPath, 0o755);
+
+    const result = spawnSync("bash", [path.join(__dirname, "status.sh"), backlogDir], {
+      cwd: root,
+      env: { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}` },
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /=== Tracker Tasks ===/);
+    assert.match(result.stdout, /^BACK-7\.2\t-\tCustom store task\toffline$/m);
+    assert.doesNotMatch(result.stdout, /=== GitHub Issues ===/);
+  });
 });
 
 describe("configured-only failure before effects", () => {

--- a/skills/dev-backlog/scripts/progress-sync.js
+++ b/skills/dev-backlog/scripts/progress-sync.js
@@ -18,7 +18,11 @@ const { execFileSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const { readConfig } = require("./lib.js");
-const { invokeCapability, resolveConfiguredTracker } = require("./tracker.js");
+const {
+  invokeCapability,
+  resolveConfiguredTracker,
+  writeTrackerCliError,
+} = require("./tracker.js");
 const {
   githubIssueNumber,
   parsePlanCheckbox,
@@ -418,6 +422,9 @@ function main() {
 
     printResult(result);
   } catch (e) {
+    if (writeTrackerCliError(e, { json: options.json })) {
+      process.exit(1);
+    }
     console.error(`Error: ${e.message}`);
     process.exit(1);
   }

--- a/skills/dev-backlog/scripts/progress-sync.js
+++ b/skills/dev-backlog/scripts/progress-sync.js
@@ -217,7 +217,7 @@ function sync({
   readFs = { readTaskFiles, readActiveSprintSummary },
   fetchComments = fetchIssueComments,
 }) {
-  const resolved = resolveConfiguredTracker(readConfig(backlogDir), { execFile });
+  const resolved = resolveConfiguredTracker(readConfig(backlogDir), { execFile, backlogDir });
   const requiredCapabilities = [
     "progress-issues",
     "pull-request-relationships",

--- a/skills/dev-backlog/scripts/sprint-init.js
+++ b/skills/dev-backlog/scripts/sprint-init.js
@@ -174,7 +174,8 @@ function createSprintFile({
   hasCapabilities,
 }) {
   if (!getDue || !getIssues) {
-    const resolved = resolveConfiguredTracker(readConfig(path.dirname(sprintsDir)));
+    const backlogDir = path.dirname(sprintsDir);
+    const resolved = resolveConfiguredTracker(readConfig(backlogDir), { backlogDir });
     invokeCapability(resolved, "milestones", () => undefined);
     getDue = getDue || getMilestoneDue;
     getIssues = getIssues || getMilestoneIssues;

--- a/skills/dev-backlog/scripts/sprint-init.js
+++ b/skills/dev-backlog/scripts/sprint-init.js
@@ -16,7 +16,11 @@ const path = require("path");
 const { renderTaskRef } = require("./task-ref.js");
 const { slugify, estimateSize, readConfig } = require("./lib");
 const { getMilestoneDue, getMilestoneIssues } = require("./github-milestones.js");
-const { invokeCapability, resolveConfiguredTracker } = require("./tracker.js");
+const {
+  invokeCapability,
+  resolveConfiguredTracker,
+  writeTrackerCliError,
+} = require("./tracker.js");
 const { resolveCharterPath } = require("./spec-paths.js");
 
 function parseArgs(args) {
@@ -268,6 +272,9 @@ function main() {
 
     printResult(result);
   } catch (error) {
+    if (writeTrackerCliError(error, { json: parsed.json })) {
+      process.exit(1);
+    }
     console.error(error.message);
     process.exit(1);
   }

--- a/skills/dev-backlog/scripts/sprint-mirror.js
+++ b/skills/dev-backlog/scripts/sprint-mirror.js
@@ -185,7 +185,7 @@ function sync({
   execFile = execFileSync,
   sprintStatePath = SPRINT_STATE_PATH,
 } = {}) {
-  const resolved = resolveConfiguredTracker(readConfig(backlogDir), { execFile });
+  const resolved = resolveConfiguredTracker(readConfig(backlogDir), { execFile, backlogDir });
   invokeCapability(resolved, "mirrors", () => undefined);
   const state = resolveSprintState({ backlogDir, execFile, sprintStatePath });
   const slug = path.basename(state.active_sprint.path, ".md");

--- a/skills/dev-backlog/scripts/sprint-mirror.js
+++ b/skills/dev-backlog/scripts/sprint-mirror.js
@@ -21,7 +21,11 @@ const { execFileSync } = require("child_process");
 const path = require("path");
 const { readConfig } = require("./lib.js");
 const { parseTaskRef, renderTaskRef } = require("./task-ref.js");
-const { invokeCapability, resolveConfiguredTracker } = require("./tracker.js");
+const {
+  invokeCapability,
+  resolveConfiguredTracker,
+  writeTrackerCliError,
+} = require("./tracker.js");
 const {
   findMirrorIssue,
   createMirrorIssue,
@@ -257,6 +261,9 @@ function main() {
 
     printResult(result);
   } catch (error) {
+    if (writeTrackerCliError(error, { json: parsed.json })) {
+      process.exit(1);
+    }
     console.error(`Error: ${error.message}`);
     process.exit(1);
   }

--- a/skills/dev-backlog/scripts/status.sh
+++ b/skills/dev-backlog/scripts/status.sh
@@ -73,9 +73,9 @@ else
   echo "(no backlog/sprints/ directory)"
 fi
 
-# --- GitHub Issues ---
+# --- Configured Tracker Tasks ---
 echo ""
-echo "=== GitHub Issues ==="
+echo "=== Tracker Tasks ==="
 if command -v column >/dev/null 2>&1; then
   node "$SCRIPT_DIR/tracker-status-list.js" "$BACKLOG_DIR" | column -t -s $'\t' \
     || echo "(gh not available)"

--- a/skills/dev-backlog/scripts/tracker-capability.js
+++ b/skills/dev-backlog/scripts/tracker-capability.js
@@ -9,7 +9,7 @@ const {
 const { closeMilestone } = require("./github-milestones.js");
 
 function requireCapability(capability, backlogDir = "backlog") {
-  const resolved = resolveConfiguredTracker(readConfig(backlogDir));
+  const resolved = resolveConfiguredTracker(readConfig(backlogDir), { backlogDir });
   return invokeCapability(resolved, capability, () => resolved);
 }
 

--- a/skills/dev-backlog/scripts/tracker-capability.js
+++ b/skills/dev-backlog/scripts/tracker-capability.js
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
 
 const { readConfig } = require("./lib.js");
-const { invokeCapability, resolveConfiguredTracker } = require("./tracker.js");
+const {
+  invokeCapability,
+  resolveConfiguredTracker,
+  writeTrackerCliError,
+} = require("./tracker.js");
 const { closeMilestone } = require("./github-milestones.js");
 
 function requireCapability(capability, backlogDir = "backlog") {
@@ -25,6 +29,10 @@ function main() {
     }
     throw new Error(`Unknown tracker capability operation: ${operation}`);
   } catch (error) {
+    if (writeTrackerCliError(error)) {
+      process.exitCode = 1;
+      return;
+    }
     console.error(error.message);
     process.exitCode = 1;
   }

--- a/skills/dev-backlog/scripts/tracker-cycle.acceptance.test.js
+++ b/skills/dev-backlog/scripts/tracker-cycle.acceptance.test.js
@@ -325,6 +325,7 @@ function runGithubCycle(fixture) {
     SPRINT_INIT_PATH, "cycle", "--milestone", "Cycle Milestone", "--json",
   ], fixture), "github sprint-init");
   const sprintPath = path.join(fixture.root, init.sprintFile);
+  const sprintSlug = path.basename(init.sprintFile, ".md");
   assert.match(fs.readFileSync(sprintPath, "utf8"), /^due: 2026-06-30$/m);
   assert.match(fs.readFileSync(sprintPath, "utf8"), /^- \[ \] #42 Cycle task$/m);
 
@@ -361,7 +362,7 @@ function runGithubCycle(fixture) {
     "| In-flight (open PRs) | 1 |", "| Stuck candidates | 0 |", "",
     "## Month End", "", `- Finalized on: ${progress.finalizedAt}`,
     "- State: closed", "", "## Active Sprint", "",
-    "**2026-07-cycle.md** — 0/1 done, 0 in-flight, 1 remaining", "",
+    `**${sprintSlug}.md** — 0/1 done, 0 in-flight, 1 remaining`, "",
   ].join("\n"));
 
   const originalBody = fs.readFileSync(taskPath, "utf8").slice(fs.readFileSync(taskPath, "utf8").indexOf("\n## Description"));
@@ -389,7 +390,17 @@ function runGithubCycle(fixture) {
   const calls = fixture.providerCalls();
   const mirrorCreateBody = calls[6]?.[5];
   const mirrorUpdateBody = calls[8]?.[4];
-  const mirrorBodyPattern = /^<!-- dev-backlog:sprint-mirror sprint=2026-07-cycle -->\n\n> The local sprint file is canonical\. This mirror is read-only — it is\n> not edited by hand — and sync is always explicit; there is no daemon\.\n\n## Goal\n\n\[One sentence: what's true when this sprint is done\]\n\n## Plan\n\n- \[ \] #42 Cycle task\n\n## Latest Progress\n\n_No progress recorded yet\._\n\nLast explicit sync: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+  const mirrorBodyPrefix = [
+    `<!-- dev-backlog:sprint-mirror sprint=${sprintSlug} -->`, "",
+    "> The local sprint file is canonical. This mirror is read-only — it is",
+    "> not edited by hand — and sync is always explicit; there is no daemon.", "",
+    "## Goal", "", "[One sentence: what's true when this sprint is done]", "",
+    "## Plan", "", "- [ ] #42 Cycle task", "", "## Latest Progress", "",
+    "_No progress recorded yet._", "", "Last explicit sync: ",
+  ].join("\n");
+  const mirrorBodyPattern = new RegExp(
+    `^${escapeRegExp(mirrorBodyPrefix)}\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z$`
+  );
   assert.match(mirrorCreateBody, mirrorBodyPattern);
   assert.match(mirrorUpdateBody, mirrorBodyPattern);
   assert.deepEqual(calls, [

--- a/skills/dev-backlog/scripts/tracker-cycle.acceptance.test.js
+++ b/skills/dev-backlog/scripts/tracker-cycle.acceptance.test.js
@@ -1,0 +1,500 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const trackerModule = require("./tracker.js");
+
+const SCRIPTS_DIR = __dirname;
+const TRACKER_PATH = path.join(SCRIPTS_DIR, "tracker.js");
+const SETUP_PATH = path.join(SCRIPTS_DIR, "setup-dev-backlog.js");
+const SYNC_PATH = path.join(SCRIPTS_DIR, "sync-pull.js");
+const SPRINT_INIT_PATH = path.join(SCRIPTS_DIR, "sprint-init.js");
+const SPRINT_CLOSE_PATH = path.join(SCRIPTS_DIR, "sprint-close.sh");
+const SPRINT_MIRROR_PATH = path.join(SCRIPTS_DIR, "sprint-mirror.js");
+const PROGRESS_SYNC_PATH = path.join(SCRIPTS_DIR, "progress-sync.js");
+const STATUS_PATH = path.join(SCRIPTS_DIR, "status.sh");
+const NEXT_PATH = path.join(SCRIPTS_DIR, "next.sh");
+
+function makeRoot(t, prefix) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+
+function run(command, args, { cwd, env = process.env } = {}) {
+  return spawnSync(command, args, { cwd, env, encoding: "utf8" });
+}
+
+function expectSuccess(result, context) {
+  assert.equal(result.status, 0, `${context}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  assert.equal(result.signal, null, context);
+  return result;
+}
+
+function parseJsonResult(result, context) {
+  expectSuccess(result, context);
+  return JSON.parse(result.stdout);
+}
+
+function writeWorker(root) {
+  const worker = path.join(root, "tracker-worker.cjs");
+  fs.writeFileSync(worker, `
+const tracker = require(${JSON.stringify(TRACKER_PATH)});
+const [backlogDir, action, payload = "{}"] = process.argv.slice(2);
+const resolved = tracker.resolveConfiguredTracker(
+  require(${JSON.stringify(path.join(SCRIPTS_DIR, "lib.js"))}).readConfig(backlogDir),
+  { backlogDir }
+);
+const input = JSON.parse(payload);
+let result;
+if (action === "list") result = resolved.adapter.list(input);
+else if (action === "read") result = resolved.adapter.read(input.selector);
+else if (action === "create") result = resolved.adapter.create(input);
+else if (action === "update") result = resolved.adapter.update(input.selector, input.changes);
+else if (action === "close") result = resolved.adapter.close(input.selector, input.options);
+else throw new Error("unknown worker action: " + action);
+process.stdout.write(JSON.stringify(result));
+`);
+  return worker;
+}
+
+function runWorker(fixture, action, payload = {}) {
+  return parseJsonResult(
+    run(process.execPath, [fixture.worker, fixture.backlogDir, action, JSON.stringify(payload)], fixture),
+    `${fixture.tracker} ${action}`
+  );
+}
+
+function writeGhFixture(root) {
+  const binDir = path.join(root, "bin");
+  const statePath = path.join(root, "gh-state.json");
+  const logPath = path.join(root, "gh-argv.jsonl");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(statePath, JSON.stringify({
+    nextIssue: 42,
+    issues: [],
+    mirror: null,
+    progress: {},
+    comments: [],
+    milestoneClosed: false,
+  }));
+  const ghPath = path.join(binDir, "gh");
+  fs.writeFileSync(ghPath, `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+const statePath = process.env.FAKE_GH_STATE;
+const logPath = process.env.FAKE_GH_LOG;
+const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+fs.appendFileSync(logPath, JSON.stringify(args) + "\\n");
+const save = () => fs.writeFileSync(statePath, JSON.stringify(state));
+const valueAfter = (flag) => args[args.indexOf(flag) + 1];
+const out = (value) => process.stdout.write(typeof value === "string" ? value : JSON.stringify(value));
+
+if (args[0] === "issue" && args[1] === "create") {
+  const title = valueAfter("--title");
+  const body = valueAfter("--body") || "";
+  if (title.startsWith("Sprint mirror:")) {
+    state.mirror = { number: 84, title, body };
+    save(); out("https://github.test/acme/widgets/issues/84\\n");
+  } else if (title.startsWith("Progress:")) {
+    state.progress[title] = { number: 90, title, body, state: "open" };
+    save(); out("https://github.test/acme/widgets/issues/90\\n");
+  } else {
+    const number = state.nextIssue++;
+    state.issues.push({
+      number, title, body, state: "open", url: "https://github.test/acme/widgets/issues/" + number,
+      labels: [{ name: "priority:high" }], milestone: { title: "Cycle Milestone" }, assignees: [],
+    });
+    save(); out("https://github.test/acme/widgets/issues/" + number + "\\n");
+  }
+  process.exit(0);
+}
+
+if (args[0] === "issue" && args[1] === "list") {
+  if (args.includes("--milestone")) {
+    out(state.issues.filter((issue) => issue.state === "open").map(({ number, title, labels }) => ({ number, title, labels })));
+  } else if (args.includes("dev-backlog:sprint-mirror in:body")) {
+    out(state.mirror ? [state.mirror] : []);
+  } else if (args.includes("--search") && String(valueAfter("--search")).includes("Progress:")) {
+    const title = String(valueAfter("--search")).replace(/^\"|\" in:title$/g, "");
+    out(state.progress[title] ? [state.progress[title]] : []);
+  } else {
+    out(state.issues.filter((issue) => {
+      const requested = valueAfter("--state") || "open";
+      return requested === "all" || issue.state === requested;
+    }));
+  }
+  process.exit(0);
+}
+
+if (args[0] === "issue" && args[1] === "view") {
+  const issue = state.issues.find((candidate) => String(candidate.number) === args[2]);
+  if (!issue) process.exit(4);
+  out(issue); process.exit(0);
+}
+
+if (args[0] === "issue" && args[1] === "edit") {
+  const number = Number(args[2]);
+  if (number === 84 && state.mirror) state.mirror.body = valueAfter("--body");
+  else if (number === 90) {
+    const entry = Object.values(state.progress).find((candidate) => candidate.number === number);
+    if (entry) entry.body = valueAfter("--body");
+  } else {
+    const issue = state.issues.find((candidate) => candidate.number === number);
+    if (issue && args.includes("--title")) issue.title = valueAfter("--title");
+    if (issue && args.includes("--body")) issue.body = valueAfter("--body");
+  }
+  save(); process.exit(0);
+}
+
+if (args[0] === "issue" && args[1] === "close") {
+  const issue = state.issues.find((candidate) => String(candidate.number) === args[2]);
+  if (issue) issue.state = "closed";
+  save(); process.exit(0);
+}
+
+if (args[0] === "pr" && args[1] === "list" && valueAfter("--state") === "open") {
+  out([{ number: 98, title: "Open cycle PR" }]); process.exit(0);
+}
+if (args[0] === "pr" && args[1] === "list" && valueAfter("--state") === "merged") {
+  out([{ number: 99, title: "Merged cycle PR", url: "https://github.test/acme/widgets/pull/99",
+    mergedAt: "2026-06-15T00:00:00Z", closingIssuesReferences: [{ number: 42 }] }]);
+  process.exit(0);
+}
+
+if (args[0] === "api" && args[1] === "repos/{owner}/{repo}/milestones" && args.includes("--jq")) {
+  const query = valueAfter("--jq");
+  out(query.includes("due_on") ? "2026-06-30T00:00:00Z\\n" : "7\\n");
+  process.exit(0);
+}
+if (args[0] === "api" && args[1] === "-X" && args[2] === "PATCH" && args[3].endsWith("/milestones/7")) {
+  state.milestoneClosed = true; save(); process.exit(0);
+}
+if (args[0] === "api" && args[1] === "repos/{owner}/{repo}/issues/90/comments" && args.includes("--paginate")) {
+  out(state.comments); process.exit(0);
+}
+if (args[0] === "api" && args[1] === "repos/{owner}/{repo}/issues/90/comments" && valueAfter("--method") === "POST") {
+  state.comments.push({ id: 501, body: valueAfter("--field").slice("body=".length) });
+  save(); process.exit(0);
+}
+if (args[0] === "api" && args[1] === "repos/{owner}/{repo}/issues/90" && valueAfter("--method") === "PATCH") {
+  const entry = Object.values(state.progress).find((candidate) => candidate.number === 90);
+  if (entry) entry.state = "closed";
+  save(); process.exit(0);
+}
+
+process.stderr.write("unhandled fake gh argv: " + JSON.stringify(args) + "\\n");
+process.exit(93);
+`);
+  fs.chmodSync(ghPath, 0o755);
+  return {
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`,
+      FAKE_GH_STATE: statePath,
+      FAKE_GH_LOG: logPath,
+    },
+    calls: () => fs.existsSync(logPath)
+      ? fs.readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean).map(JSON.parse)
+      : [],
+    state: () => JSON.parse(fs.readFileSync(statePath, "utf8")),
+  };
+}
+
+function writeGhTrap(root) {
+  const binDir = path.join(root, "bin");
+  const marker = path.join(root, "gh-was-called");
+  fs.mkdirSync(binDir, { recursive: true });
+  const ghPath = path.join(binDir, "gh");
+  fs.writeFileSync(ghPath, `#!/bin/sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(marker)}\nexit 97\n`);
+  fs.chmodSync(ghPath, 0o755);
+  return {
+    env: { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}` },
+    calls: () => fs.existsSync(marker) ? fs.readFileSync(marker, "utf8").trim().split("\n") : [],
+  };
+}
+
+function prepareGithub(t) {
+  const root = makeRoot(t, "tracker-cycle-github-");
+  const backlogDir = path.join(root, "backlog");
+  fs.mkdirSync(path.join(backlogDir, "sprints"), { recursive: true });
+  fs.mkdirSync(path.join(backlogDir, "tasks"), { recursive: true });
+  fs.mkdirSync(path.join(backlogDir, "completed"), { recursive: true });
+  const legacyConfig = [
+    'project_name: "legacy-cycle"',
+    'task_prefix: "BACK"',
+    'default_status: "To Do"',
+    'statuses: ["To Do", "In Progress", "Done"]',
+    "",
+  ].join("\n");
+  fs.writeFileSync(path.join(backlogDir, "config.yml"), legacyConfig);
+  const gh = writeGhFixture(root);
+  return {
+    tracker: "github", root, cwd: root, backlogDir, legacyConfig, worker: writeWorker(root),
+    env: gh.env, providerCalls: gh.calls, providerState: gh.state,
+  };
+}
+
+function prepareLocal(t) {
+  const root = makeRoot(t, "tracker-cycle-local-");
+  const trap = writeGhTrap(root);
+  const setup = parseJsonResult(run(process.execPath, [
+    SETUP_PATH, "--tracker", "local", "--non-interactive", "--json", "--project-name", "offline-cycle",
+  ], { cwd: root, env: trap.env }), "local setup");
+  assert.equal(setup.selection, "local");
+  return {
+    tracker: "local", root, cwd: root, backlogDir: path.join(root, "backlog"),
+    worker: writeWorker(root), env: trap.env, providerCalls: trap.calls,
+  };
+}
+
+const CYCLE_ROWS = [
+  { tracker: "github", prepare: prepareGithub },
+  { tracker: "local", prepare: prepareLocal },
+];
+
+function writeLocalSprint(fixture, identity) {
+  const sprintPath = path.join(fixture.backlogDir, "sprints", "2026-07-local-cycle.md");
+  fs.writeFileSync(sprintPath, [
+    "---", "milestone: local cycle", "status: active", "started: 2026-07-12", "---", "",
+    "# Local cycle", "", "## Goal", "Prove the local core cycle.", "", "## Plan", "",
+    "### Batch 1 - local", `- [ ] ${identity.ref} Offline canonical task`, "",
+    "## Running Context", "Local files are canonical.", "", "## Progress", "",
+  ].join("\n"));
+  return sprintPath;
+}
+
+function orient(fixture) {
+  const status = parseJsonResult(
+    run("bash", [STATUS_PATH, "--json", fixture.backlogDir], fixture),
+    `${fixture.tracker} status --json`
+  );
+  const next = parseJsonResult(
+    run("bash", [NEXT_PATH, "--json", fixture.backlogDir], fixture),
+    `${fixture.tracker} next --json`
+  );
+  return { status, next };
+}
+
+function finishSprint(fixture, sprintPath, { closeMilestone = false } = {}) {
+  const before = fs.readFileSync(sprintPath, "utf8");
+  fs.writeFileSync(sprintPath, before.replace("- [ ] ", "- [x] "));
+  const args = [SPRINT_CLOSE_PATH, fixture.backlogDir];
+  if (closeMilestone) args.push("--close-milestone");
+  expectSuccess(run("bash", args, fixture), `${fixture.tracker} sprint close`);
+  assert.match(fs.readFileSync(sprintPath, "utf8"), /^status: completed$/m);
+}
+
+function runGithubCycle(fixture) {
+  const configPath = path.join(fixture.backlogDir, "config.yml");
+  const body = "Human GitHub body\n\n## Acceptance Criteria\n- [ ] Preserve me";
+  const created = runWorker(fixture, "create", { title: "Cycle task", body });
+  assert.deepEqual(created, {
+    tracker: "github", id: "42", ref: "#42", url: "https://github.test/acme/widgets/issues/42",
+  });
+
+  const pulled = parseJsonResult(
+    run(process.execPath, [SYNC_PATH, "--limit", "1", "--json"], fixture),
+    "github sync-pull"
+  );
+  assert.equal(pulled.createdFiles[0], "BACK-42 - cycle-task.md");
+  const taskPath = path.join(fixture.backlogDir, "tasks", pulled.createdFiles[0]);
+  const today = new Date().toISOString().slice(0, 10);
+  assert.equal(fs.readFileSync(taskPath, "utf8"), [
+    "---", "id: BACK-42", "title: Cycle task", "status: To Do", "labels: []",
+    "priority: high", "milestone: Cycle Milestone", `created_date: '${today}'`, "---",
+    "## Description", "Human GitHub body", "", "## Acceptance Criteria", "- [ ] Preserve me", "",
+  ].join("\n"));
+
+  const init = parseJsonResult(run(process.execPath, [
+    SPRINT_INIT_PATH, "cycle", "--milestone", "Cycle Milestone", "--json",
+  ], fixture), "github sprint-init");
+  const sprintPath = path.join(fixture.root, init.sprintFile);
+  assert.match(fs.readFileSync(sprintPath, "utf8"), /^due: 2026-06-30$/m);
+  assert.match(fs.readFileSync(sprintPath, "utf8"), /^- \[ \] #42 Cycle task$/m);
+
+  const { status, next } = orient(fixture);
+  assert.deepEqual(status.plan_items.map(({ tracker, id, ref, issue_number }) => ({ tracker, id, ref, issue_number })), [
+    { tracker: "github", id: "42", ref: "#42", issue_number: 42 },
+  ]);
+  assert.equal(next.next_batch.items[0].ref, "#42");
+  assert.equal(runWorker(fixture, "read", { selector: "#42" }).title, "Cycle task");
+
+  const mirrorCreate = parseJsonResult(
+    run(process.execPath, [SPRINT_MIRROR_PATH, fixture.backlogDir, "--json"], fixture),
+    "github sprint mirror create"
+  );
+  const mirrorUpdate = parseJsonResult(
+    run(process.execPath, [SPRINT_MIRROR_PATH, fixture.backlogDir, "--json"], fixture),
+    "github sprint mirror update"
+  );
+  assert.deepEqual([mirrorCreate.action, mirrorUpdate.action], ["created", "updated"]);
+  assert.deepEqual([mirrorCreate.issue_number, mirrorUpdate.issue_number], [84, 84]);
+
+  const progress = parseJsonResult(run(process.execPath, [
+    PROGRESS_SYNC_PATH, "--month", "2026-06", "--finalize", "--json",
+  ], fixture), "github progress finalize");
+  assert.equal(progress.issueNumber, 90);
+  assert.equal(progress.summary.merged, 1);
+  assert.equal(progress.summary.inFlight, 1);
+  assert.equal(progress.comments.created, 1);
+  assert.equal(progress.closed, true);
+
+  const originalBody = fs.readFileSync(taskPath, "utf8").slice(fs.readFileSync(taskPath, "utf8").indexOf("\n## Description"));
+  runWorker(fixture, "update", { selector: "#42", changes: { title: "Cycle task renamed" } });
+  parseJsonResult(run(process.execPath, [SYNC_PATH, "--limit", "1", "--update", "--json"], fixture), "github update mirror");
+  const updatedMirror = fs.readFileSync(taskPath, "utf8");
+  assert.match(updatedMirror, /^title: Cycle task renamed$/m);
+  assert.equal(updatedMirror.slice(updatedMirror.indexOf("\n## Description")), originalBody);
+
+  finishSprint(fixture, sprintPath, { closeMilestone: true });
+  const completedPath = path.join(fixture.backlogDir, "completed", path.basename(taskPath));
+  assert.equal(fs.existsSync(taskPath), false);
+  assert.equal(fs.readFileSync(completedPath, "utf8"), updatedMirror);
+  runWorker(fixture, "close", { selector: "#42" });
+  assert.equal(runWorker(fixture, "list", { state: "closed", limit: 20 })[0].ref, "#42");
+  assert.equal(runWorker(fixture, "read", { selector: "#42" }).state, "closed");
+
+  assert.equal(fs.readFileSync(configPath, "utf8"), fixture.legacyConfig, "legacy config must not migrate");
+  const calls = fixture.providerCalls();
+  const has = (expected) => calls.some((actual) => JSON.stringify(actual) === JSON.stringify(expected));
+  assert.ok(has(["issue", "create", "--title", "Cycle task", "--body", body]));
+  assert.ok(has(["issue", "view", "42", "--json", "number,title,body,labels,milestone,assignees,createdAt,updatedAt"]));
+  assert.ok(has(["issue", "edit", "42", "--title", "Cycle task renamed"]));
+  assert.ok(has(["issue", "close", "42"]));
+  assert.ok(has(["issue", "list", "--milestone", "Cycle Milestone", "--state", "open", "--json", "number,title,labels"]));
+  assert.ok(has(["api", "-X", "PATCH", "repos/{owner}/{repo}/milestones/7", "-f", "state=closed"]));
+  assert.ok(calls.some((args) => args[0] === "pr" && args[1] === "list" && args.includes("merged")));
+  assert.ok(calls.some((args) => args[0] === "api" && args[1].endsWith("/issues/90/comments") && args.includes("POST")));
+  assert.equal(fixture.providerState().milestoneClosed, true);
+}
+
+function runLocalCycle(fixture) {
+  const body = "\n## Description\nHuman local body\n\n## Acceptance Criteria\n- [ ] Keep this AC\n";
+  const created = runWorker(fixture, "create", { title: "Offline canonical task", body });
+  assert.deepEqual(created, { tracker: "local", id: "1", ref: "BACK-1" });
+  const taskPath = path.join(fixture.backlogDir, "tasks", "BACK-1 - offline-canonical-task.md");
+  assert.equal(fs.readFileSync(taskPath, "utf8").endsWith(body), true);
+
+  const sprintPath = writeLocalSprint(fixture, created);
+  const { status, next } = orient(fixture);
+  assert.deepEqual(status.plan_items.map(({ tracker, id, ref, issue_number }) => ({ tracker, id, ref, issue_number })), [
+    { tracker: "local", id: "1", ref: "BACK-1", issue_number: null },
+  ]);
+  assert.equal(next.next_batch.items[0].ref, "BACK-1");
+  assert.equal(runWorker(fixture, "read", { selector: "BACK-1" }).body, body);
+
+  const bodyBefore = fs.readFileSync(taskPath, "utf8").slice(fs.readFileSync(taskPath, "utf8").indexOf("\n## Description"));
+  runWorker(fixture, "update", { selector: "BACK-1", changes: { status: "In Progress" } });
+  const afterUpdate = fs.readFileSync(taskPath, "utf8");
+  assert.match(afterUpdate, /^status: In Progress$/m);
+  assert.equal(afterUpdate.slice(afterUpdate.indexOf("\n## Description")), bodyBefore);
+
+  runWorker(fixture, "close", { selector: "BACK-1" });
+  const archivedPath = path.join(fixture.backlogDir, "completed", "BACK-1 - offline-canonical-task.md");
+  assert.equal(fs.existsSync(taskPath), false);
+  assert.match(fs.readFileSync(archivedPath, "utf8"), /^status: Done$/m);
+  assert.equal(fs.readFileSync(archivedPath, "utf8").slice(fs.readFileSync(archivedPath, "utf8").indexOf("\n## Description")), bodyBefore);
+
+  finishSprint(fixture, sprintPath);
+  assert.deepEqual(runWorker(fixture, "list", { state: "open" }), []);
+  assert.equal(runWorker(fixture, "list", { state: "closed" })[0].ref, "BACK-1");
+  const finalRead = runWorker(fixture, "read", { selector: "BACK-1" });
+  assert.equal(finalRead.state, "closed");
+  assert.equal(finalRead.status, "Done");
+  assert.deepEqual(fixture.providerCalls(), [], "local cycle must make zero provider calls");
+}
+
+describe("tracker core cycle acceptance matrix", () => {
+  for (const row of CYCLE_ROWS) {
+    it(`${row.tracker}: setup/config → create → Plan → orient/read → update → complete → final read/list`, (t) => {
+      const fixture = row.prepare(t);
+      if (row.tracker === "github") runGithubCycle(fixture);
+      else runLocalCycle(fixture);
+    });
+  }
+});
+
+describe("typed unsupported-capability contract", () => {
+  for (const capability of trackerModule.CAPABILITY_NAMES) {
+    it(`local ${capability} fails before side effects with the shared serialized shape`, (t) => {
+      const fixture = prepareLocal(t);
+      const resolved = trackerModule.resolveConfiguredTracker({ tracker: "local" }, { backlogDir: fixture.backlogDir });
+      let sideEffects = 0;
+      let caught;
+      try {
+        trackerModule.invokeCapability(resolved, capability, () => { sideEffects += 1; });
+      } catch (error) {
+        caught = error;
+      }
+      assert.equal(sideEffects, 0);
+      assert.ok(caught instanceof trackerModule.UnsupportedTrackerCapabilityError);
+      assert.equal(typeof trackerModule.serializeTrackerError, "function");
+      assert.deepEqual(trackerModule.serializeTrackerError(caught), {
+        code: "TRACKER_CAPABILITY_UNSUPPORTED",
+        tracker: "local",
+        capability,
+        message: `Tracker "local" does not support capability "${capability}".`,
+        remediation: `Use tracker "local" without "${capability}", or explicitly change backlog/config.yml to a tracker that supports it before retrying. No tracker switch was attempted.`,
+      });
+      assert.deepEqual(fixture.providerCalls(), []);
+    });
+  }
+});
+
+describe("unsupported capability public CLI boundaries", () => {
+  const boundaries = [
+    { name: "sprint-init", script: SPRINT_INIT_PATH, args: ["blocked", "--json"], capability: "milestones" },
+    { name: "sprint-mirror", script: SPRINT_MIRROR_PATH, args: ["backlog", "--json"], capability: "mirrors" },
+    { name: "progress-sync", script: PROGRESS_SYNC_PATH, args: ["--month", "2026-06", "--json"], capability: "progress-issues" },
+  ];
+
+  for (const boundary of boundaries) {
+    it(`${boundary.name} emits one structured JSON error and matching human remediation`, (t) => {
+      const fixture = prepareLocal(t);
+      const before = snapshotFiles(fixture.backlogDir);
+      const json = run(process.execPath, [boundary.script, ...boundary.args], fixture);
+      assert.notEqual(json.status, 0);
+      assert.equal(json.stderr, "");
+      const payload = JSON.parse(json.stdout);
+      assert.deepEqual(Object.keys(payload), ["error"]);
+      assert.deepEqual(payload.error, {
+        code: "TRACKER_CAPABILITY_UNSUPPORTED",
+        tracker: "local",
+        capability: boundary.capability,
+        message: `Tracker "local" does not support capability "${boundary.capability}".`,
+        remediation: `Use tracker "local" without "${boundary.capability}", or explicitly change backlog/config.yml to a tracker that supports it before retrying. No tracker switch was attempted.`,
+      });
+
+      const humanArgs = boundary.args.filter((arg) => arg !== "--json");
+      const human = run(process.execPath, [boundary.script, ...humanArgs], fixture);
+      assert.notEqual(human.status, 0);
+      assert.match(human.stderr, new RegExp(escapeRegExp(payload.error.remediation)));
+      assert.deepEqual(snapshotFiles(fixture.backlogDir), before, "capability failure must precede side effects");
+      assert.deepEqual(fixture.providerCalls(), [], "capability failure must not call gh");
+      assert.match(fs.readFileSync(path.join(fixture.backlogDir, "config.yml"), "utf8"), /^tracker: local$/m);
+    });
+  }
+});
+
+function snapshotFiles(root) {
+  const snapshot = {};
+  function walk(dir, relative = "") {
+    for (const name of fs.readdirSync(dir).sort()) {
+      const full = path.join(dir, name);
+      const key = path.join(relative, name);
+      const stat = fs.lstatSync(full);
+      if (stat.isDirectory()) walk(full, key);
+      else snapshot[key] = fs.readFileSync(full).toString("base64");
+    }
+  }
+  walk(root);
+  return snapshot;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/skills/dev-backlog/scripts/tracker-cycle.acceptance.test.js
+++ b/skills/dev-backlog/scripts/tracker-cycle.acceptance.test.js
@@ -92,8 +92,13 @@ fs.appendFileSync(logPath, JSON.stringify(args) + "\\n");
 const save = () => fs.writeFileSync(statePath, JSON.stringify(state));
 const valueAfter = (flag) => args[args.indexOf(flag) + 1];
 const out = (value) => process.stdout.write(typeof value === "string" ? value : JSON.stringify(value));
+const exact = (expected) => JSON.stringify(args) === JSON.stringify(expected);
+const exactBodyCall = (head) =>
+  args.length === head.length + 2 &&
+  exact([...head, "--body", args[args.length - 1]]) &&
+  typeof args[args.length - 1] === "string";
 
-if (args[0] === "issue" && args[1] === "create") {
+if (exactBodyCall(["issue", "create", "--title", args[3]]) && args[3]) {
   const title = valueAfter("--title");
   const body = valueAfter("--body") || "";
   if (title.startsWith("Sprint mirror:")) {
@@ -114,29 +119,34 @@ if (args[0] === "issue" && args[1] === "create") {
 }
 
 if (args[0] === "issue" && args[1] === "list") {
-  if (args.includes("--milestone")) {
+  if (exact(["issue", "list", "--milestone", "Cycle Milestone", "--state", "open", "--json", "number,title,labels"])) {
     out(state.issues.filter((issue) => issue.state === "open").map(({ number, title, labels }) => ({ number, title, labels })));
-  } else if (args.includes("dev-backlog:sprint-mirror in:body")) {
+  } else if (exact(["issue", "list", "--state", "all", "--search", "dev-backlog:sprint-mirror in:body", "--json", "number,body", "--limit", "50"])) {
     out(state.mirror ? [state.mirror] : []);
-  } else if (args.includes("--search") && String(valueAfter("--search")).includes("Progress:")) {
+  } else if (/^Progress: (May|June|July) 2026$/.test(String(valueAfter("--search")).replace(/^\"|\" in:title$/g, "")) &&
+      exact(["issue", "list", "--state", "all", "--search", valueAfter("--search"), "--json", "number,title,body", "--limit", "50"])) {
     const title = String(valueAfter("--search")).replace(/^\"|\" in:title$/g, "");
     out(state.progress[title] ? [state.progress[title]] : []);
-  } else {
+  } else if (exact(["issue", "list", "--state", "open", "--limit", "1", "--json", "number,title,body,labels,milestone,assignees"]) ||
+      exact(["issue", "list", "--state", "closed", "--limit", "20", "--json", "number,title,body,labels,milestone,assignees,createdAt,updatedAt"])) {
     out(state.issues.filter((issue) => {
       const requested = valueAfter("--state") || "open";
       return requested === "all" || issue.state === requested;
     }));
+  } else {
+    process.stderr.write("unhandled fake gh argv: " + JSON.stringify(args) + "\\n"); process.exit(93);
   }
   process.exit(0);
 }
 
-if (args[0] === "issue" && args[1] === "view") {
+if (exact(["issue", "view", "42", "--json", "number,title,body,labels,milestone,assignees,createdAt,updatedAt"])) {
   const issue = state.issues.find((candidate) => String(candidate.number) === args[2]);
   if (!issue) process.exit(4);
   out(issue); process.exit(0);
 }
 
-if (args[0] === "issue" && args[1] === "edit") {
+if (exact(["issue", "edit", "42", "--title", "Cycle task renamed"]) ||
+    exactBodyCall(["issue", "edit", "84"]) || exactBodyCall(["issue", "edit", "90"])) {
   const number = Number(args[2]);
   if (number === 84 && state.mirror) state.mirror.body = valueAfter("--body");
   else if (number === 90) {
@@ -150,37 +160,39 @@ if (args[0] === "issue" && args[1] === "edit") {
   save(); process.exit(0);
 }
 
-if (args[0] === "issue" && args[1] === "close") {
+if (exact(["issue", "close", "42"])) {
   const issue = state.issues.find((candidate) => String(candidate.number) === args[2]);
   if (issue) issue.state = "closed";
   save(); process.exit(0);
 }
 
-if (args[0] === "pr" && args[1] === "list" && valueAfter("--state") === "open") {
+if (exact(["pr", "list", "--state", "open", "--json", "number,title", "--limit", "100"])) {
   out([{ number: 98, title: "Open cycle PR" }]); process.exit(0);
 }
-if (args[0] === "pr" && args[1] === "list" && valueAfter("--state") === "merged") {
+if (exact(["pr", "list", "--state", "merged", "--search", "merged:>=2026-06-01 merged:<2026-07-01", "--json", "number,title,url,mergedAt,closingIssuesReferences", "--limit", "200"])) {
   out([{ number: 99, title: "Merged cycle PR", url: "https://github.test/acme/widgets/pull/99",
     mergedAt: "2026-06-15T00:00:00Z", closingIssuesReferences: [{ number: 42 }] }]);
   process.exit(0);
 }
 
-if (args[0] === "api" && args[1] === "repos/{owner}/{repo}/milestones" && args.includes("--jq")) {
+if (exact(["api", "repos/{owner}/{repo}/milestones", "--jq", '.[] | select(.title==env.MS) | .due_on']) ||
+    exact(["api", "repos/{owner}/{repo}/milestones", "--jq", '.[] | select(.title==env.MS) | .number'])) {
   const query = valueAfter("--jq");
   out(query.includes("due_on") ? "2026-06-30T00:00:00Z\\n" : "7\\n");
   process.exit(0);
 }
-if (args[0] === "api" && args[1] === "-X" && args[2] === "PATCH" && args[3].endsWith("/milestones/7")) {
+if (exact(["api", "-X", "PATCH", "repos/{owner}/{repo}/milestones/7", "-f", "state=closed"])) {
   state.milestoneClosed = true; save(); process.exit(0);
 }
-if (args[0] === "api" && args[1] === "repos/{owner}/{repo}/issues/90/comments" && args.includes("--paginate")) {
+if (exact(["api", "repos/{owner}/{repo}/issues/90/comments", "--paginate"])) {
   out(state.comments); process.exit(0);
 }
-if (args[0] === "api" && args[1] === "repos/{owner}/{repo}/issues/90/comments" && valueAfter("--method") === "POST") {
+if (args.length === 6 && exact(["api", "repos/{owner}/{repo}/issues/90/comments", "--method", "POST", "--field", args[5]]) &&
+    String(args[5]).startsWith("body=")) {
   state.comments.push({ id: 501, body: valueAfter("--field").slice("body=".length) });
   save(); process.exit(0);
 }
-if (args[0] === "api" && args[1] === "repos/{owner}/{repo}/issues/90" && valueAfter("--method") === "PATCH") {
+if (exact(["api", "repos/{owner}/{repo}/issues/90", "--method", "PATCH", "--field", "state=closed"])) {
   const entry = Object.values(state.progress).find((candidate) => candidate.number === 90);
   if (entry) entry.state = "closed";
   save(); process.exit(0);
@@ -342,6 +354,15 @@ function runGithubCycle(fixture) {
   assert.equal(progress.summary.inFlight, 1);
   assert.equal(progress.comments.created, 1);
   assert.equal(progress.closed, true);
+  assert.equal(progress.body, [
+    "<!-- dev-backlog:progress-issue month=2026-06 -->", "",
+    "# Progress: June 2026", "", "## Summary", "",
+    "| Metric | Count |", "| --- | --- |", "| Merged PRs (month) | 1 |",
+    "| In-flight (open PRs) | 1 |", "| Stuck candidates | 0 |", "",
+    "## Month End", "", `- Finalized on: ${progress.finalizedAt}`,
+    "- State: closed", "", "## Active Sprint", "",
+    "**2026-07-cycle.md** — 0/1 done, 0 in-flight, 1 remaining", "",
+  ].join("\n"));
 
   const originalBody = fs.readFileSync(taskPath, "utf8").slice(fs.readFileSync(taskPath, "utf8").indexOf("\n## Description"));
   runWorker(fixture, "update", { selector: "#42", changes: { title: "Cycle task renamed" } });
@@ -359,50 +380,94 @@ function runGithubCycle(fixture) {
   assert.equal(runWorker(fixture, "read", { selector: "#42" }).state, "closed");
 
   assert.equal(fs.readFileSync(configPath, "utf8"), fixture.legacyConfig, "legacy config must not migrate");
+  const mergeComment = [
+    "<!-- dev-backlog:progress-comment id=2026-06/merge/pr-99 -->",
+    "**Merged:** [#99](https://github.test/acme/widgets/pull/99) — Merged cycle PR",
+    "- Task: #42",
+    "- Landed: 2026-06-15 00:00 UTC",
+  ].join("\n");
   const calls = fixture.providerCalls();
-  const has = (expected) => calls.some((actual) => JSON.stringify(actual) === JSON.stringify(expected));
-  assert.ok(has(["issue", "create", "--title", "Cycle task", "--body", body]));
-  assert.ok(has(["issue", "view", "42", "--json", "number,title,body,labels,milestone,assignees,createdAt,updatedAt"]));
-  assert.ok(has(["issue", "edit", "42", "--title", "Cycle task renamed"]));
-  assert.ok(has(["issue", "close", "42"]));
-  assert.ok(has(["issue", "list", "--milestone", "Cycle Milestone", "--state", "open", "--json", "number,title,labels"]));
-  assert.ok(has(["api", "-X", "PATCH", "repos/{owner}/{repo}/milestones/7", "-f", "state=closed"]));
-  assert.ok(calls.some((args) => args[0] === "pr" && args[1] === "list" && args.includes("merged")));
-  assert.ok(calls.some((args) => args[0] === "api" && args[1].endsWith("/issues/90/comments") && args.includes("POST")));
-  assert.equal(fixture.providerState().milestoneClosed, true);
+  const mirrorCreateBody = calls[6]?.[5];
+  const mirrorUpdateBody = calls[8]?.[4];
+  const mirrorBodyPattern = /^<!-- dev-backlog:sprint-mirror sprint=2026-07-cycle -->\n\n> The local sprint file is canonical\. This mirror is read-only — it is\n> not edited by hand — and sync is always explicit; there is no daemon\.\n\n## Goal\n\n\[One sentence: what's true when this sprint is done\]\n\n## Plan\n\n- \[ \] #42 Cycle task\n\n## Latest Progress\n\n_No progress recorded yet\._\n\nLast explicit sync: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+  assert.match(mirrorCreateBody, mirrorBodyPattern);
+  assert.match(mirrorUpdateBody, mirrorBodyPattern);
+  assert.deepEqual(calls, [
+    ["issue", "create", "--title", "Cycle task", "--body", body],
+    ["issue", "list", "--state", "open", "--limit", "1", "--json", "number,title,body,labels,milestone,assignees"],
+    ["api", "repos/{owner}/{repo}/milestones", "--jq", '.[] | select(.title==env.MS) | .due_on'],
+    ["issue", "list", "--milestone", "Cycle Milestone", "--state", "open", "--json", "number,title,labels"],
+    ["issue", "view", "42", "--json", "number,title,body,labels,milestone,assignees,createdAt,updatedAt"],
+    ["issue", "list", "--state", "all", "--search", "dev-backlog:sprint-mirror in:body", "--json", "number,body", "--limit", "50"],
+    ["issue", "create", "--title", `Sprint mirror: ${mirrorCreate.sprint}`, "--body", mirrorCreateBody],
+    ["issue", "list", "--state", "all", "--search", "dev-backlog:sprint-mirror in:body", "--json", "number,body", "--limit", "50"],
+    ["issue", "edit", "84", "--body", mirrorUpdateBody],
+    ["pr", "list", "--state", "open", "--json", "number,title", "--limit", "100"],
+    ["pr", "list", "--state", "merged", "--search", "merged:>=2026-06-01 merged:<2026-07-01", "--json", "number,title,url,mergedAt,closingIssuesReferences", "--limit", "200"],
+    ["issue", "list", "--state", "all", "--search", '"Progress: June 2026" in:title', "--json", "number,title,body", "--limit", "50"],
+    ["issue", "list", "--state", "all", "--search", '"Progress: May 2026" in:title', "--json", "number,title,body", "--limit", "50"],
+    ["issue", "list", "--state", "all", "--search", '"Progress: July 2026" in:title', "--json", "number,title,body", "--limit", "50"],
+    ["issue", "create", "--title", "Progress: June 2026", "--body", progress.body],
+    ["api", "repos/{owner}/{repo}/issues/90/comments", "--paginate"],
+    ["api", "repos/{owner}/{repo}/issues/90/comments", "--method", "POST", "--field", `body=${mergeComment}`],
+    ["api", "repos/{owner}/{repo}/issues/90", "--method", "PATCH", "--field", "state=closed"],
+    ["issue", "edit", "42", "--title", "Cycle task renamed"],
+    ["issue", "list", "--state", "open", "--limit", "1", "--json", "number,title,body,labels,milestone,assignees"],
+    ["api", "repos/{owner}/{repo}/milestones", "--jq", '.[] | select(.title==env.MS) | .number'],
+    ["api", "-X", "PATCH", "repos/{owner}/{repo}/milestones/7", "-f", "state=closed"],
+    ["issue", "close", "42"],
+    ["issue", "list", "--state", "closed", "--limit", "20", "--json", "number,title,body,labels,milestone,assignees,createdAt,updatedAt"],
+    ["issue", "view", "42", "--json", "number,title,body,labels,milestone,assignees,createdAt,updatedAt"],
+  ]);
+  assert.deepEqual(fixture.providerState(), {
+    nextIssue: 43,
+    issues: [{
+      number: 42, title: "Cycle task renamed", body, state: "closed",
+      url: "https://github.test/acme/widgets/issues/42",
+      labels: [{ name: "priority:high" }], milestone: { title: "Cycle Milestone" }, assignees: [],
+    }],
+    mirror: { number: 84, title: `Sprint mirror: ${mirrorCreate.sprint}`, body: mirrorUpdateBody },
+    progress: {
+      "Progress: June 2026": {
+        number: 90, title: "Progress: June 2026", body: progress.body, state: "closed",
+      },
+    },
+    comments: [{ id: 501, body: mergeComment }],
+    milestoneClosed: true,
+  });
 }
 
 function runLocalCycle(fixture) {
   const body = "\n## Description\nHuman local body\n\n## Acceptance Criteria\n- [ ] Keep this AC\n";
-  const created = runWorker(fixture, "create", { title: "Offline canonical task", body });
-  assert.deepEqual(created, { tracker: "local", id: "1", ref: "BACK-1" });
-  const taskPath = path.join(fixture.backlogDir, "tasks", "BACK-1 - offline-canonical-task.md");
+  const created = runWorker(fixture, "create", { id: "7.2", title: "Offline canonical task", body });
+  assert.deepEqual(created, { tracker: "local", id: "7.2", ref: "BACK-7.2" });
+  const taskPath = path.join(fixture.backlogDir, "tasks", "BACK-7.2 - offline-canonical-task.md");
   assert.equal(fs.readFileSync(taskPath, "utf8").endsWith(body), true);
 
   const sprintPath = writeLocalSprint(fixture, created);
   const { status, next } = orient(fixture);
   assert.deepEqual(status.plan_items.map(({ tracker, id, ref, issue_number }) => ({ tracker, id, ref, issue_number })), [
-    { tracker: "local", id: "1", ref: "BACK-1", issue_number: null },
+    { tracker: "local", id: "7.2", ref: "BACK-7.2", issue_number: null },
   ]);
-  assert.equal(next.next_batch.items[0].ref, "BACK-1");
-  assert.equal(runWorker(fixture, "read", { selector: "BACK-1" }).body, body);
+  assert.equal(next.next_batch.items[0].ref, "BACK-7.2");
+  assert.equal(runWorker(fixture, "read", { selector: "BACK-7.2" }).body, body);
 
   const bodyBefore = fs.readFileSync(taskPath, "utf8").slice(fs.readFileSync(taskPath, "utf8").indexOf("\n## Description"));
-  runWorker(fixture, "update", { selector: "BACK-1", changes: { status: "In Progress" } });
+  runWorker(fixture, "update", { selector: "BACK-7.2", changes: { status: "In Progress" } });
   const afterUpdate = fs.readFileSync(taskPath, "utf8");
   assert.match(afterUpdate, /^status: In Progress$/m);
   assert.equal(afterUpdate.slice(afterUpdate.indexOf("\n## Description")), bodyBefore);
 
-  runWorker(fixture, "close", { selector: "BACK-1" });
-  const archivedPath = path.join(fixture.backlogDir, "completed", "BACK-1 - offline-canonical-task.md");
+  runWorker(fixture, "close", { selector: "BACK-7.2" });
+  const archivedPath = path.join(fixture.backlogDir, "completed", "BACK-7.2 - offline-canonical-task.md");
   assert.equal(fs.existsSync(taskPath), false);
   assert.match(fs.readFileSync(archivedPath, "utf8"), /^status: Done$/m);
   assert.equal(fs.readFileSync(archivedPath, "utf8").slice(fs.readFileSync(archivedPath, "utf8").indexOf("\n## Description")), bodyBefore);
 
   finishSprint(fixture, sprintPath);
   assert.deepEqual(runWorker(fixture, "list", { state: "open" }), []);
-  assert.equal(runWorker(fixture, "list", { state: "closed" })[0].ref, "BACK-1");
-  const finalRead = runWorker(fixture, "read", { selector: "BACK-1" });
+  assert.equal(runWorker(fixture, "list", { state: "closed" })[0].ref, "BACK-7.2");
+  const finalRead = runWorker(fixture, "read", { selector: "BACK-7.2" });
   assert.equal(finalRead.state, "closed");
   assert.equal(finalRead.status, "Done");
   assert.deepEqual(fixture.providerCalls(), [], "local cycle must make zero provider calls");
@@ -438,7 +503,7 @@ describe("typed unsupported-capability contract", () => {
         tracker: "local",
         capability,
         message: `Tracker "local" does not support capability "${capability}".`,
-        remediation: `Use tracker "local" without "${capability}", or explicitly change backlog/config.yml to a tracker that supports it before retrying. No tracker switch was attempted.`,
+        remediation: `Use tracker "local" without "${capability}", or explicitly change ${path.join(fixture.backlogDir, "config.yml")} to a tracker that supports it before retrying. No tracker switch was attempted.`,
       });
       assert.deepEqual(fixture.providerCalls(), []);
     });
@@ -447,16 +512,17 @@ describe("typed unsupported-capability contract", () => {
 
 describe("unsupported capability public CLI boundaries", () => {
   const boundaries = [
-    { name: "sprint-init", script: SPRINT_INIT_PATH, args: ["blocked", "--json"], capability: "milestones" },
-    { name: "sprint-mirror", script: SPRINT_MIRROR_PATH, args: ["backlog", "--json"], capability: "mirrors" },
-    { name: "progress-sync", script: PROGRESS_SYNC_PATH, args: ["--month", "2026-06", "--json"], capability: "progress-issues" },
+    { name: "sprint-init", script: SPRINT_INIT_PATH, args: () => ["blocked", "--json"], capability: "milestones", configPath: () => "backlog/config.yml" },
+    { name: "sprint-mirror", script: SPRINT_MIRROR_PATH, args: (fixture) => [fixture.backlogDir, "--json"], capability: "mirrors", configPath: (fixture) => path.join(fixture.backlogDir, "config.yml") },
+    { name: "progress-sync", script: PROGRESS_SYNC_PATH, args: () => ["--month", "2026-06", "--json"], capability: "progress-issues", configPath: () => "backlog/config.yml" },
   ];
 
   for (const boundary of boundaries) {
     it(`${boundary.name} emits one structured JSON error and matching human remediation`, (t) => {
       const fixture = prepareLocal(t);
       const before = snapshotFiles(fixture.backlogDir);
-      const json = run(process.execPath, [boundary.script, ...boundary.args], fixture);
+      const boundaryArgs = boundary.args(fixture);
+      const json = run(process.execPath, [boundary.script, ...boundaryArgs], fixture);
       assert.notEqual(json.status, 0);
       assert.equal(json.stderr, "");
       const payload = JSON.parse(json.stdout);
@@ -466,10 +532,10 @@ describe("unsupported capability public CLI boundaries", () => {
         tracker: "local",
         capability: boundary.capability,
         message: `Tracker "local" does not support capability "${boundary.capability}".`,
-        remediation: `Use tracker "local" without "${boundary.capability}", or explicitly change backlog/config.yml to a tracker that supports it before retrying. No tracker switch was attempted.`,
+        remediation: `Use tracker "local" without "${boundary.capability}", or explicitly change ${boundary.configPath(fixture)} to a tracker that supports it before retrying. No tracker switch was attempted.`,
       });
 
-      const humanArgs = boundary.args.filter((arg) => arg !== "--json");
+      const humanArgs = boundaryArgs.filter((arg) => arg !== "--json");
       const human = run(process.execPath, [boundary.script, ...humanArgs], fixture);
       assert.notEqual(human.status, 0);
       assert.match(human.stderr, new RegExp(escapeRegExp(payload.error.remediation)));

--- a/skills/dev-backlog/scripts/tracker-status-list.js
+++ b/skills/dev-backlog/scripts/tracker-status-list.js
@@ -4,13 +4,13 @@ const { readConfig } = require("./lib.js");
 const { resolveConfiguredTracker } = require("./tracker.js");
 
 function listStatusRows(backlogDir = "backlog", { execFile } = {}) {
-  const resolved = resolveConfiguredTracker(readConfig(backlogDir), { execFile });
+  const resolved = resolveConfiguredTracker(readConfig(backlogDir), { execFile, backlogDir });
   return resolved.adapter.list({
     state: "open",
     limit: 20,
     fields: "number,title,labels,milestone",
   }).map((task) => [
-    task.number,
+    task.number ?? task.ref,
     task.milestone?.title || "-",
     task.title,
     (task.labels || []).map((label) => typeof label === "string" ? label : label.name).join(","),

--- a/skills/dev-backlog/scripts/tracker.js
+++ b/skills/dev-backlog/scripts/tracker.js
@@ -7,6 +7,7 @@
 
 const { createGithubAdapter } = require("./github-tracker.js");
 const { createLocalAdapter } = require("./local-tracker.js");
+const path = require("path");
 
 const TRACKER_KEYS = Object.freeze(["github", "local"]);
 const REQUIRED_ADAPTER_OPERATIONS = Object.freeze([
@@ -69,7 +70,7 @@ class TrackerUnavailableError extends Error {
 }
 
 class UnsupportedTrackerCapabilityError extends Error {
-  constructor(tracker, capability) {
+  constructor(tracker, capability, configPath = path.join(DEFAULT_BACKLOG_DIR, "config.yml")) {
     super(`Tracker "${tracker}" does not support capability "${capability}".`);
     this.name = "UnsupportedTrackerCapabilityError";
     this.code = UNSUPPORTED_CAPABILITY_CODE;
@@ -77,7 +78,7 @@ class UnsupportedTrackerCapabilityError extends Error {
     this.capability = capability;
     this.remediation =
       `Use tracker "${tracker}" without "${capability}", or explicitly change ` +
-      "backlog/config.yml to a tracker that supports it before retrying. " +
+      `${configPath} to a tracker that supports it before retrying. ` +
       "No tracker switch was attempted.";
   }
 }
@@ -210,7 +211,11 @@ function resolveConfiguredTracker(config, { execFile, adapters, backlogDir } = {
     github: execFile ? createGithubAdapter({ execFile }) : TRACKER_ADAPTERS.github,
     local: backlogDir ? createLocalAdapter({ backlogDir }) : TRACKER_ADAPTERS.local,
   };
-  return resolveTracker(config, { adapters: registered });
+  const resolved = resolveTracker(config, { adapters: registered });
+  return Object.freeze({
+    ...resolved,
+    configPath: path.join(backlogDir || DEFAULT_BACKLOG_DIR, "config.yml"),
+  });
 }
 
 function validateIdentity(identity) {
@@ -301,7 +306,11 @@ function invokeCapability(resolved, capability, operation, ...args) {
 
   const supported = readCapabilities(resolved.tracker, resolved.adapter);
   if (!supported.includes(capability)) {
-    throw new UnsupportedTrackerCapabilityError(resolved.tracker, capability);
+    throw new UnsupportedTrackerCapabilityError(
+      resolved.tracker,
+      capability,
+      resolved.configPath
+    );
   }
   return operation(...args);
 }

--- a/skills/dev-backlog/scripts/tracker.js
+++ b/skills/dev-backlog/scripts/tracker.js
@@ -26,6 +26,7 @@ const CAPABILITY_NAMES = Object.freeze([
   "comments",
   "closing-semantics",
 ]);
+const UNSUPPORTED_CAPABILITY_CODE = "TRACKER_CAPABILITY_UNSUPPORTED";
 
 const DEFAULT_BACKLOG_DIR = "backlog";
 
@@ -71,9 +72,41 @@ class UnsupportedTrackerCapabilityError extends Error {
   constructor(tracker, capability) {
     super(`Tracker "${tracker}" does not support capability "${capability}".`);
     this.name = "UnsupportedTrackerCapabilityError";
+    this.code = UNSUPPORTED_CAPABILITY_CODE;
     this.tracker = tracker;
     this.capability = capability;
+    this.remediation =
+      `Use tracker "${tracker}" without "${capability}", or explicitly change ` +
+      "backlog/config.yml to a tracker that supports it before retrying. " +
+      "No tracker switch was attempted.";
   }
+}
+
+function serializeTrackerError(error) {
+  if (!(error instanceof UnsupportedTrackerCapabilityError)) return null;
+  return {
+    code: error.code,
+    tracker: error.tracker,
+    capability: error.capability,
+    message: error.message,
+    remediation: error.remediation,
+  };
+}
+
+function writeTrackerCliError(error, {
+  json = false,
+  stdout = process.stdout,
+  stderr = process.stderr,
+  prefix = "",
+} = {}) {
+  const serialized = serializeTrackerError(error);
+  if (!serialized) return false;
+  if (json) {
+    stdout.write(`${JSON.stringify({ error: serialized })}\n`);
+  } else {
+    stderr.write(`${prefix}${serialized.message}\n${serialized.remediation}\n`);
+  }
+  return true;
 }
 
 function renderValue(value) {
@@ -282,12 +315,15 @@ module.exports = {
   TRACKER_KEYS,
   REQUIRED_ADAPTER_OPERATIONS,
   CAPABILITY_NAMES,
+  UNSUPPORTED_CAPABILITY_CODE,
   TRACKER_ADAPTERS,
   TrackerConfigurationError,
   TrackerContractError,
   TrackerIdentityError,
   TrackerUnavailableError,
   UnsupportedTrackerCapabilityError,
+  serializeTrackerError,
+  writeTrackerCliError,
   selectTracker,
   validateAdapter,
   validateIdentity,

--- a/skills/dev-backlog/scripts/tracker.test.js
+++ b/skills/dev-backlog/scripts/tracker.test.js
@@ -340,6 +340,21 @@ describe("local adapter and optional capabilities", () => {
     assert.equal(mutations, 0);
   });
 
+  it("names the selected custom backlog config in unsupported remediation", (t) => {
+    const backlogDir = makeLocalBacklog(t);
+    const resolved = resolveConfiguredTracker({ tracker: "local" }, { backlogDir });
+
+    assert.throws(
+      () => invokeCapability(resolved, "mirrors", () => undefined),
+      (error) => {
+        assert.ok(error instanceof UnsupportedTrackerCapabilityError);
+        assert.ok(error.remediation.includes(path.join(backlogDir, "config.yml")));
+        assert.equal(error.remediation.includes("change backlog/config.yml"), false);
+        return true;
+      }
+    );
+  });
+
   it("invokes a supported capability only after the gate succeeds", () => {
     const resolved = {
       tracker: "github",

--- a/spec/capabilities.md
+++ b/spec/capabilities.md
@@ -39,6 +39,9 @@ The former `spec-charter`, `spec-system-map`, and `spec-grill` capability blocks
 - 2026-07-11 (Sprint tracker-seam, PRs #271/#280/#282/#284/#286): Configured tracker resolution must never use availability failure to choose another store; missing configuration is a stable GitHub compatibility rule, while explicit local remains unavailable until persistence lands.
 - 2026-07-11 (PR #284): Exact task-ref matching needs tests for numeric collisions, decimal descendants, punctuation, alphanumeric suffixes, hyphenated foreign prefixes, and numeric slugs; visual regex review missed several of these boundaries.
 - 2026-07-11 (PR #286): Moving GitHub calls behind a provider seam must preserve marker ownership in dry-run as well as apply mode, keep injection/argv/output compatibility, and confine direct `gh` calls to the lifecycle adapter or explicit capability transports.
+- 2026-07-11 (PR #298): A canonical local Markdown store needs exact-ID allocation across active and completed tasks, fail-closed filesystem boundaries, metadata-only body preservation, and crash-recoverable archive semantics; merely replacing `gh` commands is not sufficient.
+- 2026-07-12 (PR #301): Setup must treat tracker-less repositories as legacy GitHub authority, pin before an explicit switch, preserve user YAML bytes, and never use provider evidence as runtime selection or migration authority.
+- 2026-07-12 (#278 implementation proof): One table-driven subprocess matrix can freeze the legacy GitHub cycle and prove the offline local cycle; optional-feature failures need one typed serializer so JSON and human boundaries carry identical remediation before effects.
 <!-- LEARN:END -->
 
 ### Decisions

--- a/spec/system-map.md
+++ b/spec/system-map.md
@@ -2,115 +2,101 @@
 
 ## System Shape
 
-dev-backlog is a skill suite plus deterministic helper scripts. The current
-runtime uses GitHub Issues as the canonical task source; local Markdown files
-provide execution context for humans and coding agents.
+dev-backlog is a skill suite plus deterministic Node/Bash helpers. One
+configuration value selects canonical task truth; sprint Markdown remains the
+shared execution hub in both modes.
 
 ```text
-GitHub Issues
-  -> gh CLI explicit sync
-  -> backlog/tasks/ thin mirror
-  -> backlog/sprints/ active execution hub
-  -> humans / Claude Code / Codex
+backlog/config.yml: tracker
+        |
+        v
+tracker.js (configured-only resolve, availability, capability gate)
+        |
+        +-- github-tracker.js -> gh -> GitHub Issues (canonical)
+        |                         `-> backlog/tasks/ derived mirrors
+        |
+        `-- local-tracker.js  -> backlog/tasks/ active canonical tasks
+                                  backlog/completed/ closed canonical tasks
 
-backlog/sprints/ (canonical, committed at explicit boundaries)
-  -> sprint-state.js JSON  (status.sh --json / next.sh --json)
-  -> backlog-doctor verdict (aggregated health, hard/soft severity)
-  -> any actor: human, relay executor, external loop, analyzer
-  -> sprint-mirror.js -> machine-managed GitHub mirror issue (read-only surface)
-
-spec/
-  charter.md       project yardstick
-  system-map.md    project structure map
-  capabilities.md  capability contracts
+backlog/sprints/ (canonical execution hub)
+        +-> sprint-state.js -> status.sh --json / next.sh --json
+        +-> backlog-doctor.js
+        `-> capability-gated GitHub mirror/progress transports
 ```
 
-### Accepted Target
-
-Issue #270 accepts exactly one explicitly configured canonical tracker per
-repository, initially `github` or `local`. The target seam normalizes only the
-core task lifecycle and stable identity; capability-gated provider features
-remain outside that small interface. This target is not yet the runtime:
-
-```text
-Configured tracker (`github` or `local`)
-  -> tracker task interface + capability report
-  -> canonical or derived backlog/tasks/ files
-  -> unchanged sprint execution hub
-```
+`setup-dev-backlog.js` persists a deliberate `github` or `local` choice. A
+missing key remains GitHub for backward compatibility without rewriting the
+config. Availability failure is never a selection mechanism, and runtime never
+probes or falls back to the other adapter.
 
 ## Runtime Boundaries
 
-- `skills/dev-backlog/` currently owns GitHub-backed sprint execution, task mirrors, and progress helper scripts.
-- Current helper scripts call `gh` directly or through GitHub-specific helper modules; no configured tracker seam exists yet.
-- `skills/backlog-triage/` owns advisory GitHub Issue grooming, charter Alignment reports, and spec-aware Decision Review.
-- The `spec-charter`/`spec-system-map`/`spec-grill` authoring skills ship with craftkit (installed as sibling skills, not in this repo); they own the `spec/charter.md`, `spec/system-map.md`, and `spec/capabilities.md` authoring gates.
-- `spec/` holds durable project specs, not active sprint execution memory.
+- `skills/dev-backlog/scripts/tracker.js` owns configured resolution, the exact seven-operation adapter contract, identity validation, capability discovery/gating, and the shared unsupported-capability error/serializer.
+- `github-tracker.js` owns required GitHub task lifecycle argv/translation. Named GitHub modules own milestones, sprint mirrors, Progress/PR/comments, and other optional transports.
+- `local-tracker.js` owns the canonical local filesystem lifecycle and reports no optional provider capabilities. It never invokes `gh`.
+- `task-ref.js` owns complete `#N` and `{PREFIX}-N[.M]` parsing/rendering. GitHub keeps numeric `issue_number`; local exposes `null` for that compatibility alias.
+- `sprint-state.js` remains the single machine parser of sprint Markdown; `status.sh --json`, `next.sh --json`, mirror rendering, and doctor projections consume its state.
+- `skills/backlog-triage/` owns advisory grooming. Provider enrichment/mutation remains capability-gated and explicit.
+- Craftkit-installed spec authoring skills own human-gated changes to `spec/`; dev-backlog reads those files as optional yardsticks.
 
-The accepted target moves tracker selection, normalized task lifecycle, and
-capability discovery into `skills/dev-backlog/`. Tracker adapters will own
-provider/local mechanics, while sprint execution continues to own only the
-execution hub.
+Detailed adapter mechanics, the pre-seam inventory, and the compatibility matrix
+are single-sourced in [`docs/tracker-adapter-design.md`](../docs/tracker-adapter-design.md).
 
 ## Core Flows
 
-1. **Sync:** `sync-pull.js` mirrors open GitHub Issues into `backlog/tasks/`.
-2. **Plan:** sprint planning reads charter Objectives when present, then writes one active file under `backlog/sprints/`.
-3. **Execute:** agents read the active sprint, update Plan state and Progress, and keep task context local.
-4. **Read (machine):** any actor reads execution state through the JSON surfaces (`status.sh --json` / `next.sh --json`) and one `backlog-doctor` verdict instead of parsing markdown; `sprint-mirror.js` explicitly publishes the active sprint to a machine-managed mirror issue.
-5. **Groom:** `backlog-triage` produces advisory reports with classification, relationships, stale signals, Alignment, and Decision Review; mutations require explicit user action.
-6. **Spec evolve:** the craftkit-installed `spec-charter`, `spec-system-map`, and `spec-grill` skills update durable project specs through their own gates. Sprint close runs `backlog-doctor` and may recommend `spec-charter reassess` (signal-gated, report-only); reassess reports land as dated files under `backlog/triage/`.
-
-The accepted target adds explicit select/probe before sync, changes sync into
-adapter-specific materialization, and capability-gates provider publication.
-Those flows become current only after the dual-mode implementation is merged.
+1. **Setup:** create minimum directories and persist exactly one tracker; never migrate task files.
+2. **Create/read/update/close:** call the configured adapter's required lifecycle and carry normalized `{ tracker, id, ref, url? }` identity.
+3. **Materialize:** GitHub mode explicitly mirrors canonical issues through `sync-pull.js`; local mode already stores canonical Markdown and has no provider sync.
+4. **Plan/orient:** write normalized refs into the active sprint; consume state via `status.sh --json` / `next.sh --json`.
+5. **Complete:** close the canonical task, check the Plan, run `sprint-close.sh`, archive remaining checked task files, and retain sprint history.
+6. **Publish/enrich:** milestones, PR relationships, sprint mirrors, Progress issues, comments, and closing semantics run only when reported. Unsupported requests return the shared typed error before effects.
+7. **Groom/spec:** triage stays advisory by default; doctor/reassess may recommend spec work but do not mutate durable specs automatically.
 
 ## Storage And External Systems
 
-- GitHub Issues: current task source of truth.
-- `backlog/config.yml`: current Backlog.md-compatible task-file configuration; it does not yet persist a tracker selection.
-- Git: versioned local Markdown artifacts and scripts.
-- `gh` CLI: current explicit GitHub read/write bridge.
-- Node.js scripts: deterministic checks and sync helpers.
-- Bash scripts: local workflow wrappers.
+- `backlog/config.yml`: the only tracker-selection authority plus Backlog.md settings.
+- GitHub Issues: canonical task truth only for `tracker: github`.
+- `backlog/tasks/` and `backlog/completed/`: derived GitHub mirrors or canonical local tasks according to the configured mode.
+- `backlog/sprints/`: canonical execution state in both modes, committed at explicit boundaries.
+- `gh`: GitHub-mode bridge only; acceptance tests replace it with an argv recorder and local tests trap it.
+- Git: versioned Markdown, scripts, and durable specs.
 
 ## Project-Wide Invariants
 
-- No hidden server, database, daemon, or background sync.
-- GitHub Issues currently define task intent; sprint files define execution context.
-- The local sprint file is canonical and committed at explicit boundaries; GitHub-side mirrors are derived surfaces.
-- `sprint-state.js` is the single parser of sprint markdown for machine consumers; new tools consume its JSON (see the consumption contract) instead of re-parsing.
-- Automation is report-only toward `spec/*`: doctor and reassess signals recommend; only human-gated `spec-charter amend` / `spec-grill` mutate specs.
-- `spec/charter.md` is canonical; root `CHARTER.md` is legacy fallback only.
-- `spec/capabilities.md` remains compact enough to read at session start.
-- Completed sprint files are immutable history.
+- Exactly one configured adapter owns canonical task truth; no runtime fallback, co-authority, or background sync.
+- Existing tracker-less repositories remain GitHub-backed with zero migration and unchanged `#N`, numeric aliases, mirror bytes, argv, milestones, mirrors, progress, comments, and closing behavior.
+- Local mode implements only the core task lifecycle. It never fabricates provider semantics or URLs.
+- Unsupported optional capabilities have stable code `TRACKER_CAPABILITY_UNSUPPORTED`, tracker, capability, message, and remediation; JSON and human boundaries share that one serializer contract.
+- Sprint files remain the execution hub and completed sprint files are immutable history.
+- Automation is report-only toward `spec/*`; `spec/charter.md` is canonical and root `CHARTER.md` is legacy fallback only.
 
-Accepted target invariants add exactly one explicit and persistent tracker
-selection, no runtime fallback to another adapter, and clear failure for
-unsupported optional capabilities. The target core interface never invents
-milestone, PR-link, mirror, or close-keyword semantics.
+## Executable Evidence
+
+`skills/dev-backlog/scripts/tracker-cycle.acceptance.test.js` proves both full
+cycles with real temporary files and subprocesses, no network, exact GitHub
+compatibility evidence, local zero-provider evidence, body-preserving updates,
+Done archive/final reads, and every optional-capability failure shape. O8/O9
+remain active until this implementation proof is merged and recorded.
 
 ## Accepted Capability Contracts
 
-Accepted capability contracts live in [`capabilities.md`](capabilities.md). Current boundaries are:
-
-- `sprint-execution` - sprint planning, in-flight state, progress context, and active/completed sprint invariants.
-- `tracker-task-truth` - explicit tracker selection, normalized task lifecycle and identity, capability discovery, and provider degradation.
-- `backlog-sync` - explicit canonical-task materialization and optional machine-managed publication without overwriting human-authored content.
-- `triage-grooming` - advisory issue classification, relationships, stale signals, Alignment, Decision Review, and report/apply boundaries.
-- `task-progress-reporting` - monthly GitHub Progress issue synchronization and finalization.
-
-The former `spec-charter`/`spec-system-map`/`spec-grill` capability contracts moved to craftkit with the skills themselves (0.7.0, charter Decision 2026-07-04).
+- `sprint-execution` — plan state, context, progress, and active/completed sprint invariants.
+- `tracker-task-truth` — configured ownership, normalized lifecycle/identity, capability discovery, and deterministic degradation.
+- `backlog-sync` — explicit materialization/publication without overwriting human-authored content.
+- `triage-grooming` — advisory classification, relationships, stale signals, Alignment, and Decision Review.
+- `task-progress-reporting` — capability-gated monthly GitHub Progress synchronization/finalization.
 
 ## Open Boundary Questions
 
-The accepted adapter seam must still prove backward-compatible task references and JSON fields while supporting local canonical IDs. GitLab, Gitea, and Forgejo remain candidates only after the `github`/`local` seam passes the dual-mode sprint-cycle proof. New candidate boundaries should go through `spec-grill`; project-wide structure changes should go through `spec-system-map amend`.
+GitLab, Gitea, and Forgejo remain future candidates after the merged
+`github`/`local` proof. They must fit the same authority and capability rules;
+the current interface does not promise generic provider parity or a published
+tracker-neutral shape.
 
 ## Where To Go Next
 
 - Product direction: [`charter.md`](charter.md)
 - Capability contracts: [`capabilities.md`](capabilities.md)
 - Sprint execution contract: [`../skills/dev-backlog/SKILL.md`](../skills/dev-backlog/SKILL.md)
-- Machine consumption contract and JSON schema: [`../skills/dev-backlog/references/integration-contract.md`](../skills/dev-backlog/references/integration-contract.md)
-- Tracker adapter contract and GitHub compatibility inventory: [`../docs/tracker-adapter-design.md`](../docs/tracker-adapter-design.md)
-- Spec-system rationale: [`../docs/spec-system-design.md`](../docs/spec-system-design.md)
+- Actor/JSON contract: [`../skills/dev-backlog/references/integration-contract.md`](../skills/dev-backlog/references/integration-contract.md)
+- Adapter compatibility/proof: [`../docs/tracker-adapter-design.md`](../docs/tracker-adapter-design.md)


### PR DESCRIPTION
## Summary

- add one table-driven acceptance matrix that proves the full GitHub and offline local tracker cycles
- freeze legacy GitHub argv, mirror/progress state, local decimal refs, archive behavior, and zero-provider authority
- provide one structured unsupported-capability contract with custom-backlog remediation
- align the README, skill references, tracker design, and governed spec surfaces with the executable runtime
- make human status honor configured custom local stores

## Verification

- `node --test skills/*/scripts/*.test.js` — 652 passed, 1 pre-existing opt-in skip
- `bash skills/dev-backlog/scripts/smoke-test.sh` — 157/157 passed
- objectives, component, capabilities, and backlog validators passed
- `NPM_CONFIG_CACHE=/tmp/dev-backlog-npm-cache npx --yes skills add . -l` found exactly 2 skills
- `git diff --check` passed
- fresh independent hardened code review: LGTM, no actionable findings

## Review assurance note

The retained relay run preserves the hardened advisory attempts. OpenCode timed out on the large review payload, Cline did not emit its required structured result event, and the authenticated Pi/OpenCode-Go route returned its weekly usage-limit response. These provider failures made no source changes. Publication proceeds under operator recovery with the independent code review and the full deterministic gate set above; GitHub CI and unresolved-thread checks remain mandatory before merge.

Closes #278


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * GitHub 또는 로컬 트래커를 선택해 작업의 기준 저장소로 사용할 수 있습니다.
  * 스프린트 계획과 작업 참조가 두 트래커 모드에서 일관되게 처리됩니다.
  * 트래커에서 지원하지 않는 기능은 표준 JSON 또는 안내 메시지로 명확히 표시됩니다.
* **개선 사항**
  * 초기 설정 및 상태 조회가 선택된 트래커에 맞춰 동작합니다.
  * 로컬 모드에서는 오프라인 작업과 파일 기반 작업 관리를 지원합니다.
* **문서**
  * 설정, 작업 흐름, 파일 형식, 트래커 연동 및 검증 절차를 전반적으로 업데이트했습니다.
* **테스트**
  * GitHub·로컬 모드의 전체 작업 주기와 오류 처리를 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->