### PR TITLE
feat(dev-backlog): Phase 1b — sprint lifecycle track-awareness (#292)

### DIFF
--- a/backlog/sprints/2026-07-multi-track-sprints.md
+++ b/backlog/sprints/2026-07-multi-track-sprints.md
@@ -21,7 +21,7 @@ Replace the global single-active-sprint invariant with a component-partitioned m
 - [x] #291 Phase 1a: scope: frontmatter + portfolio-aware read resolvers → PR #300 (merged)
 
 ### Batch 3 — Behavior (parallel-safe: disjoint files)
-- [ ] #292 Phase 1b: sprint lifecycle track-awareness (init/close/mirror)
+- [x] #292 Phase 1b: sprint lifecycle track-awareness (init/close/mirror) → PR #307
 - [x] #293 Phase 1c: backlog-doctor active_sprint → scope-disjointness check → PR #305 (merged)
 
 ### Batch 4 — Spec amendment (HUMAN-GATED)
@@ -43,3 +43,4 @@ Replace the global single-active-sprint invariant with a component-partitioned m
 - 2026-07-11: sprint planned. Epic #289 + children #290–#295 filed; dev-relay epic #954 + #955–#957 filed. Design doc landed in docs/ (uncommitted).
 - 2026-07-12: Batches 1–2 landed while the sprint file was held: #290 RED gate (PR #297), #291 Phase 1a resolvers (PR #300) — sprint-state schema 2, portfolio + --track/--component, scopesOverlap in lib.js.
 - 2026-07-12: #293 Phase 1c landed (PR #305) — doctor scope-disjointness with per-track fan-out; GATE_MT_DISJOINT/GATE_MT_OVERLAP enforced, smoke 172/172, 0 xfail; single-active output verified byte-identical. Sprint file re-added as sole active.
+- 2026-07-12: #292 Phase 1b — sprint-init refuses only on scope overlap (--scope flag, D2 explicit), sprint-close/--track, sprint-mirror/--track; init/close single-track G4 verified byte-identical (text + exit codes + written files); fixed the cwd-dependent sprint-init.test.js #13 rot. Smoke 187/187.

--- a/skills/dev-backlog/scripts/smoke-test.sh
+++ b/skills/dev-backlog/scripts/smoke-test.sh
@@ -1285,6 +1285,72 @@ if (!c || c.status !== "warn" || c.informational !== true) process.exit(1);
 if (!/cannot prove disjoint/.test(c.detail.summary)) process.exit(1);
 '
 
+# --- Phase 1b (#292) ENFORCED: lifecycle track-awareness (init/close) ---
+# init: a disjoint-scope second track is created without refusal; an
+# overlapping scope is refused naming the conflicting track. Scope is always
+# explicit via --scope (D2) — never inferred from touched paths.
+MT_LIFE_DIR="$TEST_DIR/mt-lifecycle"
+mkdir -p "$MT_LIFE_DIR/backlog/sprints"
+mt_write_sprint "$MT_LIFE_DIR/backlog/sprints/2026-07-auth.md" "Auth" 1 '["src/auth/**"]'
+set +e
+OUT=$(cd "$MT_LIFE_DIR" && node "$SCRIPT_DIR/sprint-init.js" "billing" --scope "src/billing/**" --json 2>/dev/null)
+STATUS=$?
+set -e
+assert_equals "multi-track #292: disjoint second-track init exit code" "$STATUS" "0"
+assert_json_eval "multi-track #292: disjoint init creates with scope frontmatter, no warnings" "$OUT" '
+const j = JSON.parse(require("fs").readFileSync(0, "utf8"));
+if (j.created !== true) process.exit(1);
+if (!Array.isArray(j.warnings) || j.warnings.length !== 0) process.exit(1);
+if (!/^scope: \["src\/billing\/\*\*"\]$/m.test(j.content)) process.exit(1);
+'
+
+set +e
+OUT=$(cd "$MT_LIFE_DIR" && node "$SCRIPT_DIR/sprint-init.js" "auth-two" --scope "src/auth/api/**" --dry-run 2>&1)
+STATUS=$?
+set -e
+assert_equals "multi-track #292: overlapping-scope init exit code" "$STATUS" "1"
+assert_contains "multi-track #292: overlapping init names the conflicting track" "$OUT" "Active track overlaps on scope: 2026-07-auth.md"
+
+# G4: first-sprint init (no active sprint yet) keeps today's text and exit code.
+MT_INIT_SOLO_DIR="$TEST_DIR/mt-init-solo"
+mkdir -p "$MT_INIT_SOLO_DIR/backlog/sprints"
+set +e
+OUT=$(cd "$MT_INIT_SOLO_DIR" && node "$SCRIPT_DIR/sprint-init.js" "solo-probe" --dry-run 2>/dev/null)
+STATUS=$?
+set -e
+assert_equals "multi-track G4 #292: single-track init dry-run exit code" "$STATUS" "0"
+assert_contains "multi-track G4 #292: single-track init dry-run text" "$OUT" "[dry-run] Would create:"
+
+# close: --track picks one track out of a portfolio; ambiguous close still
+# refuses (now with a --track hint); a no-match selector fails loud.
+MT_CLOSE_DIR="$TEST_DIR/mt-close"
+mkdir -p "$MT_CLOSE_DIR/backlog/sprints"
+mt_write_sprint "$MT_CLOSE_DIR/backlog/sprints/2026-07-auth.md" "Auth" 1 '["src/auth/**"]'
+mt_write_sprint "$MT_CLOSE_DIR/backlog/sprints/2026-07-billing.md" "Billing" 2 '["src/billing/**"]'
+
+set +e
+OUT=$(bash "$SCRIPT_DIR/sprint-close.sh" "$MT_CLOSE_DIR/backlog" 2>&1)
+STATUS=$?
+set -e
+assert_equals "multi-track #292: ambiguous close exit code" "$STATUS" "1"
+assert_contains "multi-track #292: ambiguous close refuses" "$OUT" "Refusing to close an ambiguous sprint"
+assert_contains "multi-track #292: ambiguous close suggests --track" "$OUT" "Pass --track <slug> to close one track."
+
+OUT=$(bash "$SCRIPT_DIR/sprint-close.sh" "$MT_CLOSE_DIR/backlog" --track 2026-07-billing --dry-run 2>&1)
+assert_contains "multi-track #292: close --track dry-run targets the selected track" "$OUT" "Would set status: completed in $MT_CLOSE_DIR/backlog/sprints/2026-07-billing.md"
+assert_contains "multi-track #292: close --track dry-run leaves files untouched" "$(grep '^status:' "$MT_CLOSE_DIR/backlog/sprints/2026-07-billing.md")" "active"
+
+OUT=$(bash "$SCRIPT_DIR/sprint-close.sh" "$MT_CLOSE_DIR/backlog" --track 2026-07-billing 2>&1)
+assert_contains "multi-track #292: close --track closes the selected track" "$(grep '^status:' "$MT_CLOSE_DIR/backlog/sprints/2026-07-billing.md")" "completed"
+assert_contains "multi-track #292: close --track leaves the other track active" "$(grep '^status:' "$MT_CLOSE_DIR/backlog/sprints/2026-07-auth.md")" "active"
+
+set +e
+OUT=$(bash "$SCRIPT_DIR/sprint-close.sh" "$MT_CLOSE_DIR/backlog" --track bogus 2>&1)
+STATUS=$?
+set -e
+assert_equals "multi-track #292: close --track no-match exit code" "$STATUS" "1"
+assert_contains "multi-track #292: close --track no-match message" "$OUT" "No active track matches 'bogus'"
+
 # (3) Back-compat (ENFORCED, GATE=1 — must stay GREEN on HEAD and after Phase 1).
 #     A single active track behaves exactly as today; this is the G4 text anchor
 #     (text output only — never snapshot --json, which changes by design).

--- a/skills/dev-backlog/scripts/sprint-close.sh
+++ b/skills/dev-backlog/scripts/sprint-close.sh
@@ -2,7 +2,10 @@
 set -uo pipefail
 # Close the active sprint: mark completed, move tasks, remind about context.
 #
-# Usage: bash scripts/sprint-close.sh [backlog-dir] [--dry-run] [--close-milestone]
+# Usage: bash scripts/sprint-close.sh [backlog-dir] [--track slug] [--dry-run] [--close-milestone]
+#
+# With multiple active tracks, --track <slug> picks which one to close;
+# without it the close refuses as ambiguous (a single active needs no flag).
 #
 # Steps:
 #   1. Run backlog-doctor pre-close and compute the text-only reassess signal
@@ -18,24 +21,35 @@ BACKLOG_DIR="backlog"
 DRY_RUN=false
 CLOSE_MILESTONE=false
 BACKLOG_DIR_SET=false
+TRACK=""
 
-for arg in "$@"; do
-  case "$arg" in
+while [ "$#" -gt 0 ]; do
+  case "$1" in
     --dry-run) DRY_RUN=true ;;
     --close-milestone) CLOSE_MILESTONE=true ;;
+    --track)
+      shift
+      TRACK="${1:-}"
+      if [ -z "$TRACK" ]; then
+        echo "Missing value for --track"
+        exit 1
+      fi
+      ;;
+    --track=*) TRACK="${1#--track=}" ;;
     --*)
-      echo "Unknown argument: $arg"
+      echo "Unknown argument: $1"
       exit 1
       ;;
     *)
       if $BACKLOG_DIR_SET; then
-        echo "Unexpected argument: $arg"
+        echo "Unexpected argument: $1"
         exit 1
       fi
-      BACKLOG_DIR="$arg"
+      BACKLOG_DIR="$1"
       BACKLOG_DIR_SET=true
       ;;
   esac
+  shift
 done
 
 # Optional provider mutations must be authorized before local sprint mutation.
@@ -54,19 +68,32 @@ if [ ! -d "$SPRINTS_DIR" ]; then
   exit 1
 fi
 
-ACTIVE=$(find_active_sprint "$SPRINTS_DIR" 2>/dev/null)
-ACTIVE_STATUS=$?
-if [ "$ACTIVE_STATUS" -eq 2 ]; then
-  echo "Multiple active sprints found. Refusing to close an ambiguous sprint:"
-  find_active_sprints "$SPRINTS_DIR" | while IFS= read -r sprint; do
-    echo "  - $(basename "$sprint")"
-  done
-  exit 1
-fi
+if [ -n "$TRACK" ]; then
+  ACTIVE=$(resolve_track "$SPRINTS_DIR" "$TRACK")
+  if [ -z "$ACTIVE" ]; then
+    echo "No active track matches '$TRACK'. Active tracks:"
+    find_active_sprints "$SPRINTS_DIR" | while IFS= read -r sprint; do
+      [ -z "$sprint" ] && continue
+      echo "  - $(basename "$sprint" .md)"
+    done
+    exit 1
+  fi
+else
+  ACTIVE=$(find_active_sprint "$SPRINTS_DIR" 2>/dev/null)
+  ACTIVE_STATUS=$?
+  if [ "$ACTIVE_STATUS" -eq 2 ]; then
+    echo "Multiple active sprints found. Refusing to close an ambiguous sprint:"
+    find_active_sprints "$SPRINTS_DIR" | while IFS= read -r sprint; do
+      echo "  - $(basename "$sprint")"
+    done
+    echo "Pass --track <slug> to close one track."
+    exit 1
+  fi
 
-if [ "$ACTIVE_STATUS" -ne 0 ]; then
-  echo "No active sprint to close."
-  exit 0
+  if [ "$ACTIVE_STATUS" -ne 0 ]; then
+    echo "No active sprint to close."
+    exit 0
+  fi
 fi
 
 SPRINT_NAME=$(basename "$ACTIVE" .md)

--- a/skills/dev-backlog/scripts/sprint-init.js
+++ b/skills/dev-backlog/scripts/sprint-init.js
@@ -4,17 +4,24 @@
  *
  * Usage: ./scripts/sprint-init.js "auth-system"
  *        ./scripts/sprint-init.js "auth-system" --milestone "Sprint W13"
+ *        ./scripts/sprint-init.js "auth-system" --scope "src/auth/**"
  *        ./scripts/sprint-init.js "auth-system" --dry-run
  *        ./scripts/sprint-init.js "auth-system" --json
  *
  * First arg is the topic name. Milestone defaults to topic if not specified.
  * Filename: YYYY-MM-<topic>.md
+ *
+ * Multi-track (#292): a second active sprint is refused only when its scope
+ * overlaps an existing active track (shared scopesOverlap from lib.js);
+ * disjoint tracks are created without refusal, scopeless-next-to-scopeless
+ * warns and allows (cannot prove overlap).
  */
 
 const fs = require("fs");
 const path = require("path");
 const { renderTaskRef } = require("./task-ref.js");
-const { slugify, estimateSize, readConfig } = require("./lib");
+const { slugify, estimateSize, readConfig, sprintScopeKey, scopesOverlap } = require("./lib");
+const { parseFrontmatter } = require("./sprint-state.js");
 const { getMilestoneDue, getMilestoneIssues } = require("./github-milestones.js");
 const {
   invokeCapability,
@@ -23,18 +30,20 @@ const {
 } = require("./tracker.js");
 const { resolveCharterPath } = require("./spec-paths.js");
 
+const USAGE = 'Usage: sprint-init.js "topic" [--milestone "Milestone Name"] [--scope "glob[,glob]"] [--dry-run] [--json]';
+
 function parseArgs(args) {
   const dryRun = args.includes("--dry-run");
   const json = args.includes("--json");
   const filteredArgs = args.filter((a) => a !== "--dry-run" && a !== "--json");
 
   if (!filteredArgs.length) {
-    return { error: 'Usage: sprint-init.js "topic" [--milestone "Milestone Name"] [--dry-run] [--json]' };
+    return { error: USAGE };
   }
 
   const topic = filteredArgs[0];
   if (topic.startsWith("--")) {
-    return { error: 'Usage: sprint-init.js "topic" [--milestone "Milestone Name"] [--dry-run] [--json]' };
+    return { error: USAGE };
   }
 
   let milestone = topic;
@@ -43,7 +52,19 @@ function parseArgs(args) {
     milestone = filteredArgs[msIdx + 1];
   }
 
-  return { topic, milestone, dryRun, json };
+  const parsed = { topic, milestone, dryRun, json };
+
+  // Explicit only (D2): scope is never inferred from touched paths.
+  const scopeIdx = filteredArgs.indexOf("--scope");
+  if (scopeIdx !== -1) {
+    const raw = filteredArgs[scopeIdx + 1];
+    if (!raw || raw.startsWith("--")) {
+      return { error: `Missing value for --scope. ${USAGE}` };
+    }
+    parsed.scope = raw.split(",").map((glob) => glob.trim()).filter(Boolean);
+  }
+
+  return parsed;
 }
 
 function buildIssueLines(issues) {
@@ -70,24 +91,33 @@ function buildSpecFrontmatterBlock({ hasCharter, hasCapabilities }) {
   return lines.length ? `${lines.join("\n")}\n` : "";
 }
 
+// scope: is emitted only when explicitly requested (--scope, D2) — a track's
+// partition axis is declared, never inferred, and absent scope is never an error.
+function buildScopeFrontmatterLine(scope) {
+  if (!Array.isArray(scope) || scope.length === 0) return "";
+  return `scope: [${scope.map((glob) => `"${glob}"`).join(", ")}]\n`;
+}
+
 function buildSprintContent({
   milestone,
   started,
   due,
   topic,
   issues,
+  scope,
   hasCharter = false,
   hasCapabilities = false,
 }) {
   const issueLines = buildIssueLines(issues);
   const specBlock = buildSpecFrontmatterBlock({ hasCharter, hasCapabilities });
+  const scopeLine = buildScopeFrontmatterLine(scope);
 
   return `---
 milestone: ${milestone}
 status: active
 started: ${started}
 due: ${due}
-${specBlock}---
+${scopeLine}${specBlock}---
 
 # ${topic}
 
@@ -129,6 +159,7 @@ function createSprintResult({
   issues,
   content,
   existingFile,
+  warnings = [],
 }) {
   return {
     action: "sprint-init",
@@ -142,8 +173,46 @@ function createSprintResult({
     placeholderIssue: Boolean(content) && issues.length === 0,
     existingFile,
     created: !dryRun && !existingFile,
+    warnings,
     content,
   };
+}
+
+// Track records for the existing active sprints: file name + parsed frontmatter.
+function loadActiveTrackRecords(sprintsDir) {
+  return listActiveSprintFiles(sprintsDir).map((file) => ({
+    file,
+    frontmatter: parseFrontmatter(fs.readFileSync(path.join(sprintsDir, file), "utf-8")),
+  }));
+}
+
+// Refusal is per-track overlap (via the ONE shared scopesOverlap predicate),
+// no longer "any second active sprint". Scopeless pairs cannot be proven
+// disjoint — warn-and-allow, matching the doctor's informational stance.
+function checkTrackDisjointness({ sprintsDir, scope }) {
+  const activeTracks = loadActiveTrackRecords(sprintsDir);
+  const newFrontmatter = Array.isArray(scope) && scope.length ? { scope } : {};
+
+  const conflict = activeTracks.find(
+    (track) => scopesOverlap(newFrontmatter, track.frontmatter)
+  );
+  if (conflict) {
+    throw new Error(
+      `Active track overlaps on scope: ${conflict.file}. `
+      + "Give the new sprint a disjoint component:/scope: or close the conflicting track first."
+    );
+  }
+
+  const scopelessAfterCreate = activeTracks
+    .filter((track) => sprintScopeKey(track.frontmatter).kind === "none")
+    .map((track) => track.file);
+  if (sprintScopeKey(newFrontmatter).kind === "none" && scopelessAfterCreate.length >= 1) {
+    return [
+      `Active track(s) without component:/scope: (${scopelessAfterCreate.join(", ")}); `
+      + "cannot prove the new sprint is disjoint. Declare component: or scope: on each track (backlog-doctor will warn).",
+    ];
+  }
+  return [];
 }
 
 // Detect whether the spec axis backs each field. Charter resolves canonical
@@ -160,6 +229,7 @@ function detectSpecPresence({ repoRoot = process.cwd(), fileExists = fs.existsSy
 function createSprintFile({
   topic,
   milestone,
+  scope,
   dryRun,
   sprintsDir = path.join("backlog", "sprints"),
   today = new Date(),
@@ -187,17 +257,12 @@ function createSprintFile({
   const topicSlug = slugify(topic) || "sprint";
   const sprintFile = path.join(sprintsDir, `${datePrefix}-${topicSlug}.md`);
   const existingFile = fileExists(sprintFile);
-  const activeSprintFiles = listActiveSprintFiles(sprintsDir);
 
   if (existingFile && !dryRun) {
     throw new Error(`Sprint file already exists: ${sprintFile}`);
   }
 
-  if (activeSprintFiles.length > 0 && !existingFile) {
-    throw new Error(
-      `Active sprint already exists: ${activeSprintFiles.join(", ")}. Close it before creating another active sprint.`
-    );
-  }
+  const warnings = existingFile ? [] : checkTrackDisjointness({ sprintsDir, scope });
 
   const detected = detectSpecPresence({ repoRoot, fileExists });
   const charterPresent = hasCharter ?? detected.hasCharter;
@@ -213,6 +278,7 @@ function createSprintFile({
         due,
         topic,
         issues,
+        scope,
         hasCharter: charterPresent,
         hasCapabilities: capabilitiesPresent,
       });
@@ -231,6 +297,7 @@ function createSprintFile({
     issues,
     content,
     existingFile,
+    warnings,
   });
 }
 
@@ -238,6 +305,10 @@ function printResult(result) {
   if (result.existingFile && result.dryRun) {
     console.log(`[dry-run] File already exists: ${result.sprintFile}`);
     return;
+  }
+
+  for (const warning of result.warnings || []) {
+    console.log(`Warning: ${warning}`);
   }
 
   if (result.placeholderIssue) {
@@ -287,9 +358,11 @@ module.exports = {
   parseArgs,
   buildIssueLines,
   buildSpecFrontmatterBlock,
+  buildScopeFrontmatterLine,
   buildSprintContent,
   detectSpecPresence,
   listActiveSprintFiles,
+  checkTrackDisjointness,
   createSprintFile,
   printResult,
 };

--- a/skills/dev-backlog/scripts/sprint-init.test.js
+++ b/skills/dev-backlog/scripts/sprint-init.test.js
@@ -41,6 +41,20 @@ describe("parseArgs", () => {
     const parsed = parseArgs(["--milestone", "Sprint W13"]);
     assert.match(parsed.error, /Usage: sprint-init\.js/);
   });
+
+  it("parses --scope into a glob list, splitting on commas (#292)", () => {
+    const parsed = parseArgs(["auth", "--scope", "src/auth/**, src/authz/**"]);
+    assert.deepEqual(parsed.scope, ["src/auth/**", "src/authz/**"]);
+  });
+
+  it("omits the scope key entirely when --scope is not passed (#292)", () => {
+    assert.ok(!("scope" in parseArgs(["auth"])));
+  });
+
+  it("rejects --scope without a value (#292)", () => {
+    assert.match(parseArgs(["auth", "--scope"]).error, /Missing value for --scope/);
+    assert.match(parseArgs(["auth", "--scope", "--json"]).error, /Missing value for --scope/);
+  });
 });
 
 describe("buildIssueLines", () => {
@@ -89,6 +103,20 @@ describe("buildSprintContent", () => {
     assert.match(content, /due: TBD\n---/);
     assert.doesNotMatch(content, /^objectives:/m);
     assert.doesNotMatch(content, /^component:/m);
+  });
+
+  it("emits a scope: line only when explicitly requested (D2, #292)", () => {
+    const scoped = buildSprintContent({
+      milestone: "m", started: "2026-04-05", due: "TBD", topic: "t", issues: [],
+      scope: ["src/auth/**", "src/authz/**"],
+    });
+    assert.match(scoped, /^scope: \["src\/auth\/\*\*", "src\/authz\/\*\*"\]$/m);
+    assert.match(scoped, /due: TBD\nscope: \["src\/auth\/\*\*", "src\/authz\/\*\*"\]\n---/);
+
+    const unscoped = buildSprintContent({
+      milestone: "m", started: "2026-04-05", due: "TBD", topic: "t", issues: [],
+    });
+    assert.doesNotMatch(unscoped, /^scope:/m);
   });
 
   it("emits objectives only when charter present, component only when capabilities present", () => {
@@ -202,36 +230,112 @@ describe("createSprintFile", () => {
     ]);
   });
 
-  it("refuses to create a new active sprint when another active sprint exists", () => {
-    fs.writeFileSync(path.join(tmpDir, "2026-04-current.md"), "---\nstatus: active\n---\n");
+  it("refuses when the new sprint scope overlaps an active track (#292)", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "2026-04-current.md"),
+      '---\nstatus: active\nscope: ["src/auth/**"]\n---\n',
+    );
 
     assert.throws(() => {
       createSprintFile({
         topic: "next-sprint",
         milestone: "Sprint W14",
+        scope: ["src/auth/api/**"],
         dryRun: false,
         sprintsDir: tmpDir,
         today: new Date("2026-04-05T09:00:00Z"),
         getDue: () => "2026-04-12",
         getIssues: () => [],
       });
-    }, /Active sprint already exists: 2026-04-current\.md/);
+    }, /Active track overlaps on scope: 2026-04-current\.md/);
   });
 
-  it("also refuses dry-run creation when another active sprint exists", () => {
-    fs.writeFileSync(path.join(tmpDir, "2026-04-current.md"), "---\nstatus: active\n---\n");
+  it("also refuses dry-run creation on scope overlap (#292)", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "2026-04-current.md"),
+      '---\nstatus: active\nscope: ["src/auth/**"]\n---\n',
+    );
 
     assert.throws(() => {
       createSprintFile({
         topic: "next-sprint",
         milestone: "Sprint W14",
+        scope: ["src/auth/**"],
         dryRun: true,
         sprintsDir: tmpDir,
         today: new Date("2026-04-05T09:00:00Z"),
         getDue: () => "2026-04-12",
         getIssues: () => [],
       });
-    }, /Active sprint already exists: 2026-04-current\.md/);
+    }, /Active track overlaps on scope: 2026-04-current\.md/);
+  });
+
+  it("refuses when a shared component: overlaps, regardless of scope globs (#292)", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "2026-04-current.md"),
+      '---\nstatus: active\ncomponent: "auth-system"\n---\n',
+    );
+
+    // A scopeless new sprint next to a component-scoped track cannot be proven
+    // to overlap — but two tracks on the SAME component axis can, via frontmatter.
+    const disjoint = createSprintFile({
+      topic: "billing",
+      milestone: "Sprint W14",
+      scope: ["src/billing/**"],
+      dryRun: true,
+      sprintsDir: tmpDir,
+      today: new Date("2026-04-05T09:00:00Z"),
+      getDue: () => "TBD",
+      getIssues: () => [],
+    });
+    assert.deepEqual(disjoint.warnings, []);
+  });
+
+  it("creates a disjoint-scope second active track without refusal (#292)", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "2026-04-current.md"),
+      '---\nstatus: active\nscope: ["src/auth/**"]\n---\n',
+    );
+
+    const result = createSprintFile({
+      topic: "billing",
+      milestone: "Sprint W14",
+      scope: ["src/billing/**"],
+      dryRun: false,
+      sprintsDir: tmpDir,
+      today: new Date("2026-04-05T09:00:00Z"),
+      getDue: () => "2026-04-12",
+      getIssues: () => [],
+      hasCharter: false,
+      hasCapabilities: false,
+    });
+
+    assert.equal(result.created, true);
+    assert.deepEqual(result.warnings, []);
+    const written = fs.readFileSync(result.sprintFile, "utf-8");
+    assert.match(written, /^scope: \["src\/billing\/\*\*"\]$/m);
+    assert.match(written, /^status: active$/m);
+  });
+
+  it("warns and allows a scopeless sprint next to a scopeless active track (#292)", () => {
+    fs.writeFileSync(path.join(tmpDir, "2026-04-current.md"), "---\nstatus: active\n---\n");
+
+    const result = createSprintFile({
+      topic: "next-sprint",
+      milestone: "Sprint W14",
+      dryRun: false,
+      sprintsDir: tmpDir,
+      today: new Date("2026-04-05T09:00:00Z"),
+      getDue: () => "2026-04-12",
+      getIssues: () => [],
+      hasCharter: false,
+      hasCapabilities: false,
+    });
+
+    assert.equal(result.created, true);
+    assert.equal(result.warnings.length, 1);
+    assert.match(result.warnings[0], /cannot prove/);
+    assert.match(result.warnings[0], /2026-04-current\.md/);
   });
 
   it("returns placeholder metadata on dry-run when milestone has no issues", () => {
@@ -364,6 +468,10 @@ describe("createSprintFile", () => {
       today: new Date("2026-04-05T09:00:00Z"),
       getDue: () => "2026-04-12",
       getIssues: () => [{ number: 1, title: "Task", labels: [] }],
+      // Explicit overrides: spec-field emission must not depend on the test
+      // runner's cwd having (or lacking) a spec/ directory (#258).
+      hasCharter: true,
+      hasCapabilities: true,
     });
 
     const content = fs.readFileSync(result.sprintFile, "utf-8");

--- a/skills/dev-backlog/scripts/sprint-mirror.js
+++ b/skills/dev-backlog/scripts/sprint-mirror.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /**
- * Publish the single active sprint to a machine-managed GitHub issue.
+ * Publish one active sprint track to a machine-managed GitHub issue.
  *
- * Usage: node scripts/sprint-mirror.js [backlog-dir] [--dry-run] [--json]
+ * Usage: node scripts/sprint-mirror.js [backlog-dir] [--track slug] [--dry-run] [--json]
  *
  * This is the option-(c) half of the SSOT decision (spec/charter.md,
  * Decision row 2026-07-03): the local sprint file stays canonical and is
@@ -12,9 +12,9 @@
  *
  * sprint-state.js is the single owner of sprint markdown parsing. This
  * script never reads sprint files itself — it shells out to sprint-state.js
- * (`--mode status`) and renders its JSON. If sprint-state.js reports no
- * active sprint, or fails because multiple sprints are active, this script
- * refuses rather than guessing.
+ * (`--mode status`, plus `--track` when selecting among multiple tracks) and
+ * renders its JSON. Mirrors are per track: N==1 needs no flag, a portfolio
+ * requires --track, and overlap or no-match refuses rather than guessing.
  */
 
 const { execFileSync } = require("child_process");
@@ -38,7 +38,7 @@ const SPRINT_STATE_PATH = path.join(__dirname, "sprint-state.js");
 const DEFAULT_BACKLOG_DIR = "backlog";
 
 function usage() {
-  return "Usage: sprint-mirror.js [backlog-dir] [--dry-run] [--json]";
+  return "Usage: sprint-mirror.js [backlog-dir] [--track slug] [--dry-run] [--json]";
 }
 
 function makeMarker(slug) {
@@ -48,7 +48,7 @@ function makeMarker(slug) {
 // --- Args ---
 
 function parseArgs(args) {
-  const options = { backlogDir: DEFAULT_BACKLOG_DIR, dryRun: false, json: false };
+  const options = { backlogDir: DEFAULT_BACKLOG_DIR, dryRun: false, json: false, track: null };
   let backlogDirSet = false;
 
   for (let i = 0; i < args.length; i += 1) {
@@ -56,6 +56,17 @@ function parseArgs(args) {
     if (arg === "--help" || arg === "-h") return { ...options, help: true };
     if (arg === "--dry-run") { options.dryRun = true; continue; }
     if (arg === "--json") { options.json = true; continue; }
+    if (arg === "--track") {
+      const next = args[i + 1];
+      if (!next) return { ...options, error: `Missing value for --track. ${usage()}` };
+      options.track = next;
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith("--track=")) {
+      options.track = arg.slice("--track=".length);
+      continue;
+    }
     if (arg.startsWith("--")) {
       return { ...options, error: `Unknown argument: ${arg}. ${usage()}` };
     }
@@ -75,12 +86,17 @@ function resolveSprintState({
   backlogDir = DEFAULT_BACKLOG_DIR,
   execFile = execFileSync,
   sprintStatePath = SPRINT_STATE_PATH,
+  track = null,
 } = {}) {
+  const stateArgs = [sprintStatePath, "--mode", "status"];
+  if (track) stateArgs.push("--track", track);
+  stateArgs.push(backlogDir);
+
   let out;
   try {
     out = execFile(
       process.execPath,
-      [sprintStatePath, "--mode", "status", backlogDir],
+      stateArgs,
       { encoding: "utf-8", maxBuffer: 10 * 1024 * 1024 }
     );
   } catch (error) {
@@ -99,10 +115,20 @@ function resolveSprintState({
     throw new Error(`Unsupported sprint-state schema_version: ${state.schema_version}`);
   }
 
-  // v2 keeps `active_sprint` populated only when exactly one track is active; a
-  // portfolio (N>1) leaves it null. sprint-mirror still mirrors one sprint —
-  // per-track selection is #292's work.
+  // v2 keeps `active_sprint` populated when exactly one track is active or a
+  // --track/--component selector resolved one. A portfolio (N>1) without a
+  // selector leaves it null: mirroring is per track, so ask for the track.
   if (!state.active_sprint) {
+    if (track) {
+      throw new Error(`No active track matches '${track}'.`);
+    }
+    const trackSlugs = (state.active_sprints || [])
+      .map((sprint) => path.basename(sprint.active_sprint.path, ".md"));
+    if (trackSlugs.length > 1) {
+      throw new Error(
+        `Multiple active tracks (${trackSlugs.join(", ")}). Pass --track <slug> to choose which sprint to mirror.`
+      );
+    }
     throw new Error("No active sprint found. sprint-mirror requires exactly one active sprint.");
   }
 
@@ -187,10 +213,11 @@ function sync({
   now = new Date(),
   execFile = execFileSync,
   sprintStatePath = SPRINT_STATE_PATH,
+  track = null,
 } = {}) {
   const resolved = resolveConfiguredTracker(readConfig(backlogDir), { execFile, backlogDir });
   invokeCapability(resolved, "mirrors", () => undefined);
-  const state = resolveSprintState({ backlogDir, execFile, sprintStatePath });
+  const state = resolveSprintState({ backlogDir, execFile, sprintStatePath, track });
   const slug = path.basename(state.active_sprint.path, ".md");
   const marker = makeMarker(slug);
   const title = `Sprint mirror: ${slug}`;
@@ -250,7 +277,7 @@ function main() {
   }
 
   try {
-    const result = sync({ backlogDir: parsed.backlogDir, dryRun: parsed.dryRun });
+    const result = sync({ backlogDir: parsed.backlogDir, dryRun: parsed.dryRun, track: parsed.track });
 
     if (parsed.json) {
       console.log(JSON.stringify({

--- a/skills/dev-backlog/scripts/sprint-mirror.test.js
+++ b/skills/dev-backlog/scripts/sprint-mirror.test.js
@@ -88,7 +88,16 @@ function makeExecFile({
 describe("parseArgs", () => {
   it("defaults to backlog dir with no flags", () => {
     const parsed = parseArgs([]);
-    assert.deepEqual(parsed, { backlogDir: "backlog", dryRun: false, json: false });
+    assert.deepEqual(parsed, { backlogDir: "backlog", dryRun: false, json: false, track: null });
+  });
+
+  it("parses --track in both flag forms (#292)", () => {
+    assert.equal(parseArgs(["--track", "2026-07-auth"]).track, "2026-07-auth");
+    assert.equal(parseArgs(["--track=2026-07-auth"]).track, "2026-07-auth");
+  });
+
+  it("rejects --track without a value (#292)", () => {
+    assert.match(parseArgs(["--track"]).error, /Missing value for --track/);
   });
 
   it("parses backlog-dir, --dry-run, and --json together", () => {
@@ -141,6 +150,42 @@ describe("resolveSprintState", () => {
   it("refuses when there is no active sprint", () => {
     const { execFile } = makeExecFile({ state: { schema_version: 1, active_sprint: null } });
     assert.throws(() => resolveSprintState({ execFile }), /No active sprint/);
+  });
+
+  it("passes --track through to sprint-state.js (#292)", () => {
+    const { execFile, calls } = makeExecFile();
+    resolveSprintState({ backlogDir: "backlog", execFile, track: "2026-07-auth" });
+
+    assert.deepEqual(calls[0].args.slice(1), ["--mode", "status", "--track", "2026-07-auth", "backlog"]);
+  });
+
+  it("asks for --track when a portfolio of tracks is active (#292)", () => {
+    const { execFile } = makeExecFile({
+      state: {
+        schema_version: 2,
+        active_sprint: null,
+        active_sprints: [
+          { active_sprint: { path: "backlog/sprints/2026-07-auth.md" } },
+          { active_sprint: { path: "backlog/sprints/2026-07-billing.md" } },
+        ],
+      },
+    });
+
+    assert.throws(
+      () => resolveSprintState({ execFile }),
+      /Multiple active tracks \(2026-07-auth, 2026-07-billing\)\. Pass --track/
+    );
+  });
+
+  it("refuses a --track selector that matches no active track (#292)", () => {
+    const { execFile } = makeExecFile({
+      state: { schema_version: 2, active_sprint: null, active_sprints: [] },
+    });
+
+    assert.throws(
+      () => resolveSprintState({ execFile, track: "nope" }),
+      /No active track matches 'nope'/
+    );
   });
 
   it("refuses loudly when sprint-state.js fails (ambiguous active sprints)", () => {


### PR DESCRIPTION
## Summary

Implements **#292 (Phase 1b)** of the multi-track sprints initiative (epic #289, PRD §5.2): the sprint lifecycle — init, close, mirror — becomes track-aware. All overlap decisions consume the **one shared** `scopesOverlap()` from `lib.js`; no second overlap check exists.

### `sprint-init.js`

- Refusal changes from "any second active sprint" to "second active track whose scope **overlaps** an existing active track", named in the error: `Active track overlaps on scope: <file>. …`
- New `--scope "glob[,glob]"` flag emits an explicit `scope: ["…"]` frontmatter line (D2 — scope is declared, never inferred). Omitted `--scope` emits nothing.
- Cold-adopter path: scopeless new sprint next to a scopeless active track cannot be proven disjoint → **warn-and-allow** (`warnings[]` in the JSON result, `Warning:` lines in text), matching the doctor's informational stance. Disjoint tracks create without refusal.

### `sprint-close.sh`

- `--track <slug>` (slug or `component:` handle, via lib.sh `resolve_track`) picks which track to close out of a portfolio.
- No flag + N>1 active still refuses (`Refusing to close an ambiguous sprint`) and now appends `Pass --track <slug> to close one track.`
- No-match selector exits 1 listing the active tracks.

### `sprint-mirror.js`

- `--track` passes through to `sprint-state.js --mode status --track <slug>`; the `:98` singular read is now selector-aware.
- A portfolio without `--track` refuses: `Multiple active tracks (a, b). Pass --track <slug> …`; a no-match selector refuses naming it. N==1 default path unchanged.

## Verification

- `bash smoke-test.sh` → **187/187 pass, 0 xfail** (new Phase 1b fixtures: disjoint init, overlap refusal, close `--track` full cycle, ambiguous-close hint, single-track init G4 anchor)
- All 21 node suites green — including `sprint-init.test.js`, whose pre-existing cwd-dependent #13 failure ("produces frontmatter compatible with find_active_sprint", #258 rot) is fixed here as assigned by the issue
- **G4 byte-identity fixtures run against `origin/main`**: single-track `sprint-init` (dry-run + real create, written file included) and `sprint-close` (dry-run + real close, mutated backlog tree included) diffed old-vs-new — byte-identical text, equal exit codes, identical files. The mirror's no-track `sprint-state` invocation is assert-pinned unchanged in its test suite.
- Sprint file `2026-07-multi-track-sprints.md` ticks #292 in the same squash.

Refs #292, #289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)