### PR TITLE
chore(backlog): activate the v0.9.0 local substrate sprint

### DIFF
--- a/backlog/sprints/2026-07-v0-9-0-local-substrate.md
+++ b/backlog/sprints/2026-07-v0-9-0-local-substrate.md
@@ -1,0 +1,89 @@
+---
+milestone: v0.9.0 local substrate redesign
+status: active
+started: 2026-07-26
+due: TBD
+objectives: [O8, O9]
+component: "tracker-task-truth"
+---
+
+# v0-9-0-local-substrate
+
+## Goal
+`local` is one storage substrate presenting the same normalized interface a remote tracker does —
+JSON canonical, markdown derived, no lock — so adding the next tracker stays a ~170-line translator
+and the three Windows lock-race skips are gone.
+
+## Plan
+
+### Batch 1 - Design gate (blocking)
+
+- [ ] #320 design: re-tier the tracker adapters — local as storage substrate, remotes as translators (~45min)
+
+### Batch 2 - Local substrate [after:#320]
+
+- [ ] #321 refactor(local-tracker): JSON canonical store + atomic rename; drop the frontmatter YAML round-trip and the allocation lock (~4hr)
+
+### Batch 3 - Selection file [after:#321]
+
+- [ ] #322 refactor(setup): move tracker selection to backlog/.tracker; delete the config.yml YAML tokenizer (~3hr)
+
+### Batch 4 - Contract + release [after:#321,#322]
+
+- [ ] #323 docs: align contract surfaces with the local substrate redesign + record the adapter size budget (~1hr)
+- [ ] #324 release: prepare and cut v0.9.0 (~45min)
+
+## Running Context
+
+- **This is a subtraction release.** No new user-facing capability. Success is measured in code
+  removed, contract clarity, and Windows fidelity — not features added. Reject scope that adds
+  surface, including new adapters (gitlab/jira/linear come *after* the tier rule is proven, not in
+  this sprint).
+- **The seam is not the problem.** `tracker.js` (346 lines) is well-factored: minimal required
+  operations, capability gating, configured-only resolution, typed errors. Do not refactor it beyond
+  what the selection-source change in #322 requires.
+- **The asymmetry that motivates the sprint:** `github-tracker.js` is 172 lines (a translator);
+  `local-tracker.js` is 1,391 (a transactional file DB + YAML serializer). Every future tracker is
+  the first kind. `local` was placed in the wrong tier.
+- **Three YAML implementations exist today.** `lib.js:parseSimpleYaml` (~80 lines, reads
+  `config.yml`, used everywhere — **keep**), the `setup-dev-backlog.js` tokenizer (395 lines, writes
+  the tracker key — **delete via #322**), and the `local-tracker.js` frontmatter round-trip (~200
+  lines — **delete via #321**). The zero-dependency rule (no `package.json`; skills run without
+  `npm install`) is correct and stays; what was wrong was hand-writing a YAML parser to set one key.
+- **The lock is the sole cause of the Windows divergence.** Three tests carry
+  `t.skip("Windows prevents replacing an open lock pathname; Ubuntu covers this POSIX race")`.
+  Atomic rename behaves identically on both platforms, so #321 deletes those skips rather than
+  re-documenting them. Windows support gets cheaper *and* more honest — total Windows-specific code
+  is only 68 lines (`bash-runtime.js` 44 + `portable-path.js` 24) plus one CI job, and it stays.
+- **`local` has zero adopters.** Across 19 repos consuming dev-backlog, exactly one `config.yml`
+  carries a `tracker:` key and its value is the default `github` (this repo's own). No local store
+  exists anywhere. That is why the canonical-shape change ships without a migration path — and why
+  the window to make it is now.
+- **Co-authoritative trap.** The `tracker-task-truth` hard constraint forbids treating two task
+  stores as co-authoritative. The derived markdown mirror must therefore never be parsed back as
+  truth. State it in the design (#320), enforce it in code (#321), assert it in contract prose (#323).
+- **Survives the format change** (PR #298 Learnings): exact-ID allocation across active + completed,
+  fail-closed control-character/injection validation, crash-recoverable close/archive semantics.
+  Dropping any of these is a regression, not a simplification.
+- **Spec escalation rule.** The canonical-shape change reads as an implementation choice, so a
+  `Decisions` row in `spec/capabilities.md` suffices. If review finds it touches an Expected
+  Behavior or Hard Constraint, it escalates to a human-gated `spec-grill` pass — never amend an
+  invariant unattended (the v0.8.0 #294 precedent).
+- **Batches 2 and 3 are deliberately serial.** They are conceptually independent but both touch
+  `tracker.js` and `tracker-cycle.acceptance.test.js`, so they are not intra-batch parallel-safe.
+- **multi-track is explicitly out of scope and stays.** It is unused today (0 files with `scope:`,
+  0 repos with 2+ active tracks) but costs ~0 while unused (single-track output is byte-identical
+  per PRD G4), reverting it would need a human-gated capabilities amendment, and in-repo parallelism
+  is wanted — the real gap is the entry path to opening a second track, which belongs with the O3
+  portfolio work, not here.
+- Relay/PR review stops at ready-to-merge unless merge is separately approved.
+
+## Progress
+- 2026-07-26: Sprint planned from a workspace-wide complexity review. Milestone 16 and issues
+  #320-#324 filed. Evidence behind the plan: 19 repos consume dev-backlog (tamgu_note 24 sprints,
+  dev-backlog 23, dev-relay 18, beopjalal 16, ...) so adoption is real, but every v0.8.0 axis has
+  zero consumers — `local` unused, `tracker:` set in 1 of 18 configs (to the default), `scope:` in 0
+  files, 0 repos with 2+ active tracks. Diagnosis: the charter validates objectives on
+  implementation proof, not on adoption, so surface accumulates while every health signal stays
+  green. Response chosen: keep the generalization direction (more trackers *are* wanted), fix the
+  tier model so it stays cheap, and record a 200-line adapter budget as the durable guard.


### PR DESCRIPTION
Plans milestone 16 (#320–#324) as a **subtraction release**: re-tier the tracker adapters so `local` is one storage substrate rather than a second tracker.

## Why

Measured across the 19 repos that consume dev-backlog — adoption is real, but every v0.8.0 axis has zero consumers:

| axis | usage |
|---|---|
| `local` tracker | no local store exists in any repo |
| `tracker:` key | 1 of 18 `config.yml` files, value = the default `github` |
| `scope:` (multi-track) | 0 sprint files |
| 2+ active tracks | 0 repos |

The asymmetry that motivates the work: `github-tracker.js` is 172 lines (a translator over `gh`); `local-tracker.js` is 1,391 (a transactional file DB plus a YAML round-trip serializer). Every tracker we would add next is the first kind — `local` was placed in the wrong tier.

The seam itself (`tracker.js`, 346 lines) is sound and stays.

## Scope

- #320 design gate — adapter tiering, local canonical shape, 200-line adapter budget
- #321 `local-tracker.js` → JSON canonical + atomic rename; drops the frontmatter YAML round-trip, the allocation lock, and the 3 Windows lock-race skips
- #322 tracker selection → `backlog/.tracker`; deletes the 395-line `config.yml` YAML tokenizer
- #323 contract surfaces + capability Decisions row
- #324 cut v0.9.0

## Deliberately out of scope

**multi-track stays.** Unused today but ~0 cost while unused (single-track output is byte-identical per PRD G4), reverting would need a human-gated capabilities amendment, and in-repo parallelism is wanted — the real gap is the entry path to opening a second track, which belongs with the O3 portfolio work.

## Verification

`backlog-doctor` 8/8 PASS; `next.sh` resolves Batch 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UekMHpbBRahCdnP9Jhd6ap