### PR TITLE
feat(dev-backlog): Phase 1c — backlog-doctor scope-disjointness (#293)

### DIFF
--- a/skills/dev-backlog/scripts/backlog-doctor.js
+++ b/skills/dev-backlog/scripts/backlog-doctor.js
@@ -13,7 +13,8 @@ const {
   extractSectionLines,
   hasSection,
   parsePlanItem,
-  readSprintState,
+  parseFrontmatter,
+  parseSprintContent,
 } = require("./sprint-state.js");
 const { checkObjectives } = require("./objectives-check.js");
 const {
@@ -24,7 +25,7 @@ const {
   analyzeCapabilities,
   hasHardFailures: hasCapabilityHardFailures,
 } = require("./capabilities-doctor.js");
-const { readConfig } = require("./lib.js");
+const { readConfig, sprintScopeKey, scopesOverlap } = require("./lib.js");
 
 const SCHEMA_VERSION = 1;
 const DEFAULT_BACKLOG_DIR = "backlog";
@@ -157,26 +158,43 @@ function runDoctor({
   const sprintsDir = path.join(backlogPath, "sprints");
   const capabilitiesPath = path.join(root, "spec", "capabilities.md");
 
-  const active = checkActiveSprint({ repoRoot: root, sprintsDir });
-  const sprintState = loadSprintState({
-    activePath: active.detail.active_path,
-    backlogPath,
-    today,
+  const tracks = loadActiveTracks(sprintsDir);
+  const active = checkActiveSprint({ repoRoot: root, sprintsDir, tracks });
+
+  // Per-sprint checks fan out per active track (PRD §5.3): 0 or 1 active keeps
+  // today's single untagged run; N>1 runs each check once per track and tags
+  // the verdict with that track's slug.
+  const trackRuns = tracks.length > 0 ? tracks : [null];
+  const perTrack = trackRuns.map((track) => {
+    const activePath = track ? track.path : null;
+    const tag = tracks.length > 1 ? track : null;
+    const sprintState = loadSprintState({ activePath, backlogPath, today });
+    return {
+      objectives: tagTrack(checkObjectiveDrift({ repoRoot: root, sprintsDir, activePath }), tag),
+      component_lint: tagTrack(
+        checkComponentRouting({ repoRoot: root, sprintsDir, capabilitiesPath, activePath }),
+        tag,
+      ),
+      sprint_shape: tagTrack(
+        checkSprintShape({ repoRoot: root, backlogPath, activePath, activeStatus: active.status }),
+        tag,
+      ),
+      in_flight_trace: tagTrack(checkInFlightTrace({ sprintState, activeStatus: active.status }), tag),
+      in_flight_staleness: tagTrack(
+        checkInFlightStaleness({ sprintState, activeStatus: active.status, staleDays }),
+        tag,
+      ),
+    };
   });
 
   const checks = [
     active,
-    checkObjectiveDrift({ repoRoot: root, sprintsDir, activePath: active.detail.active_path }),
-    checkComponentRouting({ repoRoot: root, sprintsDir, capabilitiesPath, activePath: active.detail.active_path }),
+    ...perTrack.map((run) => run.objectives),
+    ...perTrack.map((run) => run.component_lint),
     checkCapabilities({ repoRoot: root, capabilitiesPath }),
-    checkSprintShape({
-      repoRoot: root,
-      backlogPath,
-      activePath: active.detail.active_path,
-      activeStatus: active.status,
-    }),
-    checkInFlightTrace({ sprintState, activeStatus: active.status }),
-    checkInFlightStaleness({ sprintState, activeStatus: active.status, staleDays }),
+    ...perTrack.map((run) => run.sprint_shape),
+    ...perTrack.map((run) => run.in_flight_trace),
+    ...perTrack.map((run) => run.in_flight_staleness),
     checkContextBloat({ repoRoot: root, sprintsDir, threshold: contextLineThreshold }),
   ];
 
@@ -213,14 +231,80 @@ function listSprintFiles(sprintsDir) {
     .sort();
 }
 
-function checkActiveSprint({ repoRoot, sprintsDir }) {
+// Active sprint files as track records: path + slug + parsed frontmatter, in
+// portfolio order (`started:` ascending per D4, filename as a stable tiebreaker
+// — same ordering as sprint-state.js).
+function loadActiveTracks(sprintsDir) {
+  return findActiveSprintFiles(sprintsDir)
+    .map((filePath) => ({
+      path: filePath,
+      slug: path.basename(filePath, ".md"),
+      frontmatter: parseFrontmatter(fs.readFileSync(filePath, "utf-8")),
+    }))
+    .sort(compareTracks);
+}
+
+function compareTracks(a, b) {
+  const sa = a.frontmatter.started || "";
+  const sb = b.frontmatter.started || "";
+  if (sa !== sb) return sa < sb ? -1 : 1;
+  return a.path < b.path ? -1 : 1;
+}
+
+function firstOverlappingTrackPair(tracks) {
+  for (let i = 0; i < tracks.length; i += 1) {
+    for (let j = i + 1; j < tracks.length; j += 1) {
+      if (scopesOverlap(tracks[i].frontmatter, tracks[j].frontmatter)) {
+        return [tracks[i], tracks[j]];
+      }
+    }
+  }
+  return null;
+}
+
+// N>1 only: tag a per-sprint verdict with the track it belongs to.
+function tagTrack(check, track) {
+  if (!track) return check;
+  return { ...check, track: track.slug };
+}
+
+function checkActiveSprint({ repoRoot, sprintsDir, tracks = loadActiveTracks(sprintsDir) }) {
   const sprintFiles = listSprintFiles(sprintsDir);
-  const activeFiles = findActiveSprintFiles(sprintsDir);
+  const activeFiles = tracks.map((track) => track.path);
   const displayActive = activeFiles.map((file) => displayPath(repoRoot, file));
 
-  if (activeFiles.length > 1) {
-    return verdict("active_sprint", "fail", {
-      summary: `Multiple active sprint files found (${activeFiles.length}).`,
+  if (tracks.length > 1) {
+    const overlap = firstOverlappingTrackPair(tracks);
+    if (overlap) {
+      const [a, b] = overlap;
+      return verdict("active_sprint", "fail", {
+        summary: `Active tracks overlap on scope: ${displayPath(repoRoot, a.path)} ∩ ${displayPath(repoRoot, b.path)}. Give them disjoint component:/scope: or close one before continuing.`,
+        active_files: displayActive,
+        overlapping_files: [displayPath(repoRoot, a.path), displayPath(repoRoot, b.path)],
+        sprint_count: sprintFiles.length,
+        active_path: null,
+      });
+    }
+
+    const scopeless = tracks.filter((track) => sprintScopeKey(track.frontmatter).kind === "none");
+    if (scopeless.length >= 2) {
+      // informational: scopeless tracks cannot be proven disjoint, but cannot
+      // be proven overlapping either; like the between-sprints zero-active
+      // state this stays out of the reassess-signal warn count.
+      return {
+        ...verdict("active_sprint", "warn", {
+          summary: `${tracks.length} active tracks, ${scopeless.length} without component:/scope:; cannot prove disjoint. Declare component: or scope: on each track.`,
+          active_files: displayActive,
+          scopeless_files: scopeless.map((track) => displayPath(repoRoot, track.path)),
+          sprint_count: sprintFiles.length,
+          active_path: null,
+        }),
+        informational: true,
+      };
+    }
+
+    return verdict("active_sprint", "pass", {
+      summary: `${tracks.length} active tracks, scopes disjoint.`,
       active_files: displayActive,
       sprint_count: sprintFiles.length,
       active_path: null,
@@ -384,11 +468,19 @@ function checkCapabilities({ repoRoot, capabilitiesPath }) {
   }
 }
 
+// Parse one track's sprint file directly (not via readSprintState, whose
+// no-selector read is portfolio-global and fails loud on overlapping tracks;
+// the doctor reports overlap itself via the active_sprint verdict).
 function loadSprintState({ activePath, backlogPath, today }) {
   if (!activePath) return { state: null, error: null };
   try {
     return {
-      state: readSprintState({ backlogDir: backlogPath, today }),
+      state: parseSprintContent({
+        sprintPath: activePath,
+        content: fs.readFileSync(activePath, "utf-8"),
+        today,
+        taskPrefix: readConfig(backlogPath).task_prefix,
+      }),
       error: null,
     };
   } catch (error) {
@@ -741,9 +833,10 @@ function exitCodeFor(report) {
 
 function formatHumanSummary(report) {
   const labels = { pass: "PASS", warn: "WARN", fail: "FAIL" };
-  const lines = report.checks.map((check) => (
-    `[${labels[check.status]}] ${check.name} - ${check.detail.summary}`
-  ));
+  const lines = report.checks.map((check) => {
+    const trackTag = check.track ? ` [${check.track}]` : "";
+    return `[${labels[check.status]}] ${check.name}${trackTag} - ${check.detail.summary}`;
+  });
   lines.push(`Exit hint: ${report.exit_hint}`);
   lines.push(
     `Reassess signal: ${report.reassess_signal.fired ? "fired" : "quiet"} - ${report.reassess_signal.reason}`,

--- a/skills/dev-backlog/scripts/backlog-doctor.test.js
+++ b/skills/dev-backlog/scripts/backlog-doctor.test.js
@@ -71,11 +71,13 @@ ${sections}
 }
 
 // A sprint whose spec-axis frontmatter keys can each be present-empty, present-
-// valued, or fully omitted (pass no value). Used to exercise the B3 omission paths.
-function sprintNoSpecFields({ objectives, component } = {}) {
+// valued, or fully omitted (pass no value). Used to exercise the B3 omission
+// paths and, via scope:, the multi-track disjointness paths (#293).
+function sprintNoSpecFields({ objectives, component, scope, plan = "- [ ] #1 Ship the health check" } = {}) {
   const fm = ["---", "status: active", "started: 2026-07-03"];
   if (objectives !== undefined) fm.push(`objectives: ${objectives}`);
   if (component !== undefined) fm.push(`component: "${component}"`);
+  if (scope !== undefined) fm.push(`scope: ${scope}`);
   fm.push("---");
   return `${fm.join("\n")}
 
@@ -85,7 +87,7 @@ function sprintNoSpecFields({ objectives, component } = {}) {
 Keep the sprint healthy.
 
 ## Plan
-- [ ] #1 Ship the health check
+${plan}
 
 ## Running Context
 - Follow existing script contracts.
@@ -173,17 +175,97 @@ describe("runDoctor", () => {
       "context_bloat",
     ]);
     assert.ok(formatHumanSummary(report).includes("[PASS] active_sprint"));
+    // G4: a single active track never grows track tags (text and JSON alike).
+    assert.ok(report.checks.every((item) => item.track === undefined));
   });
 
-  it("fails on ambiguous active sprint state", () => {
+  it("fails when two active tracks share the same component (scope overlap, #293)", () => {
     seedCleanRepo(repoRoot);
     write(path.join(repoRoot, "backlog", "sprints", "2026-07-second.md"), sprint());
 
     const report = runDoctor({ repoRoot });
 
     assert.equal(check(report, "active_sprint").status, "fail");
-    assert.match(check(report, "active_sprint").detail.summary, /Multiple active sprint files/);
+    assert.match(check(report, "active_sprint").detail.summary, /Active tracks overlap on scope/);
     assert.equal(exitCodeFor(report), 1);
+  });
+
+  it("passes disjoint-scope active tracks as a portfolio and fans per-sprint checks out per track (#293)", () => {
+    write(
+      path.join(repoRoot, "backlog", "sprints", "2026-07-auth.md"),
+      sprintNoSpecFields({ scope: '["src/auth/**"]' }),
+    );
+    write(
+      path.join(repoRoot, "backlog", "sprints", "2026-07-billing.md"),
+      sprintNoSpecFields({ scope: '["src/billing/**"]' }),
+    );
+
+    const report = runDoctor({ repoRoot, today: new Date("2026-07-03T00:00:00Z") });
+
+    assert.equal(check(report, "active_sprint").status, "pass");
+    assert.match(check(report, "active_sprint").detail.summary, /2 active tracks, scopes disjoint/);
+    assert.equal(exitCodeFor(report), 0);
+
+    for (const name of ["objectives_check", "component_lint", "sprint_shape", "in_flight_trace", "in_flight_staleness"]) {
+      const fanned = report.checks.filter((item) => item.name === name);
+      assert.equal(fanned.length, 2, `${name} should run once per track`);
+      assert.deepEqual(fanned.map((item) => item.track), ["2026-07-auth", "2026-07-billing"]);
+    }
+    assert.match(formatHumanSummary(report), /\[PASS\] sprint_shape \[2026-07-auth\]/);
+  });
+
+  it("tags per-track verdicts so a warn names the track it belongs to (#293)", () => {
+    write(
+      path.join(repoRoot, "backlog", "sprints", "2026-07-auth.md"),
+      sprintNoSpecFields({ scope: '["src/auth/**"]', plan: "- [~] #1 Needs a pointer" }),
+    );
+    write(
+      path.join(repoRoot, "backlog", "sprints", "2026-07-billing.md"),
+      sprintNoSpecFields({ scope: '["src/billing/**"]' }),
+    );
+
+    const report = runDoctor({ repoRoot, today: new Date("2026-07-03T00:00:00Z") });
+
+    const traces = report.checks.filter((item) => item.name === "in_flight_trace");
+    assert.deepEqual(
+      traces.map((item) => [item.track, item.status]),
+      [["2026-07-auth", "warn"], ["2026-07-billing", "pass"]],
+    );
+    assert.equal(exitCodeFor(report), 0);
+  });
+
+  it("fails when active tracks overlap via nested scope globs (#293)", () => {
+    write(
+      path.join(repoRoot, "backlog", "sprints", "2026-07-auth-a.md"),
+      sprintNoSpecFields({ scope: '["src/auth/**"]' }),
+    );
+    write(
+      path.join(repoRoot, "backlog", "sprints", "2026-07-auth-b.md"),
+      sprintNoSpecFields({ scope: '["src/auth/api/**"]' }),
+    );
+
+    const report = runDoctor({ repoRoot });
+
+    assert.equal(check(report, "active_sprint").status, "fail");
+    assert.match(check(report, "active_sprint").detail.summary, /Active tracks overlap on scope/);
+    assert.deepEqual(check(report, "active_sprint").detail.overlapping_files, [
+      "backlog/sprints/2026-07-auth-a.md",
+      "backlog/sprints/2026-07-auth-b.md",
+    ]);
+    assert.equal(exitCodeFor(report), 1);
+  });
+
+  it("warns informationally when two or more active tracks are scopeless (cannot prove disjoint, #293)", () => {
+    write(path.join(repoRoot, "backlog", "sprints", "2026-07-one.md"), sprintNoSpecFields());
+    write(path.join(repoRoot, "backlog", "sprints", "2026-07-two.md"), sprintNoSpecFields());
+
+    const report = runDoctor({ repoRoot, today: new Date("2026-07-03T00:00:00Z") });
+
+    const activeCheck = check(report, "active_sprint");
+    assert.equal(activeCheck.status, "warn");
+    assert.equal(activeCheck.informational, true);
+    assert.match(activeCheck.detail.summary, /cannot prove disjoint/);
+    assert.equal(exitCodeFor(report), 0);
   });
 
   it("warns when existing sprint files contain no active sprint because that is normal between sprints", () => {

--- a/skills/dev-backlog/scripts/smoke-test.sh
+++ b/skills/dev-backlog/scripts/smoke-test.sh
@@ -1154,16 +1154,17 @@ fi
 gated_assert "cold: skills/ carry no required ../spec-charter read (#254/#255 A2/A3)" "$GATE_A2A3" "$A2A3_RES"
 
 # ============================================================
-# multi-track sprints RED gate (PRD 2026-07-multi-track-sprints, #290)
+# multi-track sprints gates (PRD 2026-07-multi-track-sprints, #290)
 # ============================================================
 # Two disjoint-scope sprints may be active at once (a portfolio); overlapping
-# scopes fail with a NEW message. RED against HEAD (single-active only). Flip
-# each gate when its fix lands. NOTE: exit-fail alone is not a valid RED signal
-# for the overlap case — HEAD already fails on ANY two actives with a DIFFERENT
-# message ("Multiple active sprint files found"), so the overlap fixture keys on
-# the new "Active tracks overlap on scope" message, not the exit code (#290 B2).
-GATE_MT_DISJOINT="${GATE_MT_DISJOINT:-0}"  # flip when #291+#293 land: doctor passes on disjoint-scope tracks
-GATE_MT_OVERLAP="${GATE_MT_OVERLAP:-0}"    # flip when #293 lands: doctor emits the scope-overlap message
+# scopes fail with the doctor's scope-overlap message. Born RED at #290;
+# enforced since #293 landed the doctor disjointness rewrite. NOTE: exit-fail
+# alone was never a valid signal for the overlap case — pre-#293 HEAD already
+# failed on ANY two actives with a DIFFERENT message ("Multiple active sprint
+# files found"), so the overlap fixture keys on the active_sprint verdict's
+# "Active tracks overlap on scope" message, not the exit code (#290 B2).
+GATE_MT_DISJOINT="${GATE_MT_DISJOINT:-1}"  # #291+#293 landed: enforced — doctor passes on disjoint-scope tracks
+GATE_MT_OVERLAP="${GATE_MT_OVERLAP:-1}"    # #293 landed: enforced — doctor active_sprint verdict emits the scope-overlap message
 
 # helper: write a minimal, shape-valid active sprint with a given scope
 mt_write_sprint() { # dir file title issue scope_yaml
@@ -1229,6 +1230,60 @@ const summary = (c && c.detail && c.detail.summary) || "";
 process.exit(/Active tracks overlap on scope/.test(summary) ? 0 : 1);
 ' 2>/dev/null; then MT_OVERLAP_RES="pass"; else MT_OVERLAP_RES="fail"; fi
 gated_assert "multi-track: doctor active_sprint verdict emits scope-overlap message (#293 B2)" "$GATE_MT_OVERLAP" "$MT_OVERLAP_RES"
+
+# (2b) #293 enforced extras: a disjoint portfolio is fully healthy (exit 0) and
+#      the per-sprint checks fan out per active track with track-tagged verdicts.
+set +e
+OUT=$(cd "$MT_DISJOINT_DIR" && node "$SCRIPT_DIR/backlog-doctor.js" --json 2>/dev/null)
+STATUS=$?
+set -e
+assert_equals "multi-track #293: doctor exit code on disjoint portfolio" "$STATUS" "0"
+assert_json_eval "multi-track #293: per-sprint checks fan out per track with track tags" "$OUT" '
+const j = JSON.parse(require("fs").readFileSync(0, "utf8"));
+const shapes = (j.checks || []).filter((c) => c.name === "sprint_shape");
+if (shapes.length !== 2) process.exit(1);
+const tags = shapes.map((c) => c.track).sort();
+if (tags[0] !== "2026-07-auth" || tags[1] !== "2026-07-billing") process.exit(1);
+'
+
+# (2c) Two scopeless active tracks: cannot prove disjoint → informational warn,
+#      never a fail (#293; matches the between-sprints informational stance).
+MT_SCOPELESS_DIR="$TEST_DIR/mt-scopeless"
+mkdir -p "$MT_SCOPELESS_DIR/backlog/sprints"
+for slug in one two; do
+  cat > "$MT_SCOPELESS_DIR/backlog/sprints/2026-07-$slug.md" << EOF
+---
+milestone: mt
+status: active
+started: 2026-07-01
+---
+
+# Scopeless $slug
+
+## Goal
+Scopeless $slug done.
+
+## Plan
+- [ ] #9 Scopeless $slug task
+
+## Running Context
+- none
+
+## Progress
+- 2026-07-01: opened.
+EOF
+done
+set +e
+OUT=$(cd "$MT_SCOPELESS_DIR" && node "$SCRIPT_DIR/backlog-doctor.js" --json 2>/dev/null)
+STATUS=$?
+set -e
+assert_equals "multi-track #293: scopeless pair doctor exit code" "$STATUS" "0"
+assert_json_eval "multi-track #293: scopeless pair warns informationally (cannot prove disjoint)" "$OUT" '
+const j = JSON.parse(require("fs").readFileSync(0, "utf8"));
+const c = (j.checks || []).find((x) => x.name === "active_sprint");
+if (!c || c.status !== "warn" || c.informational !== true) process.exit(1);
+if (!/cannot prove disjoint/.test(c.detail.summary)) process.exit(1);
+'
 
 # (3) Back-compat (ENFORCED, GATE=1 — must stay GREEN on HEAD and after Phase 1).
 #     A single active track behaves exactly as today; this is the G4 text anchor


### PR DESCRIPTION
## Summary

Implements **#293 (Phase 1c)** of the multi-track sprints initiative (epic #289, PRD §5.3): the doctor's `active_sprint` check becomes a **scope-disjointness** check, and per-sprint checks fan out per active track.

### active_sprint check rewrite (`backlog-doctor.js`)

| Active tracks | Verdict |
|---|---|
| 0 | unchanged (informational between-sprints warn / pass) |
| 1 | `pass` — exact `Exactly one active sprint …` string retained (G4) |
| N, scopes disjoint | `pass` — `N active tracks, scopes disjoint.` |
| N, scopes overlap | `fail` — `Active tracks overlap on scope: <a> ∩ <b>. …` |
| N, ≥2 scopeless | informational `warn` — cannot prove disjoint; recommends declaring `component:`/`scope:` |

Overlap detection imports the **one shared** `scopesOverlap()` from `lib.js` (no re-implementation), with track ordering matching sprint-state's D4 (`started:` asc, filename tiebreak).

### Per-track fan-out

`objectives_check`, `component_lint`, `sprint_shape`, `in_flight_trace`, and `in_flight_staleness` now run once per active track when N>1, each verdict tagged with its track slug (JSON `track` field; human lines render `check_name [slug]`). A single active track keeps today's single untagged run. `loadSprintState` parses the track's file directly via `parseSprintContent` instead of `readSprintState`, whose no-selector read is portfolio-global and throws `OVERLAPPING_TRACKS` — the doctor reports overlap itself via the verdict.

### Gates flipped (0 xfail)

`GATE_MT_DISJOINT` and `GATE_MT_OVERLAP` default to enforced, plus new smoke coverage: disjoint portfolio exits 0 with track-tagged checks; two scopeless actives warn informationally.

## Verification

- `bash smoke-test.sh` → **172/172 pass, 0 xfail, 0 xpass**
- `node backlog-doctor.test.js` → 30/30 (new: disjoint portfolio, nested-glob overlap, same-component overlap, scopeless informational warn, per-track tagging, single-track no-tag G4 guard)
- All other node suites green; `sprint-init.test.js` #13 is the pre-existing rot slated for #292 (unchanged baseline)
- **G4 byte-identity**: old (`origin/main`) vs new doctor diffed on a single-active fixture — text AND JSON byte-identical, equal exit codes; live-repo (zero-active) output unchanged

Refs #293, #289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)