### PR TITLE
docs: run the post-multi-track signal-driven reassessment (#312)

### DIFF
--- a/backlog/sprints/2026-07-v0-8-0-hardening.md
+++ b/backlog/sprints/2026-07-v0-8-0-hardening.md
@@ -20,10 +20,11 @@ reviewed, and the resulting release is ready to cut as v0.8.0.
 
 ### Batch 2 - Direction check [after:#311]
 
-- [ ] #312 docs: run the post-multi-track signal-driven reassessment (~45min)
+- [x] #312 docs: run the post-multi-track signal-driven reassessment (~45min) → report `backlog/triage/2026-07-20-reassess.md` + issue #315
 
 ### Batch 3 - Release [after:#311,#312]
 
+- [ ] #315 spec: amend system-map stale O8/O9 evidence status (~20min)
 - [ ] #313 release: prepare and cut v0.8.0 (~45min)
 
 ## Running Context
@@ -53,3 +54,12 @@ reviewed, and the resulting release is ready to cut as v0.8.0.
 - 2026-07-16: #311 → PR #314 → independently reviewed twice (Critical/Important
   0 after fixes) → user-approved squash merge. Issue #311 closed; Batch 1
   complete and #312 is next.
+- 2026-07-20: #312 reassessment run (analysis delegated to a subagent). Report
+  `backlog/triage/2026-07-20-reassess.md`: backlog-doctor 8/8, capabilities-
+  doctor ok (5 caps/198 lines), component-lint clean. One concrete drift —
+  `system-map.md:79` stale O8/O9 status contradicting validated charter — filed
+  as #315 (milestone 15, clear before/with the v0.8.0 tag). O6 stays
+  `[deferred]` on a negative demand scan. No v0.8.0 blockers found. Deferred
+  candidates stay recorded in the report only: charter O1 wording (human-gated),
+  `tracker-task-truth` setup-idempotency grill line, optional Windows invariant
+  line (can ride the #315 pass).

--- a/backlog/triage/2026-07-20-reassess.md
+++ b/backlog/triage/2026-07-20-reassess.md
@@ -1,0 +1,50 @@
+# Reassess Report — 2026-07-20
+
+Report-only stale-spec review triggered by the sprint-close reassess signal (doctor clean; 3 sprints closed since the last reassess `2026-07-07`, threshold 3). The three closes are the tracker-adapter foundation (`2026-07-tracker-seam`, `2026-07-tracker-local-cycle`, objectives O8/O9) and multi-track sprints (`2026-07-multi-track-sprints`, epic #289). This dated report resets the 3-sprint counter. Report-only: no spec files were edited. Accepted fixes route through `spec-charter amend`, `spec-system-map amend`, `spec-grill <capability>`, or a user-approved Learning Action.
+
+## Evidence
+
+- `capabilities-doctor --json`: `ok`, 5 capabilities, 198 lines, every block within budget, no warnings/hard failures. `tracker-task-truth` carries 6 Learnings (all 2026-07-11/12), `sprint-execution` 3; the other three carry 0. The capability spec is fresh, not bloated.
+- `component-lint --json`: no issues; 22 sprints checked, 15 routed / 7 unrouted (the unrouted are pre-spec-axis legacy sprints — expected, not drift), 1 active track.
+- `backlog-doctor`: 8/8 PASS; `active_sprint` reports exactly one active track (`2026-07-v0-8-0-hardening`); reassess signal fired (3 closed since 2026-07-07).
+- The two big changes this window (tracker adapters O8/O9; multi-track #289) already had their spec impact **absorbed by human-gated amends inside the same cycle**: charter O8/O9 promoted to `[validated]` (`charter.md:43-44`, proof PR #303); `capabilities.md` singleton invariant flipped to track-partitioned disjointness via the human-run `spec-grill` pass #294 (`capabilities.md:69`, `:112`, `:7`); `system-map.md` Core Flows 4/5 de-singularized (`system-map.md:50-51`). Charter is at revision 9, last amended 2026-07-12.
+- `system-map.md:79` ("Executable Evidence") still reads "O8/O9 remain active until this implementation proof is merged and recorded" — but the proof (PR #303) merged 2026-07-12 and `charter.md:43-44` already marks both `[validated]`. The map contradicts the charter.
+- Active sprint `2026-07-v0-8-0-hardening`: #311 → PR #314 (Windows-first-class checkout + verification) merged 2026-07-16; #313 (cut v0.8.0) pending. `VERSION` is still `0.7.0`; `CHANGELOG.md` `[Unreleased]` already holds the multi-track + Windows + review batch.
+- No `/goal` / completion-condition-emission signal appears in any of the three closed sprints, the active sprint, `_context.md`, or the two design docs. `docs/prd-2026-07-autonomous-execution.md:42` reaffirms O6 as a consumer-side concern that "stays deferred."
+
+## No Change
+
+- Charter O8, O9 `[validated]` and O1, O3, O4, O5, O7 all still match evidence; O6 `[deferred]` is correctly parked (see Missing Evidence / verdict below).
+- `spec/capabilities.md` — the whole file is one week old on its multi-track surfaces and was authored **with** the work it governs: `sprint-execution:69` states the scope-disjointness fail-loud behavior and the single-track-identical fallback; `backlog-sync:112` states per-track `sprint-mirror` selection; `tracker-task-truth` in-scope names both `github`/`local` adapters and the normalized lifecycle. Track disjointness, the local tracker, and track-aware lifecycle are all reflected. No churn warranted.
+- `system-map.md` invariants (`:66-71`) and Core Flows (`:50-51`) — the single-active-sprint world is **already gone** from the map; nothing there still describes a global sprint singleton. Question 3 answered: no residual single-active language survives outside the one stale Executable-Evidence line called out below.
+- `backlog-sync`, `triage-grooming`, `task-progress-reporting` contracts — no new durable behavior or repeatedly worked-around constraint this cycle.
+
+## System Map Candidates
+
+- **Executable Evidence — stale O8/O9 status** — evidence: `system-map.md:79` says "O8/O9 remain active until this implementation proof is merged and recorded," contradicting `charter.md:43-44` (both `[validated]`, proof PR #303 merged 2026-07-12). Suspected change: reword the closing sentence to record the proof as merged/landed (O8/O9 validated), keeping the acceptance-test description. next: `spec-system-map amend`. **This is the one concrete drift this cycle; worth clearing before or with the v0.8.0 tag.**
+- **Windows-first-class execution path (weak/optional)** — evidence: #311/PR #314 (merged 2026-07-16, `CHANGELOG.md` `[Unreleased]` "Windows checkout and verification") made a normal Git checkout + Node + Bash a *verified* first-class path on Windows: native paths stay internal, serialized fields normalize to `/` (`portable-path.js`), Node acceptance tests resolve Git-for-Windows Bash (`bash-runtime.js:resolveBashExecutable`), CI runs the full suites on Windows, and POSIX open-lock-replacement race tests are documented Windows skips (`v0-8-0-hardening.md:34-36`). No `spec/*` file mentions platform. Suspected change: at most one line under Project-Wide Invariants or Storage/External Systems ("helpers run on POSIX and Git-for-Windows Bash; native paths internal, serialized fields `/`-normalized; POSIX-only lock-race tests skip on Windows"). next: `spec-system-map amend` (optional) — defensible either way. It shipped as a "Fixed"/hardening change, not a new capability or product-direction change, so leaving it out of spec scope is legitimate; if the map is opened for the O8/O9 fix, add it in the same pass.
+
+## Grill Candidates
+
+- **`tracker-task-truth` — setup idempotency (weak/optional)** — evidence: idempotent, zero-migration, byte-preserving `setup-dev-backlog` shipped in #277/PR #301 and is captured in the block's Learnings (`capabilities.md:43`, "pin before an explicit switch, preserve user YAML bytes") but is **not** stated as an Expected Behavior — `capabilities.md:29-31` only says setup "persists exactly one tracker selection." Suspected change: one Behavior line for idempotent re-runs / persisted-selection immutability. next: `spec-grill tracker-task-truth` (optional, low urgency) — the contract is one week old and co-authored with the work, and the behavior is already captured in the Learnings channel, so this is a transparency note rather than a stale-contract fix.
+
+## Amend Candidates
+
+- **Charter O1 wording clarification (human-gated, low urgency)** — evidence: O1's "read the same active sprint file as the single execution *state*" (`charter.md:37`) predates multi-track. `_context.md:36`, the multi-track PRD §9 D3 (`docs/prd-2026-07-multi-track-sprints.md:198`), and the multi-track sprint Running Context all record the same finding: O1 is *compatible* with multi-track (it is about shared state per track, not sprint count) but its wording is a standing human-gated clarification candidate. Suspected change: clarify "single execution state" to "shared per-track execution state" (or similar); do not weaken the objective — its meaning is already correct. next: `spec-charter amend` (human-gated). Repeatedly recorded but deliberately parked; not urgent.
+
+## Learning Actions
+
+- Keep inline: `tracker-task-truth`'s 6 Learnings (2026-07-11/12, PRs #271-#303) and `sprint-execution`'s 3 (through 2026-07-05) — all recent, high-signal startup context for the seam/local/multi-track work just shipped.
+- Promote: none — no Learning has repeated across capabilities this cycle; the tracker Learnings are fresh and already backed by a Decisions row (`capabilities.md:50`).
+- Archive: none — nothing has aged out of the hot startup path; `_context.md` context_bloat check passes (within the 200-line threshold).
+
+## Missing Evidence
+
+- **O6 demand scan is a negative result.** No `/goal` auto-emission signal exists in the three closed sprints, the active sprint, `_context.md`, or either design doc; the only mentions are historical (2026-05 triage reports) and the autonomous-execution PRD's explicit "stays deferred, consumer-side" (`docs/prd-2026-07-autonomous-execution.md:42`). Verdict recorded below.
+- `system-map.md` has no revision / last-amended frontmatter (unlike `charter.md`'s `revision: 9`), so the `:79` staleness was caught by content contradiction with the charter, not by a recorded date — the same provenance gap the 2026-07-04 reassess flagged.
+- `docs/tracker-adapter-design.md:8` ("O8/O9 stay active until the proof branch is merged") carries the same stale forward-looking status as `system-map.md:79`, but it is a design doc, not governed `spec/*`; note it for a docs cleanup, not a spec route.
+- Live GitHub/PR state (issue #313 progress, dev-relay Phase 2 leaves #955/#956/#957) was read from sprint/PRD files, not queried — this pass stayed within local files per the report-only boundary.
+
+## Recommended Next Step
+
+- Run `spec-system-map amend` to correct the `system-map.md:79` O8/O9 status (proof merged → validated); it is the one concrete drift this cycle and is cheap to fold into the v0.8.0 release housekeeping (#313). The Windows portability line can ride the same pass if desired. The `spec-charter amend` (O1 wording) and `spec-grill tracker-task-truth` (setup idempotency) candidates are low-urgency and human-gated / optional — defer them; the specs are healthy today. O6 stays `[deferred]` — no demand signal.


### PR DESCRIPTION
## Summary

- Adds the dated reassess report `backlog/triage/2026-07-20-reassess.md`, clearing the 3-sprint reassess signal (last report 2026-07-07; closes since: tracker-seam, tracker-local-cycle, multi-track).
- Evidence: backlog-doctor 8/8 PASS, capabilities-doctor `ok` (5 capabilities, 198 lines), component-lint clean.
- One concrete drift accepted → issue #315 (`system-map.md:79` stale O8/O9 status vs validated charter; `docs/tracker-adapter-design.md:8` twin). Added to Batch 3 ahead of the release.
- O6 verdict: remains `[deferred]` — negative demand scan across the three closed sprints, active sprint, `_context.md`, and design docs.
- Deferred (report-recorded only): charter O1 wording (human-gated), `tracker-task-truth` setup-idempotency grill line, optional Windows invariant line.
- Sprint file: Batch 2 checked off, #315 slotted into Batch 3.

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)