### PR TITLE
chore: re-add multi-track sprint file as sole active (#289)

### DIFF
--- a/backlog/sprints/2026-07-multi-track-sprints.md
+++ b/backlog/sprints/2026-07-multi-track-sprints.md
@@ -1,0 +1,45 @@
+---
+milestone: 2026-07 multi-track sprints
+status: active
+started: 2026-07-11
+due: TBD
+objectives: [O1]
+component: "sprint-execution"
+---
+
+# multi-track-sprints
+
+## Goal
+Replace the global single-active-sprint invariant with a component-partitioned model — multiple disjoint-scope tracks active at once — with single-track behavior byte-identical. Tracked by epic #289; design in `docs/prd-2026-07-multi-track-sprints.md`. dev-relay coordination is a separate repo epic (`sungjunlee/dev-relay#954`).
+
+## Plan
+
+### Batch 1 — RED gate (test-first)
+- [x] #290 Phase 0: multi-track RED gate — evals + smoke fixtures → PR #297 (merged)
+
+### Batch 2 — Resolver foundation
+- [x] #291 Phase 1a: scope: frontmatter + portfolio-aware read resolvers → PR #300 (merged)
+
+### Batch 3 — Behavior (parallel-safe: disjoint files)
+- [ ] #292 Phase 1b: sprint lifecycle track-awareness (init/close/mirror)
+- [x] #293 Phase 1c: backlog-doctor active_sprint → scope-disjointness check → PR #305 (merged)
+
+### Batch 4 — Spec amendment (HUMAN-GATED)
+- [ ] #294 Phase 1e: amend capabilities.md singleton invariant
+
+### Batch 5 — Docs + contract
+- [ ] #295 Phase 3: docs + integration-contract schema_version → 2
+
+## Running Context
+- Design + decisions frozen in `docs/prd-2026-07-multi-track-sprints.md` (§9 D1–D4 resolved).
+- The singleton is a durable capability contract, not just SKILL prose: `spec/capabilities.md:28` (sprint-execution invariant), `:69` (backlog-sync/sprint-mirror), `:7` (component single-slug). Amendment is human-gated via spec-grill → tracked as #294, which gates the SKILL/process prose flip in #295.
+- Charter O1 ("single execution **state**") is about shared state, not sprint count — compatible with multi-track, but its wording is a candidate for a human-gated clarification alongside #294. Do not silently amend the charter.
+- dev-relay coupling is shallow: the only hard code-level singleton is `append-learnings.js:resolveActiveSprint` (dev-relay#955); the rest is prose (dev-relay#956) + an indirect fleet fail-loud (dev-relay#957). `sprint-close-report.js --sprint <path>` is the agnostic pattern to replicate.
+- Back-compat is the merge gate for Batch 2–3: single-active output must stay byte-identical (PRD G4). The G4 anchor lives in smoke-test.sh (single-track doctor/next.sh text; never snapshot --json).
+- `scopesOverlap()` in `scripts/lib.js` is the ONE overlap predicate — sprint-state and backlog-doctor consume it; #292's sprint-init refusal must import it too, never re-implement.
+- This sprint file was held out of #296 (a second active sprint was still illegal pre-#293) and re-added 2026-07-12 as the sole active after the tracker-adapter sprint closed.
+
+## Progress
+- 2026-07-11: sprint planned. Epic #289 + children #290–#295 filed; dev-relay epic #954 + #955–#957 filed. Design doc landed in docs/ (uncommitted).
+- 2026-07-12: Batches 1–2 landed while the sprint file was held: #290 RED gate (PR #297), #291 Phase 1a resolvers (PR #300) — sprint-state schema 2, portfolio + --track/--component, scopesOverlap in lib.js.
+- 2026-07-12: #293 Phase 1c landed (PR #305) — doctor scope-disjointness with per-track fan-out; GATE_MT_DISJOINT/GATE_MT_OVERLAP enforced, smoke 172/172, 0 xfail; single-active output verified byte-identical. Sprint file re-added as sole active.


### PR DESCRIPTION
Re-adds `backlog/sprints/2026-07-multi-track-sprints.md` (held out of #296 while a second active sprint was still illegal) as the sole active track, now that the tracker-adapter sprint closed. Content from `78981eb`, refreshed: #290/#291/#293 ticked with merged PRs, Running Context carries the shared `scopesOverlap` contract + G4 anchor notes, Progress records the landings.

Live `backlog-doctor` on this branch: all 8 checks PASS, exit hint pass, reassess quiet.

Refs #289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * 2026-07 멀티 트랙 스프린트 운영 계획을 추가했습니다.
  * 컴포넌트별 독립 트랙을 동시에 운영하는 방식과 단일 트랙의 기존 동작 보존 원칙을 정의했습니다.
  * 병렬 처리, 중복 범위 검증, 단계별 진행 항목 및 통합 계약 버전 관리 계획을 정리했습니다.
  * 2026-07-11~12 진행 상황과 완료된 배치 작업을 기록했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->