### PR TITLE
chore: close multi-track sprint — 6/6, epic #289 dev-backlog side done

### DIFF
--- a/backlog/sprints/2026-07-multi-track-sprints.md
+++ b/backlog/sprints/2026-07-multi-track-sprints.md
@@ -1,6 +1,6 @@
 ---
 milestone: 2026-07 multi-track sprints
-status: active
+status: completed
 started: 2026-07-11
 due: TBD
 objectives: [O1]
@@ -46,3 +46,4 @@ Replace the global single-active-sprint invariant with a component-partitioned m
 - 2026-07-12: #292 Phase 1b — sprint-init refuses only on scope overlap (--scope flag, D2 explicit), sprint-close/--track, sprint-mirror/--track; init/close single-track G4 verified byte-identical (text + exit codes + written files); fixed the cwd-dependent sprint-init.test.js #13 rot. Smoke 187/187.
 - 2026-07-12: #294 human-gated spec-grill pass — capabilities.md sprint-execution invariant flipped to track-partitioned scope disjointness, backlog-sync sprint-mirror predicate rewritten per-track, header notes component: as the track-scope key; Decisions rows appended in both capabilities; system-map Core Flows 4/5 de-singularized (the originally cited :36 line no longer existed post tracker-adapter refactor). Unblocks #295.
 - 2026-07-12: #295 docs — integration-contract documents schema_version 2 (active_sprints[] + retained v1 fields), portfolio/overlap contract, track resolution for relay-merge and Learnings appends; SKILL.md/process.md/scripts.md/README prose flipped off the singleton (no residual "exactly one active sprint" claim); CHANGELOG multi-track entry; multi-track eval prompt un-gated. dev-relay#954 coordination comment posted. dev-backlog side of epic #289 complete — remaining work is dev-relay #955/#956/#957.
+- 2026-07-12: Sprint closed. 6/6 tasks completed.

--- a/backlog/sprints/_context.md
+++ b/backlog/sprints/_context.md
@@ -8,6 +8,7 @@
 - Direct GitHub task lifecycle transport belongs to the GitHub adapter. Milestones, PR relationships, mirrors, progress issues, comments, and closing semantics remain explicit capabilities or narrowly named provider transports.
 - Local mode owns the canonical `tasks/` → `completed/` core lifecycle; unsupported provider capabilities fail before effects instead of changing tracker authority.
 - Setup recommendations never override a persisted tracker selection, and setup re-runs preserve user-authored configuration and task bytes.
+- Active sprints partition by track scope (2026-07, epic #289): `component:` equality or explicit `scope:` globs decide overlap through the ONE `scopesOverlap()` in `scripts/lib.js` — never re-implement it. Disjoint tracks coexist as a portfolio; overlap fails loud; single-track behavior is the G4 text-byte-identity compatibility surface (anchored in smoke-test.sh; never snapshot `--json`, which is schema-versioned instead).
 
 ## Conventions
 - Prefer minimal-diff refactors over repo-wide rewrites
@@ -32,3 +33,4 @@
 - Reassess signal counting is date-granular: sprints closed on the same day as (or after) the latest `backlog/triage/YYYY-MM-DD-reassess.md` all count, so several small same-day closes can re-trigger the recommendation right after a reassess (observed 2026-07-04). Judgment call at close time; tune the threshold/rule if it keeps nagging (PRD listed thresholds as dogfood-tunable).
 - `references/spec-fallback.md` is consumption-side only, ~1 page hard cap: it says how dev-backlog/backlog-triage BEHAVE when the spec axis is thin/absent, never authors spec semantics (that lives in craftkit). Guard against it drifting into a second spec-axis authority — that was the 2026-06/07 silent-fork failure mode (#253)
 - Smoke flake (not a regression): the live-repo `status: shows sprint name` assertion in `smoke-test.sh` depends on `gh issue list` and can fail intermittently on network; re-run before assuming a change broke it. The offline cold-adopter section is deterministic (2026-07)
+- Charter O1's "single execution state" wording predates multi-track; it means shared state, not sprint count (compatible per #294 analysis). A human-gated wording clarification stays an open candidate — never amend the charter silently (2026-07, epic #289)


### PR DESCRIPTION
Closes out `backlog/sprints/2026-07-multi-track-sprints.md` via `sprint-close.sh` (dogfooding the close flow shipped this sprint): `status: completed`, 6/6 tasks, pre-close doctor 8/8 PASS. Durable Running Context promoted to `_context.md`:

- the `scopesOverlap()` single-predicate rule + G4 text-anchor convention (Architecture Decisions)
- the charter-O1 wording clarification candidate — human-gated, still open (Known Gotchas)

The close's reassess signal **fired** (3 sprints closed since `backlog/triage/2026-07-04-reassess.md`, threshold 3) — surfaced to the operator rather than auto-run, per the report-only rule.

Refs #289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)