### PR TITLE
spec: amend system-map O8/O9 evidence status + windows invariant (#315)

### DIFF
--- a/backlog/sprints/2026-07-v0-8-0-hardening.md
+++ b/backlog/sprints/2026-07-v0-8-0-hardening.md
@@ -24,7 +24,7 @@ reviewed, and the resulting release is ready to cut as v0.8.0.
 
 ### Batch 3 - Release [after:#311,#312]
 
-- [ ] #315 spec: amend system-map stale O8/O9 evidence status (~20min)
+- [x] #315 spec: amend system-map stale O8/O9 evidence status (~20min) → PR #<PENDING>
 - [ ] #313 release: prepare and cut v0.8.0 (~45min)
 
 ## Running Context
@@ -63,3 +63,11 @@ reviewed, and the resulting release is ready to cut as v0.8.0.
   candidates stay recorded in the report only: charter O1 wording (human-gated),
   `tracker-task-truth` setup-idempotency grill line, optional Windows invariant
   line (can ride the #315 pass).
+- 2026-07-20: #315 amend applied. `spec-system-map` skill is installed but
+  `disable-model-invocation: true` blocks the Skill tool, so its documented
+  amend contract (re-read map + evidence, project-wide-only edits, no
+  capability/charter leakage) was followed by hand. `system-map.md:79`
+  reworded to record the proof merged as PR #303 (2026-07-12) and O8/O9
+  validated; added one Project-Wide Invariants line for Windows-first-class
+  execution per the reassess System Map Candidates. `docs/tracker-adapter-design.md`
+  twin fixed as a plain docs edit. `backlog-doctor` reverified green.

--- a/backlog/sprints/2026-07-v0-8-0-hardening.md
+++ b/backlog/sprints/2026-07-v0-8-0-hardening.md
@@ -24,7 +24,7 @@ reviewed, and the resulting release is ready to cut as v0.8.0.
 
 ### Batch 3 - Release [after:#311,#312]
 
-- [x] #315 spec: amend system-map stale O8/O9 evidence status (~20min) → PR #<PENDING>
+- [x] #315 spec: amend system-map stale O8/O9 evidence status (~20min) → PR #317
 - [ ] #313 release: prepare and cut v0.8.0 (~45min)
 
 ## Running Context

--- a/docs/tracker-adapter-design.md
+++ b/docs/tracker-adapter-design.md
@@ -3,8 +3,8 @@
 Status: implemented foundation with dual-mode acceptance proof on issue #278's
 implementation branch. Runtime evidence was originally inventoried at commit
 `019a6ec`; merged issues #273-#277 provide selection, identity, GitHub wiring,
-local persistence, and setup. GitHub remains the compatibility baseline. O8/O9
-stay active until the proof branch is merged and recorded.
+local persistence, and setup. GitHub remains the compatibility baseline. The
+proof branch merged as PR #303 (2026-07-12); O8/O9 are validated.
 
 This document froze the smallest tracker boundary that can support another
 canonical task store without weakening existing GitHub behavior. The #272

--- a/spec/system-map.md
+++ b/spec/system-map.md
@@ -69,14 +69,16 @@ are single-sourced in [`docs/tracker-adapter-design.md`](../docs/tracker-adapter
 - Unsupported optional capabilities have stable code `TRACKER_CAPABILITY_UNSUPPORTED`, tracker, capability, message, and remediation; JSON and human boundaries share that one serializer contract.
 - Sprint files remain the execution hub and completed sprint files are immutable history.
 - Automation is report-only toward `spec/*`; `spec/charter.md` is canonical and root `CHARTER.md` is legacy fallback only.
+- Helpers run on POSIX and Git-for-Windows Bash; native filesystem paths stay internal while stable serialized fields normalize to `/`; POSIX-only open-lock-replacement race tests are documented Windows skips.
 
 ## Executable Evidence
 
 `skills/dev-backlog/scripts/tracker-cycle.acceptance.test.js` proves both full
 cycles with real temporary files and subprocesses, no network, exact GitHub
 compatibility evidence, local zero-provider evidence, body-preserving updates,
-Done archive/final reads, and every optional-capability failure shape. O8/O9
-remain active until this implementation proof is merged and recorded.
+Done archive/final reads, and every optional-capability failure shape. This
+implementation proof merged as PR #303 (2026-07-12); O8 and O9 are validated
+(`charter.md:43-44`).
 
 ## Accepted Capability Contracts
 


### PR DESCRIPTION
## Summary
- Reword `spec/system-map.md:79` (Executable Evidence) to record the implementation proof as merged (PR #303, 2026-07-12) and O8/O9 as `[validated]`, matching `spec/charter.md:43-44`; kept the acceptance-test description intact.
- Add one Project-Wide Invariants line for Windows-first-class execution (POSIX + Git-for-Windows Bash, native paths stay internal, serialized fields normalize to `/`, POSIX-only lock-race tests documented as Windows skips), per the 2026-07-20 reassess report's System Map Candidates.
- Fix the same stale "O8/O9 stay active until merged" sentence in `docs/tracker-adapter-design.md` as a plain docs edit (not spec-governed).
- Check off #315 in `backlog/sprints/2026-07-v0-8-0-hardening.md` Batch 3 and log the amend in Progress.

## Verification
- `node skills/dev-backlog/scripts/backlog-doctor.js` → 8/8 PASS.
- `spec-system-map` skill is installed (`~/.claude/skills/spec-system-map`) but ships `disable-model-invocation: true`, which blocks the Skill tool from invoking it directly. Its documented amend-mode contract (re-read map + evidence, project-wide-only edits, route capability/charter changes elsewhere) was followed by hand instead.

Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)