### PR TITLE
docs(dev-backlog): Phase 3 — multi-track docs + integration-contract schema 2 (#295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,21 @@ Each entry links the GitHub issue (the canonical spec) and the merge PR (the shi
 
 ## [Unreleased]
 
-Headline: writing-great-skills review batch — reference docs re-synced with the SKILL.md contracts, release metadata aligned, spec-* move aftermath cleaned up, and one live-hit script bug fixed.
+Headline: multi-track sprints — the global "exactly one active sprint" singleton is replaced by component-partitioned concurrent tracks (epic [#289](https://github.com/sungjunlee/dev-backlog/issues/289), PRD `docs/prd-2026-07-multi-track-sprints.md`); plus the writing-great-skills review batch.
+
+### Added
+
+- **Multi-track sprints**: multiple `status: active` sprints may coexist when their scopes are disjoint (`component:` equality or `scope:` path-glob collision = overlap, decided by the single shared `scopesOverlap` predicate in `lib.js`). Single-track behavior is byte-identical (G4, fixture-verified against the pre-change scripts). Shipped in phases:
+  - `sprint-state.js` `schema_version` 2 — `active_sprints[]` portfolio plus retained back-compat single-track fields; `--track`/`--component` selectors; `OVERLAPPING_TRACKS` replaces `MULTIPLE_ACTIVE_SPRINTS` and fires only on scope collision. `next.sh`/`status.sh`/`context-hook.sh` render a portfolio for N>1 disjoint tracks. Closes [#291](https://github.com/sungjunlee/dev-backlog/issues/291) / PR [#300](https://github.com/sungjunlee/dev-backlog/pull/300).
+  - `backlog-doctor.js` `active_sprint` check rewritten as scope-disjointness (pass portfolio / fail overlap with `Active tracks overlap on scope` / informational warn for ≥2 scopeless tracks); per-sprint checks fan out per active track with track-tagged verdicts. Closes [#293](https://github.com/sungjunlee/dev-backlog/issues/293) / PR [#305](https://github.com/sungjunlee/dev-backlog/pull/305).
+  - Lifecycle track-awareness: `sprint-init.js` refuses only overlapping scopes (new `--scope "glob[,glob]"` flag; scopeless-next-to-scopeless warns and allows), `sprint-close.sh --track`, `sprint-mirror.js --track`. Closes [#292](https://github.com/sungjunlee/dev-backlog/issues/292) / PR [#307](https://github.com/sungjunlee/dev-backlog/pull/307).
+  - `spec/capabilities.md` singleton invariant amended to track-partitioned disjointness via a human-gated `spec-grill` pass; `spec/system-map.md` Core Flows de-singularized. Closes [#294](https://github.com/sungjunlee/dev-backlog/issues/294) / PR [#308](https://github.com/sungjunlee/dev-backlog/pull/308).
+  - Docs: `references/integration-contract.md` documents JSON `schema_version: 2`, the portfolio/overlap contract, and track resolution for relay-merge updates and capability-Learnings appends; SKILL.md, `references/process.md`, and README prose flipped off the singleton. Closes [#295](https://github.com/sungjunlee/dev-backlog/issues/295).
 
 ### Fixed
 
 - `sprint-close.sh` now parses flags position-independently: `--dry-run` without a positional backlog-dir works, positional/flags accept any order, and unknown `--*` flags fail loud instead of being treated as a directory; smoke-test coverage added. Closes [#247](https://github.com/sungjunlee/dev-backlog/issues/247) / PR [#251](https://github.com/sungjunlee/dev-backlog/pull/251).
+- `sprint-init.test.js` "produces frontmatter compatible with find_active_sprint" no longer depends on the test runner's cwd containing a `spec/` directory (pre-existing rot from the #258 omission change; pinned with explicit overrides). Fixed in PR [#307](https://github.com/sungjunlee/dev-backlog/pull/307).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,32 @@ Users can log in and access protected API endpoints.
 
 The configured tracker handles task truth. The sprint file handles execution.
 
+## Multi-Track Sprints
+
+Most repos run one active sprint at a time, and nothing changes for them. But two workstreams that touch **disjoint code** don't have to serialize: since the 2026-07 multi-track change, sprints partition by *scope*, and multiple disjoint-scope tracks may be `status: active` at once.
+
+**When to open a second track:** the new work touches a different component or directory subtree than every current active track, and waiting for that sprint to close would just serialize unrelated work.
+
+**Declaring scope** (explicit, never inferred — one axis per track):
+
+```yaml
+component: "auth-system"   # primary scope key when a capability axis exists
+scope: ["src/auth/**"]     # explicit path globs otherwise (sprint-init.js --scope)
+```
+
+**The invariant:** no two active tracks may overlap — same `component:`, or colliding `scope:` globs (nested paths overlap). Overlap fails loud everywhere: `sprint-init.js` refuses to create the track, `backlog-doctor` fails with `Active tracks overlap on scope`, and JSON reads exit with `OVERLAPPING_TRACKS`. Two scopeless active tracks can't be *proven* disjoint, so the doctor warns (informationally) instead.
+
+**Working a portfolio:**
+
+```bash
+bash skills/dev-backlog/scripts/next.sh                      # portfolio: one stanza per track
+bash skills/dev-backlog/scripts/next.sh --track 2026-07-auth # one track, deterministic
+bash skills/dev-backlog/scripts/sprint-close.sh --track 2026-07-auth  # close just that track
+node skills/dev-backlog/scripts/sprint-mirror.js --track 2026-07-auth # mirror one track
+```
+
+`status.sh --json` / `next.sh --json` emit `schema_version: 2` with `active_sprints[]`; the single-track fields are retained and byte-compatible, so existing consumers keep working.
+
 ## Optional extensions
 
 The core loop above needs none of these. Add one only when you want its capability — each row prices what it adds and what it requires.

--- a/backlog/sprints/2026-07-multi-track-sprints.md
+++ b/backlog/sprints/2026-07-multi-track-sprints.md
@@ -28,7 +28,7 @@ Replace the global single-active-sprint invariant with a component-partitioned m
 - [x] #294 Phase 1e: amend capabilities.md singleton invariant → PR #308 (human-run spec-grill pass 2026-07-12)
 
 ### Batch 5 — Docs + contract
-- [ ] #295 Phase 3: docs + integration-contract schema_version → 2
+- [x] #295 Phase 3: docs + integration-contract schema_version → 2 → PR #309
 
 ## Running Context
 - Design + decisions frozen in `docs/prd-2026-07-multi-track-sprints.md` (§9 D1–D4 resolved).
@@ -45,3 +45,4 @@ Replace the global single-active-sprint invariant with a component-partitioned m
 - 2026-07-12: #293 Phase 1c landed (PR #305) — doctor scope-disjointness with per-track fan-out; GATE_MT_DISJOINT/GATE_MT_OVERLAP enforced, smoke 172/172, 0 xfail; single-active output verified byte-identical. Sprint file re-added as sole active.
 - 2026-07-12: #292 Phase 1b — sprint-init refuses only on scope overlap (--scope flag, D2 explicit), sprint-close/--track, sprint-mirror/--track; init/close single-track G4 verified byte-identical (text + exit codes + written files); fixed the cwd-dependent sprint-init.test.js #13 rot. Smoke 187/187.
 - 2026-07-12: #294 human-gated spec-grill pass — capabilities.md sprint-execution invariant flipped to track-partitioned scope disjointness, backlog-sync sprint-mirror predicate rewritten per-track, header notes component: as the track-scope key; Decisions rows appended in both capabilities; system-map Core Flows 4/5 de-singularized (the originally cited :36 line no longer existed post tracker-adapter refactor). Unblocks #295.
+- 2026-07-12: #295 docs — integration-contract documents schema_version 2 (active_sprints[] + retained v1 fields), portfolio/overlap contract, track resolution for relay-merge and Learnings appends; SKILL.md/process.md/scripts.md/README prose flipped off the singleton (no residual "exactly one active sprint" claim); CHANGELOG multi-track entry; multi-track eval prompt un-gated. dev-relay#954 coordination comment posted. dev-backlog side of epic #289 complete — remaining work is dev-relay #955/#956/#957.

--- a/skills/dev-backlog/SKILL.md
+++ b/skills/dev-backlog/SKILL.md
@@ -43,7 +43,7 @@ backlog/config.yml (one tracker: github | local)
 backlog/sprints/ <- shared execution hub in both modes
 ```
 
-- Exactly one sprint file may have `status: active`; scripts warn/refuse ambiguous active sprint state.
+- One active track per scope: sprints with `status: active` must declare disjoint scopes (`component:` equality or `scope:` glob collision = overlap, decided by the shared `scopesOverlap` predicate). Disjoint tracks coexist as a portfolio; overlapping tracks fail loud; most repos run a single track, which behaves exactly as before.
 - Start every session by reading `backlog/sprints/_context.md` and the active sprint file when present.
 - Task files are thin mirrors in GitHub mode and canonical records in local mode. In both modes, decisions, progress, and cross-task context stay in the sprint file.
 - A missing `tracker:` key is the zero-migration GitHub compatibility default. Runtime failure never changes the selected tracker.
@@ -53,13 +53,14 @@ backlog/sprints/ <- shared execution hub in both modes
 
 ## Sprint File Contract
 
-One active sprint file in `backlog/sprints/YYYY-MM-<topic>.md` carries:
+Each active sprint file (one per track) in `backlog/sprints/YYYY-MM-<topic>.md` carries:
 
 | Section / field | Purpose | Completion check |
 | --- | --- | --- |
-| `status: active` | Marks the single active sprint | No other sprint is active. |
+| `status: active` | Marks an active track | No other active sprint overlaps this track's scope. |
 | `objectives: [O1]` | Charter Objective IDs advanced by the sprint | IDs exist and are actionable; omit the field entirely when no charter exists (see `references/spec-fallback.md`). |
-| `component: "slug"` | Primary capability and relay-Learnings routing handle | Resolves to one capability whose `## Learnings` block receives relay-merge entries; omit the field entirely when no capabilities file exists. |
+| `component: "slug"` | Primary capability handle, relay-Learnings routing, and the track-scope key | Resolves to one capability whose `## Learnings` block receives relay-merge entries; omit the field entirely when no capabilities file exists. |
+| `scope: ["glob"]` | Explicit path-glob track scope when no component axis fits (one axis per track, never both; never inferred) | Optional; declared via `sprint-init.js --scope`. Two scopeless active tracks draw an informational doctor warn. |
 | `## Goal` | Sprint-level success statement | One sentence describing done state. |
 | `## Plan` | Ordered batches with normalized task refs and estimates | Every planned task has a checkbox and complete `#N` or `{PREFIX}-N[.M]` ref. |
 | `## Running Context` | Decisions/gotchas affecting later tasks | Updated when work reveals reusable context. |
@@ -80,11 +81,11 @@ Full sprint and task-file examples live in `references/file-format.md`.
 ### Orient
 
 1. Read `_context.md` if present.
-2. Find the single active sprint; if none exists, list open tasks through the configured adapter and route to `plan`.
-3. Read the active sprint's Goal, Plan, Running Context, and latest Progress.
-4. Identify the next unchecked Plan item or route to `complete` when all items are done.
+2. Find the active sprint(s); if none exists, list open tasks through the configured adapter and route to `plan`.
+3. One active track: read its Goal, Plan, Running Context, and latest Progress. Multiple disjoint tracks: `next.sh`/`status.sh` render a portfolio (one stanza per track); use `--track <slug>` to work one track.
+4. Identify the next unchecked Plan item (per track) or route to `complete` when all items are done.
 
-Done when you can name the current sprint state and the next actionable batch.
+Done when you can name the current sprint state and the next actionable batch — per track when a portfolio is active.
 
 ### Create
 
@@ -98,10 +99,10 @@ local mirror; local mode already wrote the canonical task file.
 
 1. Resolve Objectives from `spec/charter.md`; fall back to legacy root `CHARTER.md`; omit the `objectives:` field entirely when both are absent (see `references/spec-fallback.md`).
 2. List/inspect open tasks. Use milestone selection only when the configured adapter reports `milestones`; local planning writes normalized refs directly and does not fabricate one.
-3. Create one active sprint file with Goal, ordered Plan batches, estimates, dependencies, `objectives:`, and `component:`. Plan batches are execution waves: intra-batch items MUST be mutually parallel-safe (disjoint files, no ordering between them), dependent items MUST go in a later batch, and batch order is execution order.
-4. Refuse to create a second active sprint until the previous one is completed.
+3. Create the active sprint file with Goal, ordered Plan batches, estimates, dependencies, `objectives:`, and `component:` (or explicit `--scope` globs when no component axis fits). Plan batches are execution waves: intra-batch items MUST be mutually parallel-safe (disjoint files, no ordering between them), dependent items MUST go in a later batch, and batch order is execution order.
+4. A second active track is refused only when its scope overlaps an existing active track; declare a disjoint `component:`/`scope:` to run tracks concurrently. A scopeless sprint next to a scopeless active track warns and allows (cannot prove overlap).
 
-Done when the sprint file is the single active execution hub and each planned issue has a clear batch position.
+Done when the sprint file is the track's execution hub and each planned issue has a clear batch position.
 
 ### Work
 
@@ -161,8 +162,8 @@ Core scripts (full flag inventory in `references/scripts.md`):
 - `scripts/setup-dev-backlog.js` — persist the explicit canonical tracker without migrating task files.
 - `scripts/sync-pull.js` — materialize configured open tasks; in GitHub mode, preserve legacy mirrors.
 - `scripts/sprint-init.js` — create a milestone-backed sprint when supported; local plans are authored from normalized refs.
-- `scripts/next.sh` / `scripts/status.sh` — next actionable batch and tracker-neutral sprint state.
-- `scripts/sprint-close.sh` — close the active sprint; prints the doctor/reassess summary.
+- `scripts/next.sh` / `scripts/status.sh` — next actionable batch and tracker-neutral sprint state; portfolio view for N disjoint tracks, `--track <slug>` for one.
+- `scripts/sprint-close.sh` — close the active sprint (`--track <slug>` when multiple tracks are active); prints the doctor/reassess summary.
 - `scripts/backlog-doctor.js` — aggregate health checks; JSON includes `reassess_signal`.
 
 ## References
@@ -180,8 +181,8 @@ Core scripts (full flag inventory in `references/scripts.md`):
 ## Eval Prompts (fresh-session recovery)
 
 - "Orient in a repo with one active sprint, `_context.md`, and a partially complete Plan." Expected: read both context files, name latest Progress, and return the first unchecked batch.
-- "Plan a sprint when another sprint is already `status: active`." Expected: refuse or complete the old sprint first; never create a second active sprint.
-- "(Multi-track target — PRD 2026-07-multi-track-sprints, gated on #291/#293/#295) Orient in a repo with two disjoint active tracks (`auth` scoped to `src/auth/**`, `billing` to `src/billing/**`), each with its own Plan." Expected: a portfolio view naming both tracks and each next batch; `next --track auth` returns auth's next batch deterministically; `backlog-doctor` passes because scopes are disjoint. Once this lands, the prior bullet's single-active refusal narrows to *overlapping-scope* tracks; disjoint tracks coexist.
+- "Plan a sprint whose scope overlaps a track that is already `status: active`." Expected: refuse, naming the conflicting track — declare a disjoint `component:`/`scope:` or complete the conflicting track first. Disjoint scopes are NOT refused; they open a second track.
+- "Orient in a repo with two disjoint active tracks (`auth` scoped to `src/auth/**`, `billing` to `src/billing/**`), each with its own Plan." Expected: a portfolio view naming both tracks and each next batch; `next --track auth` returns auth's next batch deterministically; `backlog-doctor` passes because scopes are disjoint.
 - "Cold adopter: a repo with open GitHub issues but no `backlog/`, no `spec/`, no root `CHARTER.md`, and no craftkit `spec-*` skills installed. Reach a first active sprint." Expected: bootstrap `backlog/`, route to `plan`, and create the sprint with `objectives:`/`component:` omitted (no spec axis to reference); never follow or require a `../spec-charter/...` path.
 - "Work issue #42 whose task file has three AC checkboxes." Expected: verify each AC before checking it off, then update Plan, Progress, and GitHub state.
 - "Fresh session with only repo files available, no conversation history, and no GitHub access." Expected: use `status.sh --json` and `next.sh --json` to name the active sprint, next actionable batch, and every in-flight `[~]` item with its owner/pointer (PR, branch, or run-id); if `--json` is unavailable, read the sprint file directly.

--- a/skills/dev-backlog/references/integration-contract.md
+++ b/skills/dev-backlog/references/integration-contract.md
@@ -10,7 +10,7 @@ Changes to checkbox, annotation, path, or section patterns parsed by `dev-relay`
 
 Any actor consuming dev-backlog state should treat these files as the stable read surface:
 
-- `backlog/sprints/*.md` with `status: active` is the active execution hub: frontmatter identifies lifecycle and routing state; `## Goal`, `## Plan`, `## Running Context`, and `## Progress` identify the current objective, work queue, reusable discoveries, and execution trace.
+- `backlog/sprints/*.md` with `status: active` are the active execution hubs — one per disjoint-scope track (most repos run a single track): frontmatter identifies lifecycle, routing, and track-scope state; `## Goal`, `## Plan`, `## Running Context`, and `## Progress` identify the current objective, work queue, reusable discoveries, and execution trace.
 - `backlog/sprints/_context.md` is cross-sprint project memory. Its sections provide durable context for future sessions and analyzers.
 - `backlog/tasks/` and `backlog/completed/` have mode-specific authority. With `tracker: github` they are derived issue mirrors; with `tracker: local` they are the canonical active/completed task store. Task files carry bodies and Acceptance Criteria checkboxes; sprint files remain the execution log.
 - `spec/capabilities.md`, when present, is an optional capability-level learning target addressed by active sprint frontmatter `component:`.
@@ -26,9 +26,9 @@ bash skills/dev-backlog/scripts/status.sh --json
 bash skills/dev-backlog/scripts/next.sh --json
 ```
 
-Both commands emit one JSON document to stdout with `schema_version: 1`. Tracker-neutral identity is an additive schema-v1 extension: existing consumers may ignore the new fields, and no existing field or GitHub value changes. Human-readable output remains the default when `--json` is absent. Snapshots are supported through normal shell redirection only, for example `status.sh --json > sprint-state.json`; dev-backlog does not create timestamped snapshot files or maintain a snapshot store.
+Both commands emit one JSON document to stdout with `schema_version: 2`. Schema v2 (multi-track, PRD 2026-07) adds `active_sprints[]` — every active track in `started:`-ascending order — while retaining every v1 top-level field: `active_sprint` and the other singular fields hold the sole track's values when exactly one track is active (byte-compatible with v1 consumers) and are `null`/empty for a portfolio of N>1 tracks. `--track <slug>` (or `--component <slug>`) selects one track and emits the single-track shape. Human-readable output remains the default when `--json` is absent. Snapshots are supported through normal shell redirection only, for example `status.sh --json > sprint-state.json`; dev-backlog does not create timestamped snapshot files or maintain a snapshot store.
 
-Ambiguous active sprint state is fail-loud in JSON mode: the command exits non-zero and writes the error to stderr instead of emitting partial JSON. Missing `## ` sections degrade to empty strings or arrays as shown below.
+Multiple active tracks are a **portfolio**, not an error; only **overlapping-scope** tracks are fail-loud: when two active tracks overlap (`component:` equality or `scope:` path-prefix collision, via the one shared `scopesOverlap` predicate in `lib.js`), JSON mode exits non-zero with `OVERLAPPING_TRACKS` on stderr instead of emitting partial JSON. Missing `## ` sections degrade to empty strings or arrays as shown below.
 
 ## Tracker Selection and Capability Error Surface
 
@@ -65,12 +65,13 @@ Top-level schema:
 
 | Field | Type | Meaning |
 |-------|------|---------|
-| `schema_version` | integer | Schema version for this JSON contract; starts at `1`. |
-| `active_sprint` | object or `null` | Active sprint metadata, or `null` when no active sprint is found. |
-| `plan_items` | array | Parsed `## Plan` checkbox items from the active sprint. |
-| `next_batch` | object or `null` | First batch with `[ ]` items, or flat unchecked items when no batch heading exists. |
-| `latest_progress` | array | Most recent five `## Progress` bullet entries, newest first. |
-| `in_flight` | array | `[~]` plan items plus file-derived age metadata. |
+| `schema_version` | integer | Schema version for this JSON contract; currently `2` (v1 fields all retained). |
+| `active_sprints` | array | One entry per active track in `started:`-ascending order; each entry carries the per-track `active_sprint`/`plan_items`/`next_batch`/`latest_progress`/`in_flight` fields below. Empty when nothing is active. |
+| `active_sprint` | object or `null` | Back-compat: the sole track's metadata when exactly one track is active (or a `--track`/`--component` selector resolved one); `null` for a portfolio or when no active sprint is found. |
+| `plan_items` | array | Parsed `## Plan` checkbox items from the single resolved sprint; empty for a portfolio. |
+| `next_batch` | object or `null` | First batch with `[ ]` items, or flat unchecked items when no batch heading exists; `null` for a portfolio. |
+| `latest_progress` | array | Most recent five `## Progress` bullet entries, newest first; empty for a portfolio. |
+| `in_flight` | array | `[~]` plan items plus file-derived age metadata; empty for a portfolio. |
 
 `active_sprint` fields:
 
@@ -160,7 +161,7 @@ Each `checks[]` entry has:
 | `status` | string | `pass`, `warn`, or `fail`. |
 | `detail` | object | Check-specific details. `detail.summary` is always a human-readable one-line summary. |
 
-Hard failures include ambiguous active sprint state, no active sprint while sprint files exist, objective/component drift, capabilities-doctor hard triggers, missing required active-sprint sections, and unparseable Plan checkbox lines. Soft warnings include unmoored `[~]` items (repair runbook: [`checkbox-repair.md`](checkbox-repair.md)), `[~]` items older than `--stale-days` (default `7`), capabilities-doctor warnings, and `_context.md` bloat. `_context.md` bloat warns above `200` lines; the threshold is deliberately generous so this signal means "promote or compact durable context soon," not "rewrite immediately."
+The doctor's own JSON schema stays at `1`; it is independent of the actor read-surface schema above. With multiple active tracks, per-sprint checks (`objectives_check`, `component_lint`, `sprint_shape`, `in_flight_trace`, `in_flight_staleness`) run once per track and carry a top-level `track` field naming the track slug; single-track output is unchanged and untagged. Hard failures include overlapping-scope active tracks (the `active_sprint` check emits `Active tracks overlap on scope: <a> ∩ <b>`), objective/component drift, capabilities-doctor hard triggers, missing required active-sprint sections, and unparseable Plan checkbox lines. Disjoint-scope tracks pass (`N active tracks, scopes disjoint`). Soft warnings include the informational between-sprints state (sprint files exist but none is active), two scopeless active tracks (cannot prove disjoint — also informational), unmoored `[~]` items (repair runbook: [`checkbox-repair.md`](checkbox-repair.md)), `[~]` items older than `--stale-days` (default `7`), capabilities-doctor warnings, and `_context.md` bloat. `_context.md` bloat warns above `200` lines; the threshold is deliberately generous so this signal means "promote or compact durable context soon," not "rewrite immediately."
 
 ## File Paths
 
@@ -219,6 +220,7 @@ Rules:
 - Non-empty values must match exactly one `## Capability: <slug>` heading in `spec/capabilities.md`.
 - Comma-separated values are invalid. If a sprint touches secondary areas, write that in `## Running Context` or sprint prose.
 - `component-lint.js` owns validation on the dev-backlog side; `backlog-doctor.js` warns (soft) only when the active sprint omits `component:` while `spec/capabilities.md` exists.
+- When multiple sprints are active, `component:` is also the primary track-scope key; two active tracks MUST NOT share a `component:`. A track with no component axis may declare explicit `scope:` path globs instead — one axis per track, never both. Overlap is decided by the one shared `scopesOverlap` predicate (`lib.js`).
 
 This is intentionally stricter than normal markdown prose. The field is an address for downstream writers, not a place to explain scope.
 
@@ -321,7 +323,9 @@ The following sections define the `dev-relay` consumer profile. They specialize 
 
 ## Relay-Merge Sprint Update Format
 
-When `relay-merge` completes a task, it updates the active sprint file in these specific formats:
+When `relay-merge` completes a task, it updates the active sprint file in these specific formats.
+
+**Track resolution:** with one active track, "the active sprint file" is unambiguous. With multiple active tracks, resolve the target sprint by track key — the task's owning `component:` (or track slug) selects the sprint file via `sprint-state.js --component <slug>` (or `--track <slug>`); never guess among tracks and never write one task's update into another track's sprint file.
 
 **Plan section** — mark checkbox done with PR annotation:
 ```
@@ -341,6 +345,8 @@ When `relay-merge` completes a task, it updates the active sprint file in these 
 ## Capability Learnings Append Contract
 
 When `spec/capabilities.md` exists and the active sprint has a primary `component:` value, `relay-merge` may append one capability-level Learning after a successful run. This is the `dev-relay` capability-learning writer profile, not permission for working agents or other actors to edit the capability spec.
+
+**Track resolution:** the `component` input below is also the track key. With multiple active tracks, resolve the run's sprint via `sprint-state.js --component <slug>` and take `component` from that resolved track's frontmatter — never from "the" active sprint, which is `null` in a portfolio.
 
 Inputs:
 
@@ -460,7 +466,7 @@ These patterns are also validated by `scripts/smoke-test.sh` (checkbox counting 
 
 ## Versioning
 
-This document is unversioned, while the actor JSON surface remains `schema_version: 1`. The normalized `tracker`, `id`, and `ref` fields and nullable non-GitHub `issue_number` semantics are additive schema-v1 behavior. Its checkbox and annotation grammar is compatibility-sensitive. Any change to grammar parsed by `dev-relay` regexes must be coordinated with `dev-relay` before landing; prefer strictly additive grammar that preserves existing GitHub matches and bytes.
+This document is unversioned, while the actor JSON surface is `schema_version: 2` (multi-track: adds `active_sprints[]` and track selectors; every v1 field is retained with single-track values byte-compatible, so v1 consumers keep working — see Structured JSON Read Surface). The doctor JSON surface remains its own independent `schema_version: 1`. The checkbox and annotation grammar is unchanged by schema v2 and remains compatibility-sensitive. Any change to grammar parsed by `dev-relay` regexes must be coordinated with `dev-relay` before landing; prefer strictly additive grammar that preserves existing GitHub matches and bytes.
 
 Breaking changes require:
 1. Update this document

--- a/skills/dev-backlog/references/process.md
+++ b/skills/dev-backlog/references/process.md
@@ -42,12 +42,12 @@ the linked Tracker Adapter Design Contract.
 
 1. If `backlog/` does not exist, complete **Setup**.
 2. Read `backlog/sprints/_context.md` when present.
-3. Find the active sprint and read Goal, Plan, Running Context, and latest Progress.
+3. Find the active sprint(s). One track: read Goal, Plan, Running Context, and latest Progress. Multiple disjoint tracks: `status.sh`/`next.sh` render a portfolio; pass `--track <slug>` to work one track.
 4. If no active sprint exists, list open tasks through the configured adapter and proceed to **Plan**.
-5. Use `status.sh --json` and `next.sh --json` for normalized `tracker`/`id`/`ref` state; GitHub keeps numeric `issue_number`, local returns `null`.
-6. If all Plan items are checked, proceed to **Complete**.
+5. Use `status.sh --json` and `next.sh --json` for normalized `tracker`/`id`/`ref` state (`schema_version: 2`: `active_sprints[]` plus the retained single-track fields); GitHub keeps numeric `issue_number`, local returns `null`.
+6. If all Plan items are checked, proceed to **Complete** for that track.
 
-Two sprint files at most (`_context.md` plus active sprint) provide the execution picture; canonical task reads come from the configured adapter.
+`_context.md` plus the track's sprint file provide the execution picture; canonical task reads come from the configured adapter.
 
 ## Create — New Tasks
 
@@ -59,8 +59,8 @@ Two sprint files at most (`_context.md` plus active sprint) provide the executio
 
 When starting a new sprint:
 
-1. Refuse a new sprint while another is active; complete the existing sprint rather than flipping `status:` inline.
-2. Resolve optional `objectives:` and `component:` fields from the spec axis as described in `spec-fallback.md`.
+1. Refuse a new sprint only when its scope overlaps an existing active track (`component:` equality or `scope:` glob collision — `sprint-init.js` checks via the shared `scopesOverlap` predicate); disjoint-scope tracks coexist. Complete a conflicting track rather than flipping `status:` inline. A scopeless sprint next to a scopeless active track warns and allows.
+2. Resolve optional `objectives:` and `component:` fields from the spec axis as described in `spec-fallback.md`; declare explicit `scope:` globs (`sprint-init.js --scope "glob[,glob]"`) when opening a concurrent track with no component axis.
 3. List open tasks from the configured adapter.
 4. GitHub mode may create/assign a milestone and run `sprint-init.js "topic" --milestone "Name"`; its `#N`, estimates, due date, argv, and JSON remain legacy-compatible.
 5. Local mode does not fabricate a milestone. Author the sprint file from normalized local refs returned by the adapter.
@@ -88,7 +88,7 @@ Per task:
 
 For the whole sprint:
 
-1. Run `scripts/sprint-close.sh [backlog-dir] [--dry-run] [--close-milestone]`. Pass `--close-milestone` only for a tracker that reports `milestones`; unsupported requests fail before doctor or file mutation.
+1. Run `scripts/sprint-close.sh [backlog-dir] [--track slug] [--dry-run] [--close-milestone]`. With multiple active tracks, `--track <slug>` picks which one to close; without it the close refuses as ambiguous. Pass `--close-milestone` only for a tracker that reports `milestones`; unsupported requests fail before doctor or file mutation.
 2. The command sets `status: completed`, appends final Progress, archives checked active task files that remain, and prints the doctor/reassess summary.
 3. Promote durable Running Context to `_context.md`; retain the sprint file as history.
 
@@ -118,10 +118,10 @@ Create a sprint only when execution context needs to span work or sessions.
 
 - **Small (< 1hr):** use the Quick Fix path.
 - **Current sprint:** add the normalized ref as a new batch and note the scope change in Progress.
-- **Separate sprint:** close the current sprint first, then start another.
+- **Separate sprint:** when the new work's scope is disjoint from every active track, open a concurrent track with its own `component:`/`scope:`; when it overlaps, close the conflicting sprint first, then start another.
 
 ## Next — What to Work On
 
-1. Read the active sprint and find the first unchecked batch.
+1. Read the active sprint and find the first unchecked batch (`next.sh --track <slug>` selects one track when a portfolio is active).
 2. If it is done, list configured-tracker work or start the next sprint.
 3. Present the batch with its exact normalized refs and total estimate.

--- a/skills/dev-backlog/references/scripts.md
+++ b/skills/dev-backlog/references/scripts.md
@@ -17,18 +17,19 @@ node "$skill_dir/scripts/sprint-init.js" "next-sprint" --dry-run
 - `scripts/setup-dev-backlog.js [project-name] [--tracker github|local] [--non-interactive] [--json]` — persist one canonical tracker and minimum directories without migrating task files; fresh non-interactive setup requires an explicit tracker.
 - `scripts/init.sh [project-name]` — bootstrap `backlog/` with config and directories.
 - `scripts/tracker.js` — official programmatic core lifecycle boundary: resolve the configured adapter with `{ backlogDir }`, then call `list`, `read`, `create`, `update`, or `close` as documented in `process.md`.
-- `scripts/next.sh` — show the next actionable batch.
-- `scripts/status.sh` — summarize sprint-file state plus task state from the configured tracker.
+- `scripts/next.sh [--json] [--track slug] [backlog-dir]` — show the next actionable batch; N disjoint active tracks render a portfolio, `--track` selects one.
+- `scripts/status.sh [--json] [--track slug] [backlog-dir]` — summarize sprint-file state plus task state from the configured tracker; portfolio/`--track` semantics match `next.sh`.
+- `scripts/sprint-state.js [--mode status|next] [--track slug | --component slug] [backlog-dir]` — the single sprint-markdown parser behind the `--json` surfaces; emits `schema_version: 2` with `active_sprints[]` plus retained single-track fields.
 - `scripts/sync-pull.js [PREFIX] [--update] [--dry-run] [--json] [--limit N]` — pull open GitHub issues into `backlog/tasks/`.
-- `scripts/sprint-init.js "topic" [--milestone "Name"] [--dry-run] [--json]` — create one active sprint skeleton; refuses a second active sprint. Emits `objectives:`/`component:` only when the backing spec file exists (see `spec-fallback.md`).
+- `scripts/sprint-init.js "topic" [--milestone "Name"] [--scope "glob[,glob]"] [--dry-run] [--json]` — create an active sprint skeleton; refuses only a track whose scope overlaps an existing active track (scopeless next to scopeless warns and allows). `--scope` emits explicit `scope:` globs; `objectives:`/`component:` are emitted only when the backing spec file exists (see `spec-fallback.md`).
 - `scripts/progress-sync.js [--month YYYY-MM] [--dry-run] [--json] [--relay-manifest PATH] [--finalize]` — sync monthly progress issue.
-- `scripts/sprint-close.sh [backlog-dir] [--dry-run] [--close-milestone]` — close the single active sprint and print the doctor/reassess signal summary.
+- `scripts/sprint-close.sh [backlog-dir] [--track slug] [--dry-run] [--close-milestone]` — close an active sprint and print the doctor/reassess signal summary; `--track` picks the track when several are active, otherwise an unambiguous single active needs no flag.
 - `scripts/objectives-check.js [--sprints-dir PATH] [--charter PATH] [--json]` — verify sprint Objective IDs.
 - `scripts/component-lint.js [--sprints-dir PATH] [--capabilities PATH] [--json]` — verify sprint `component:` handles.
 - `scripts/capabilities-doctor.js [--capabilities PATH] [--json] [--strict]` — check `spec/capabilities.md` compactness and Learnings markers.
 - `scripts/backlog-doctor.js [--json] [--stale-days N] [backlog-dir]` — aggregate backlog health checks; hard violations fail, soft execution signals warn. JSON includes top-level `reassess_signal`.
-- `scripts/sprint-mirror.js [backlog-dir] [--dry-run] [--json]` — publish the active sprint to a read-only GitHub issue mirror; explicit sync only.
-- `scripts/context-hook.sh [backlog-dir]` — one-line active-sprint summary for a Claude Code PreToolUse hook; silent when no active sprint.
+- `scripts/sprint-mirror.js [backlog-dir] [--track slug] [--dry-run] [--json]` — publish one active sprint track to a read-only GitHub issue mirror; a portfolio requires `--track`, and sync stays explicit only.
+- `scripts/context-hook.sh [backlog-dir]` — one-line active-sprint summary for a Claude Code PreToolUse hook (portfolio line for N tracks); silent when no active sprint.
 
 ## Tracker routing
 


### PR DESCRIPTION
## Summary

**#295 (Phase 3)** — the documentation half of the multi-track initiative (epic #289, PRD §6.4/§7), now unblocked by the #294 human-gated spec amendment (#308). No script changes.

### `references/integration-contract.md`

- Actor JSON surface documented as **`schema_version: 2`**: `active_sprints[]` (started-asc portfolio) plus every retained v1 field — single-track values byte-compatible, portfolio leaves singular fields `null`/empty; `--track`/`--component` selectors documented.
- "Ambiguous active sprint state is fail-loud" → "**Multiple active tracks are a portfolio; overlapping-scope tracks are fail-loud**" (`OVERLAPPING_TRACKS`, shared `scopesOverlap`).
- Component routing gains the track-scope-key rule: *"When multiple sprints are active, `component:` is also the primary track-scope key; two active tracks MUST NOT share a `component:`."*
- **Relay-Merge Sprint Update Format** and **Capability Learnings Append Contract** gain track-resolution paragraphs (`sprint-state.js --component <slug>` / `--track <slug>`; never guess across tracks, never write one task's update into another track's sprint).
- Doctor section documents per-track check fan-out + `track` tags; also corrects a pre-existing inaccuracy — the between-sprints zero-active state is an informational warn, not a hard failure.
- Versioning: checkbox/annotation grammar explicitly unchanged; JSON change is additive.

### SKILL.md / process.md / scripts.md

Singleton prose flipped everywhere to "one active track per scope; disjoint tracks coexist": core contract bullet, frontmatter table (new `scope:` row), Orient/Plan portfolio paths, `--track`/`--scope` flag inventory, close/next/mirror rows, unplanned-work concurrent-track option. The formerly gated multi-track eval prompt is un-gated; the overlap-refusal eval replaces the old any-second-active refusal. `grep` confirms **no residual "exactly one active sprint" claim** outside the PRD's historical context.

### README.md / CHANGELOG.md

- README: new **Multi-Track Sprints** section — when to open a second track, explicit scope declaration (D2), the overlap invariant and its fail-loud surfaces, portfolio commands.
- CHANGELOG: multi-track headline + phased Added entry (#291/#293/#292/#294/#295) and the `sprint-init.test.js` cwd-rot Fixed note.

## Coordination

The dev-relay-parsed checkbox/annotation grammar is untouched; the JSON surface change is additive with retained v1 fields. A coordination comment will be posted on `sungjunlee/dev-relay#954` after merge (feeds #955–#957).

## Verification

- `bash smoke-test.sh` → 187/187 pass; `backlog-doctor` 8/8 PASS (docs-only change)
- Residual-claim grep clean across `skills/`, README, CHANGELOG

Refs #295, #289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 서로 다른 범위의 스프린트를 여러 개 동시에 활성화할 수 있습니다.
  * 범위가 겹치는 활성 스프린트는 생성이 거부됩니다.
  * 상태 조회에서 여러 트랙을 포트폴리오 형태로 확인할 수 있으며, 특정 트랙을 선택해 작업할 수 있습니다.
  * 단일 트랙 사용 시 기존 상태 정보와의 호환성이 유지됩니다.

* **문서**
  * 멀티 트랙 스프린트 운영 규칙, 작업 흐름 및 JSON 상태 형식을 문서화했습니다.

* **버그 수정**
  * 스프린트 초기화 테스트의 특정 디렉터리 존재 의존성을 제거했습니다.
  * 스프린트 종료 옵션 처리와 다중 트랙 선택 규칙을 보완했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->