### PR TITLE
refactor(local-tracker): JSON canonical store + compare-and-swap commits (#321)

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ This keeps Codex focused on one execution file, not ten browser tabs and stale i
 |----------|-----|
 | Exactly one tracker owns task truth | GitHub collaboration and offline local work share one core lifecycle without becoming co-authoritative |
 | Sprint files are the execution hub | One file carries plan, context, and progress across sessions |
-| Task-file authority is mode-specific | Thin mirrors in GitHub mode; canonical active/completed files in local mode |
+| Task files are always mirrors | GitHub Issues or `local-tracker.json` owns task truth; both modes emit the same active/completed Markdown shape |
 | `_context.md` holds cross-sprint knowledge | Sprint files stay local to the sprint, project memory stays shared |
 | Sync is always explicit | No background process mutates your local state behind your back |
 | Task-file format is Backlog.md-compatible | `tasks/` follows the [Backlog.md](https://github.com/MrLesk/Backlog.md) task format; `sprints/` and `gh` sync are dev-backlog additions |

--- a/docs/tracker-adapter-design.md
+++ b/docs/tracker-adapter-design.md
@@ -82,11 +82,13 @@ That single decision is what lets the substrate shrink:
 - a single store file keeps write-temp plus atomic rename for complete,
   non-torn replacement.
 
-The deleted allocation lock had two jobs: atomic replacement prevents partial
-or interleaved store bytes, but it does not serialize ID allocation or any other
-read-modify-write. `local` therefore uses a minimal create-exclusive lock for
-that second job: bounded acquisition retries, then close and unlink by its own
-holder, with no stamps, liveness probing, replacement, or reclamation.
+The deleted allocation lock had two jobs: atomic rename prevents partial or
+interleaved store bytes, but it does not serialize ID allocation or any other
+read-modify-write. `local` handles that second job with revision-based
+compare-and-swap: a complete fsynced candidate claims its next revision through
+no-overwrite `link`, then renames into place; a collision re-reads and retries
+within a bounded budget. A crash leaves only inert revision-identified debris,
+never a lock that another writer must interpret or reclaim.
 
 **Co-authoritative rule (binding).** The derived mirror is never parsed back as
 truth. Every read resolves from the JSON store; a hand-edit to a mirror file is

--- a/docs/tracker-adapter-design.md
+++ b/docs/tracker-adapter-design.md
@@ -321,9 +321,9 @@ Exactly one explicitly configured tracker owns canonical task truth for a
 repository. Initial configured values are `github` and `local`; an absent new
 key may retain GitHub through the compatibility default frozen for #273, but
 runtime availability never chooses a value. Sprint files remain the canonical
-execution hub, and task files are either canonical local tasks or derived
-GitHub mirrors according to the selected adapter. They are never two canonical
-task stores.
+execution hub. Task files are derived mirrors in both modes; local task truth
+lives only in `backlog/local-tracker.json`, while GitHub task truth remains in
+GitHub Issues. They are never two canonical task stores.
 
 The seam is deep rather than a command wrapper: callers ask for task lifecycle
 operations and stable identity. The GitHub adapter owns GitHub transport and

--- a/docs/tracker-adapter-design.md
+++ b/docs/tracker-adapter-design.md
@@ -79,9 +79,14 @@ That single decision is what lets the substrate shrink:
 
 - markdown is no longer canonical, so the frontmatter YAML parse/serialize path
   and CRLF byte preservation are deleted;
-- a single store file means concurrent writers are handled by write-temp plus
-  atomic rename (~30 lines) instead of the allocation lock, stamp inspection,
-  retry loop, and close compensation (~350 lines).
+- a single store file keeps write-temp plus atomic rename for complete,
+  non-torn replacement.
+
+The deleted allocation lock had two jobs: atomic replacement prevents partial
+or interleaved store bytes, but it does not serialize ID allocation or any other
+read-modify-write. `local` therefore uses a minimal create-exclusive lock for
+that second job: bounded acquisition retries, then close and unlink by its own
+holder, with no stamps, liveness probing, replacement, or reclamation.
 
 **Co-authoritative rule (binding).** The derived mirror is never parsed back as
 truth. Every read resolves from the JSON store; a hand-edit to a mirror file is
@@ -128,18 +133,18 @@ round-trip (task files — deleted).
 
 ### Windows consequence
 
-The allocation lock is the sole cause of the local tracker's Windows
-divergence. Three tests carry:
+Replacing an open allocation-lock pathname during reclamation was the sole
+cause of the local tracker's Windows divergence. Three tests carried:
 
 ```
 t.skip("Windows prevents replacing an open lock pathname; Ubuntu covers this POSIX race")
 ```
 
-Atomic rename behaves identically on both platforms, so the redesign **deletes**
-those skips rather than re-documenting them, and their replacement coverage runs
-everywhere. Windows-specific code stays at 68 lines (`bash-runtime.js` 44 plus
-`portable-path.js` 24) and the `windows-latest` CI job. Windows support gets
-cheaper and more honest, not weaker.
+The minimal lock never replaces or reclaims an open pathname: its holder alone
+closes and unlinks it. The redesign therefore still **deletes** those skips, and
+the concurrent-writer replacement coverage runs everywhere. Windows-specific
+code stays at 68 lines (`bash-runtime.js` 44 plus `portable-path.js` 24) and the
+`windows-latest` CI job.
 
 ### What survives unchanged
 

--- a/docs/tracker-adapter-design.md
+++ b/docs/tracker-adapter-design.md
@@ -142,10 +142,12 @@ cause of the local tracker's Windows divergence. Three tests carried:
 t.skip("Windows prevents replacing an open lock pathname; Ubuntu covers this POSIX race")
 ```
 
-The minimal lock never replaces or reclaims an open pathname: its holder alone
-closes and unlinks it. The redesign therefore still **deletes** those skips, and
-the concurrent-writer replacement coverage runs everywhere. Windows-specific
-code stays at 68 lines (`bash-runtime.js` 44 plus `portable-path.js` 24) and the
+Compare-and-swap has no lock pathname to reclaim. A writer claims its revision
+through no-overwrite `link` and renames its own complete candidate into place;
+nothing is ever replaced while another process holds it open. The redesign
+therefore **deletes** those skips rather than re-documenting them, and the
+concurrent-writer coverage runs everywhere. Windows-specific code stays at 68
+lines (`bash-runtime.js` 44 plus `portable-path.js` 24) and the
 `windows-latest` CI job.
 
 ### What survives unchanged

--- a/skills/dev-backlog/SKILL.md
+++ b/skills/dev-backlog/SKILL.md
@@ -93,7 +93,7 @@ Follow `references/process.md` → `## Create — New Issues`.
 
 Done when the new task exists in the configured canonical store and is added to
 the active sprint Plan when in scope. GitHub mode may explicitly refresh its
-local mirror; local mode already wrote the canonical task file.
+local mirror; local mode writes canonical JSON and refreshes its derived mirror.
 
 ### Plan
 

--- a/skills/dev-backlog/references/file-format.md
+++ b/skills/dev-backlog/references/file-format.md
@@ -67,18 +67,20 @@ adapter allocates the canonical local ID.
 
 ## Body Structure
 
-Task files are thin GitHub mirrors when `tracker: github` and canonical task
-records when `tracker: local`. Notes, decisions, and cross-task context still go
-in the **sprint file** (`backlog/sprints/`), not here.
+Task files are derived mirrors in both modes: from GitHub Issues when
+`tracker: github`, and from `backlog/local-tracker.json` when `tracker: local`.
+Notes, decisions, and cross-task context still go in the **sprint file**
+(`backlog/sprints/`), not here.
 
 ```markdown
 ## Description
 [Synced from GitHub issue body — includes any checkboxes from the issue]
 ```
 
-`sync-pull.js` wraps a GitHub issue body in `## Description`. Local create stores
-the supplied body directly. Acceptance criteria checkboxes remain human-authored
-bytes in either mode; metadata-only refresh/update preserves them.
+`sync-pull.js` and the local projection wrap a task body in `## Description`.
+In GitHub mode the issue body is authoritative. In local mode the JSON body is
+authoritative, so hand-edited mirror bytes are overwritten on the next local
+write rather than parsed back into task truth.
 
 For manual task files or Backlog.md CLI compatibility, you can optionally add structured AC markers:
 
@@ -128,15 +130,18 @@ it never migrates task files.
 
 ## Local Canonical Storage (`tracker: local`)
 
-In local mode `backlog/tasks/` and `backlog/completed/` are the **canonical**
-task store. Required list/read/create/update/close operations return normalized
-identity `{ tracker: "local", id, ref: "{PREFIX}-{N[.M]}" }` without fabricating
-a URL. Metadata-only updates preserve body/AC bytes; close writes `status: Done`
-and archives the same file. Local reports no optional provider capabilities, so
+In local mode `backlog/local-tracker.json` is the **canonical** task store.
+`backlog/tasks/` and `backlog/completed/` are one-way derived mirrors and are
+never read back as task truth. Required list/read/create/update/close operations
+return normalized identity
+`{ tracker: "local", id, ref: "{PREFIX}-{N[.M]}" }` without fabricating a URL.
+Metadata-only updates preserve the canonical body/AC bytes; close atomically
+changes one JSON record to `state: closed` and projects `status: Done`. Local
+reports no optional provider capabilities, so
 milestones, PR relationships, mirrors, progress issues, comments, and closing
 semantics fail before filesystem or provider effects and never invoke `gh`.
 
-Filesystem allocation, publication, collision, and recovery details have one
+JSON allocation, atomic publication, collision, and recovery details have one
 implementation owner: [Tracker Adapter Design Contract](../../../docs/tracker-adapter-design.md).
 
 dev-backlog also reads `task_prefix`, `default_status`, and `statuses`;

--- a/skills/dev-backlog/references/integration-contract.md
+++ b/skills/dev-backlog/references/integration-contract.md
@@ -12,7 +12,7 @@ Any actor consuming dev-backlog state should treat these files as the stable rea
 
 - `backlog/sprints/*.md` with `status: active` are the active execution hubs — one per disjoint-scope track (most repos run a single track): frontmatter identifies lifecycle, routing, and track-scope state; `## Goal`, `## Plan`, `## Running Context`, and `## Progress` identify the current objective, work queue, reusable discoveries, and execution trace.
 - `backlog/sprints/_context.md` is cross-sprint project memory. Its sections provide durable context for future sessions and analyzers.
-- `backlog/tasks/` and `backlog/completed/` have mode-specific authority. With `tracker: github` they are derived issue mirrors; with `tracker: local` they are the canonical active/completed task store. Task files carry bodies and Acceptance Criteria checkboxes; sprint files remain the execution log.
+- `backlog/tasks/` and `backlog/completed/` are derived mirrors in both modes. GitHub Issues are authoritative for `tracker: github`; `backlog/local-tracker.json` is authoritative for `tracker: local`. Local mirrors are never parsed back into task truth. Task files expose bodies and Acceptance Criteria checkboxes; sprint files remain the execution log.
 - `spec/capabilities.md`, when present, is an optional capability-level learning target addressed by active sprint frontmatter `component:`.
 
 The sections below define the path, heading, checkbox, and annotation grammar. Consumers may read more prose, but they must not require additional headings or rewritten formats to orient from files alone.
@@ -436,7 +436,7 @@ This allows comment upserts to stay idempotent and prevents duplicate machine co
 - **No sprint file**: actors skip sprint tracking entirely. Tasks still work standalone.
 - **No `_context.md`**: ignored silently.
 - **Missing section in sprint**: treated as empty.
-- **No GitHub mirror file**: GitHub-capable actors may read the canonical issue through the configured adapter; local mode must fail a missing canonical file rather than call `gh`.
+- **No task mirror file**: actors read the canonical provider through the configured adapter. A local mirror is regenerated on the next local write and its absence never causes a `gh` call.
 - **Unsupported optional capability**: return the typed error above; do not fabricate an empty provider result, mutate local state, or switch trackers.
 - **No relay manifest path**: progress reporting stays backlog-only.
 

--- a/skills/dev-backlog/references/process.md
+++ b/skills/dev-backlog/references/process.md
@@ -53,7 +53,7 @@ the linked Tracker Adapter Design Contract.
 
 1. Call the configured adapter's required `create` operation.
 2. Use its returned normalized ref in the current sprint Plan when in scope: GitHub `#N`, local `{PREFIX}-N[.M]`.
-3. In GitHub mode, explicitly materialize/refresh the thin task mirror with `sync-pull.js`. In local mode, create already wrote the canonical task file; do not call `gh`.
+3. In GitHub mode, explicitly materialize/refresh the thin task mirror with `sync-pull.js`. In local mode, create already wrote canonical JSON and its derived task mirror; do not call `gh`.
 
 ## Plan — Sprint
 
@@ -111,7 +111,7 @@ effects and never switches trackers.
 ## Quick Fix — Single Task, No Sprint
 
 Read, update, and close the task through the configured adapter. GitHub may use
-its normal issue/closing behavior; local stays entirely in canonical Markdown.
+its normal issue/closing behavior; local stays entirely in its canonical JSON store.
 Create a sprint only when execution context needs to span work or sessions.
 
 ## Unplanned Work — Mid-Sprint Scope Change

--- a/skills/dev-backlog/references/scripts.md
+++ b/skills/dev-backlog/references/scripts.md
@@ -35,8 +35,9 @@ node "$skill_dir/scripts/sprint-init.js" "next-sprint" --dry-run
 
 `backlog/config.yml` is the only runtime selection authority. Missing `tracker:`
 retains legacy GitHub behavior without rewriting the config. GitHub mode uses
-`gh` and treats task files as mirrors; local mode treats task files as canonical
-and makes zero provider calls. `sprint-init`, `sprint-mirror`, and
+`gh` and treats task files as mirrors; local mode uses `local-tracker.json` as
+canonical and derives the same task-file mirrors with zero provider calls.
+`sprint-init`, `sprint-mirror`, and
 `progress-sync` are representative JSON-capable optional-feature boundaries:
 when unsupported, `--json` exits non-zero with the shared `{ "error": ... }`
 contract from `tracker.js`, while human mode prints the same remediation.

--- a/skills/dev-backlog/scripts/github-capabilities.test.js
+++ b/skills/dev-backlog/scripts/github-capabilities.test.js
@@ -21,6 +21,7 @@ const { sync: syncMirror } = require("./sprint-mirror.js");
 const { sync: syncProgress } = require("./progress-sync.js");
 const { createSprintFile } = require("./sprint-init.js");
 const { listStatusRows } = require("./tracker-status-list.js");
+const { createLocalAdapter } = require("./local-tracker.js");
 const { collectSnapshot } = require("../../backlog-triage/scripts/triage-collect.js");
 const { execute: applyTriage } = require("../../backlog-triage/scripts/triage-apply.js");
 
@@ -114,14 +115,12 @@ describe("GitHub optional capability transports", () => {
       path.join(backlogDir, "config.yml"),
       "tracker: local\ntask_prefix: BACK\n"
     );
-    fs.writeFileSync(
-      path.join(backlogDir, "tasks", "BACK-7.2 - custom-store-task.md"),
-      [
-        "---", "id: BACK-7.2", "title: Custom store task", "status: To Do",
-        "labels: [offline]", "priority: medium", "created_date: '2026-07-12'", "---",
-        "## Description", "Custom local task", "",
-      ].join("\n")
-    );
+    createLocalAdapter({ backlogDir }).create({
+      id: "7.2",
+      title: "Custom store task",
+      body: "Custom local task",
+      labels: ["offline"],
+    });
     const columnPath = path.join(binDir, "column");
     fs.writeFileSync(columnPath, "#!/bin/sh\ncat\n");
     fs.chmodSync(columnPath, 0o755);

--- a/skills/dev-backlog/scripts/local-tracker.integration.test.js
+++ b/skills/dev-backlog/scripts/local-tracker.integration.test.js
@@ -26,7 +26,6 @@ function makeOfflineStore(t) {
   return { root, backlogDir };
 }
 
-/** Install a `gh` that records any invocation and fails, proving no-gh paths. */
 function installFailingGh(t, root) {
   const binDir = path.join(root, "bin");
   fs.mkdirSync(binDir, { recursive: true });
@@ -36,16 +35,32 @@ function installFailingGh(t, root) {
     `#!/bin/sh\necho "gh $*" >> "${marker}"\nexit 97\n`
   );
   fs.chmodSync(path.join(binDir, "gh"), 0o755);
-  const savedPath = process.env.PATH;
-  process.env.PATH = `${binDir}:${savedPath}`;
-  t.after(() => {
-    process.env.PATH = savedPath;
-  });
-  return { binDir, marker, envPath: `${binDir}:${savedPath}` };
+  const envPath = `${binDir}:${process.env.PATH}`;
+  return { marker, envPath };
 }
 
 function localAdapter(backlogDir) {
   return resolveConfiguredTracker({ tracker: "local" }, { backlogDir });
+}
+
+function canonical(backlogDir) {
+  return JSON.parse(fs.readFileSync(path.join(backlogDir, "local-tracker.json"), "utf8"));
+}
+
+function strays(backlogDir) {
+  const result = [];
+  function walk(dir) {
+    for (const name of fs.readdirSync(dir)) {
+      const full = path.join(dir, name);
+      const stat = fs.lstatSync(full);
+      if (stat.isDirectory()) walk(full);
+      else if (name.endsWith(".tmp") || name === ".local-tracker.lock" || name === ".local-tracker.close") {
+        result.push(full);
+      }
+    }
+  }
+  walk(backlogDir);
+  return result;
 }
 
 describe("offline local core sprint cycle", () => {
@@ -54,22 +69,25 @@ describe("offline local core sprint cycle", () => {
     const { marker, envPath } = installFailingGh(t, root);
     const { adapter } = localAdapter(backlogDir);
 
-    // create three canonical local tasks, offline
     const first = adapter.create({ title: "Design offline adapter" });
-    const second = adapter.create({ title: "Prove core cycle" });
+    const second = adapter.create({
+      title: "Prove core cycle",
+      body: "Human body\n\n## Acceptance Criteria\n- [ ] Keep this AC",
+    });
     const third = adapter.create({ title: "Archive on close" });
-    assert.deepEqual([first, second, third].map((task) => task.ref), ["BACK-1", "BACK-2", "BACK-3"]);
+    assert.deepEqual([first, second, third].map((task) => task.ref), [
+      "BACK-1",
+      "BACK-2",
+      "BACK-3",
+    ]);
     assert.equal([first, second, third].every((task) => !("url" in task)), true);
 
-    // Plan them into an active sprint using their normalized refs
     fs.writeFileSync(
       path.join(backlogDir, "sprints", "cycle.md"),
       [
         "---", "milestone: local cycle", "status: active", "started: 2026-07-11", "---", "",
-        "# Offline Local Cycle", "",
-        "## Goal", "Prove the offline local core cycle.", "",
-        "## Plan", "",
-        "### Batch 1 - core",
+        "# Offline Local Cycle", "", "## Goal", "Prove the offline local core cycle.", "",
+        "## Plan", "", "### Batch 1 - core",
         `- [ ] ${first.ref} Design offline adapter`,
         `- [ ] ${second.ref} Prove core cycle`,
         `- [ ] ${third.ref} Archive on close`,
@@ -77,50 +95,48 @@ describe("offline local core sprint cycle", () => {
       ].join("\n")
     );
 
-    // status orientation: the active sprint reads back normalized local plan items
     const state = readSprintState({ backlogDir });
     assert.equal(state.active_sprint.frontmatter.milestone, "local cycle");
     assert.deepEqual(state.plan_items.map((item) => item.ref), ["BACK-1", "BACK-2", "BACK-3"]);
-    assert.equal(state.plan_items.every((item) => item.tracker === "local" && item.issue_number === null), true);
+    assert.equal(
+      state.plan_items.every((item) => item.tracker === "local" && item.issue_number === null),
+      true
+    );
+    assert.deepEqual(findNextBatch(state.plan_items).items.map((item) => item.ref), [
+      "BACK-1",
+      "BACK-2",
+      "BACK-3",
+    ]);
 
-    // next orientation: the first todo batch is the local batch we planned
-    const nextBatch = findNextBatch(state.plan_items);
-    assert.equal(nextBatch.heading, "### Batch 1 - core");
-    assert.deepEqual(nextBatch.items.map((item) => item.ref), ["BACK-1", "BACK-2", "BACK-3"]);
-
-    // the whole orientation path is gh-free when driven as a subprocess
-    const oriented = spawnSync(process.execPath, [
-      path.join(SCRIPTS_DIR, "sprint-state.js"), "--mode", "next", backlogDir, "--json",
-    ], { encoding: "utf8", env: { ...process.env, PATH: envPath } });
+    const oriented = spawnSync(
+      process.execPath,
+      [path.join(SCRIPTS_DIR, "sprint-state.js"), "--mode", "next", backlogDir, "--json"],
+      { encoding: "utf8", env: { ...process.env, PATH: envPath } }
+    );
     assert.equal(oriented.status, 0);
-    const orientedState = JSON.parse(oriented.stdout);
-    assert.deepEqual(orientedState.plan_items.map((item) => item.ref), ["BACK-1", "BACK-2", "BACK-3"]);
+    assert.deepEqual(JSON.parse(oriented.stdout).plan_items.map((item) => item.ref), [
+      "BACK-1",
+      "BACK-2",
+      "BACK-3",
+    ]);
 
-    // read one task by its normalized ref
-    const readBack = adapter.read(second.ref);
-    assert.equal(readBack.title, "Prove core cycle");
-    assert.equal(readBack.status, "To Do");
-    assert.equal(readBack.state, "open");
+    const body = adapter.read(second).body;
+    adapter.update(second, { status: "In Progress" });
+    assert.equal(adapter.read(second).body, body);
+    assert.match(
+      fs.readFileSync(path.join(backlogDir, "tasks", "BACK-2 - prove-core-cycle.md"), "utf8"),
+      /^status: In Progress$/m
+    );
 
-    // work-state update preserves the human body byte-for-byte
-    const secondFile = path.join(backlogDir, "tasks", "BACK-2 - prove-core-cycle.md");
-    const bodyBefore = fs.readFileSync(secondFile, "utf-8");
-    const humanBody = bodyBefore.slice(bodyBefore.indexOf("\n## Description"));
-    adapter.update(second.ref, { status: "In Progress" });
-    const bodyAfter = fs.readFileSync(secondFile, "utf-8");
-    assert.equal(bodyAfter.slice(bodyAfter.indexOf("\n## Description")), humanBody);
-    assert.match(bodyAfter, /^status: In Progress$/m);
-
-    // checked close archives exactly that task into completed/ as Done
-    adapter.close(second.ref);
-    assert.equal(fs.existsSync(secondFile), false);
-    const archived = fs.readFileSync(path.join(backlogDir, "completed", "BACK-2 - prove-core-cycle.md"), "utf-8");
-    assert.match(archived, /^status: Done$/m);
+    adapter.close(second);
     assert.deepEqual(adapter.list().map((task) => task.ref), ["BACK-1", "BACK-3"]);
     assert.deepEqual(adapter.list({ state: "closed" }).map((task) => task.ref), ["BACK-2"]);
-
-    // the entire cycle never touched gh
-    assert.equal(fs.existsSync(marker), false, `gh must never run offline; invocations: ${fs.existsSync(marker) ? fs.readFileSync(marker, "utf-8") : ""}`);
+    assert.match(
+      fs.readFileSync(path.join(backlogDir, "completed", "BACK-2 - prove-core-cycle.md"), "utf8"),
+      /Keep this AC/
+    );
+    assert.equal(canonical(backlogDir).tasks.length, 3);
+    assert.equal(fs.existsSync(marker), false);
   });
 
   it("fails every optional capability before mutation and never falls back", (t) => {
@@ -133,147 +149,110 @@ describe("offline local core sprint cycle", () => {
         () => invokeCapability(resolved, capability, () => {
           mutated = true;
         }),
-        (error) => {
-          assert.equal(error.tracker, "local");
-          assert.equal(error.capability, capability);
-          return true;
-        }
+        (error) => error.tracker === "local" && error.capability === capability
       );
       assert.equal(mutated, false);
     }
   });
 
-  it("handles malformed input, exact collisions, and decimal identities", (t) => {
+  it("handles malformed input, exact active/completed collisions, and decimal identities", (t) => {
     const { backlogDir } = makeOfflineStore(t);
     const { adapter } = localAdapter(backlogDir);
-
     assert.throws(() => adapter.create({ title: "" }), LocalStoreError);
     assert.throws(() => adapter.create({}), LocalStoreError);
 
-    // seed a BACK-1/BACK-11 collision boundary directly
-    for (const [id, name] of [[1, "one"], [11, "eleven"]]) {
-      fs.writeFileSync(
-        path.join(backlogDir, "tasks", `BACK-${id} - ${name}.md`),
-        `---\nid: BACK-${id}\ntitle: ${name}\nstatus: To Do\nlabels: []\npriority: medium\ncreated_date: '2026-07-01'\n---\n## Description\n${name}\n`
-      );
-    }
-    assert.equal(adapter.read("BACK-1").id, "1");
-    assert.equal(adapter.read("BACK-11").id, "11");
-    assert.equal(adapter.create({ title: "next parent" }).id, "12");
-
-    const sub = adapter.create({ title: "decimal child", id: "1.2" });
+    assert.equal(adapter.create({ id: "1", title: "One" }).id, "1");
+    assert.equal(adapter.create({ id: "11", title: "Eleven" }).id, "11");
+    adapter.close("BACK-11");
+    assert.equal(adapter.create({ title: "Next parent" }).id, "12");
+    const sub = adapter.create({ title: "Decimal child", id: "1.2" });
     assert.deepEqual(sub, { tracker: "local", id: "1.2", ref: "BACK-1.2" });
-    assert.throws(() => adapter.create({ title: "dup decimal", id: "1.2" }), LocalStoreError);
+    assert.throws(() => adapter.create({ title: "Dup completed", id: "11" }), /already exists/);
+    assert.throws(() => adapter.create({ title: "Dup decimal", id: "1.2" }), /already exists/);
   });
 });
 
-describe("offline local close survives a process crash", () => {
-  it("fails closed on the stale lock, then heals to one authority once it is cleared", (t) => {
+describe("offline local close crash recovery", () => {
+  it("keeps one canonical task when the process dies after atomic rename and heals mirrors", (t) => {
     const { root, backlogDir } = makeOfflineStore(t);
-    fs.writeFileSync(
-      path.join(backlogDir, "tasks", "BACK-1 - one.md"),
-      "---\nid: BACK-1\ntitle: One\nstatus: To Do\nlabels: []\npriority: medium\ncreated_date: '2026-07-01'\n---\n## Description\nkeep me\n"
-    );
-
-    // A worker that dies after the completed copy is published but before the
-    // active source is unlinked — the exact window that strands the store with
-    // duplicate canonical copies and a held lock.
-    const workerPath = path.join(root, "crash-worker.js");
-    fs.writeFileSync(
-      workerPath,
-      `const { createLocalAdapter } = require(${JSON.stringify(LOCAL_TRACKER_PATH)});\n` +
-        "const [backlogDir] = process.argv.slice(2);\n" +
-        "const adapter = createLocalAdapter({ backlogDir, testHooks: { beforeUnlinkSource() { process.exit(99); } } });\n" +
-        "adapter.close('BACK-1');\n"
-    );
-    const crashed = spawnSync(process.execPath, [workerPath, backlogDir], { encoding: "utf8" });
-    assert.equal(crashed.status, 99, "worker crashed mid-close after publishing the completed copy");
-
-    // The crash left both canonical copies, a durable marker, and a stale lock.
-    assert.ok(fs.existsSync(path.join(backlogDir, "tasks", "BACK-1 - one.md")), "active source survived the crash");
-    assert.ok(fs.existsSync(path.join(backlogDir, "completed", "BACK-1 - one.md")), "completed copy was published before the crash");
-    assert.ok(fs.existsSync(path.join(backlogDir, ".local-tracker.close")), "recovery marker remains");
-    const lockPath = path.join(backlogDir, ".local-tracker.lock");
-    assert.ok(fs.existsSync(lockPath), "the crashed process left a stale lock");
-    const staleLockBytes = fs.readFileSync(lockPath, "utf-8");
-
-    // Next open must NOT auto-reclaim the dead-PID lock: a path-based reclaim
-    // cannot avoid racing a replacement holder. It fails closed with an actionable
-    // manual-cleanup error and leaves the stale lock byte-for-byte untouched.
     const { adapter } = localAdapter(backlogDir);
-    assert.throws(
-      () => adapter.close("BACK-1"),
-      (error) => error instanceof LocalStoreError && /stale lock|no longer running|manually/i.test(error.message)
+    adapter.create({ title: "One", body: "Keep me" });
+
+    const worker = path.join(root, "crash-worker.js");
+    fs.writeFileSync(
+      worker,
+      [
+        `const { createLocalAdapter } = require(${JSON.stringify(LOCAL_TRACKER_PATH)});`,
+        "const [backlogDir] = process.argv.slice(2);",
+        "const adapter = createLocalAdapter({",
+        "  backlogDir,",
+        "  testHooks: { afterStoreRename() { process.exit(99); } },",
+        "});",
+        "adapter.close('BACK-1');",
+      ].join("\n")
     );
-    assert.equal(fs.readFileSync(lockPath, "utf-8"), staleLockBytes, "the stale lock is never auto-reclaimed");
-    assert.ok(fs.existsSync(path.join(backlogDir, "tasks", "BACK-1 - one.md")), "no roll-forward while the lock is held");
-    assert.ok(fs.existsSync(path.join(backlogDir, ".local-tracker.close")), "the marker survives the fail-closed attempt");
+    const crashed = spawnSync(process.execPath, [worker, backlogDir], { encoding: "utf8" });
+    assert.equal(crashed.status, 99);
 
-    // The operator confirms no allocator is running and removes the stale lock.
-    // Recovery then derives the exact Done bytes from the active source, sees the
-    // published copy match, retires the source, and clears the marker.
-    fs.unlinkSync(lockPath);
-    const result = adapter.close("BACK-1");
-    assert.deepEqual(result, { tracker: "local", id: "1", ref: "BACK-1" });
-    assert.equal(fs.existsSync(path.join(backlogDir, "tasks", "BACK-1 - one.md")), false, "duplicate active source retired");
-    assert.deepEqual(adapter.list().map((task) => task.ref), []);
-    assert.deepEqual(adapter.list({ state: "closed" }).map((task) => task.ref), ["BACK-1"]);
-    assert.equal(fs.existsSync(lockPath), false, "the healing close releases its own lock");
-    assert.equal(fs.existsSync(path.join(backlogDir, ".local-tracker.close")), false, "marker cleared after recovery");
+    const stored = canonical(backlogDir);
+    assert.equal(stored.tasks.length, 1);
+    assert.equal(stored.tasks[0].id, "1");
+    assert.equal(stored.tasks[0].state, "closed");
+    assert.equal(stored.tasks[0].status, "Done");
+    assert.equal(adapter.read("BACK-1").state, "closed");
 
-    const archived = fs.readFileSync(path.join(backlogDir, "completed", "BACK-1 - one.md"), "utf-8");
-    assert.match(archived, /^status: Done$/m);
-    assert.ok(archived.includes("keep me"), "the archived body is preserved");
+    adapter.close("BACK-1");
+    assert.deepEqual(fs.readdirSync(path.join(backlogDir, "tasks")), []);
+    assert.deepEqual(fs.readdirSync(path.join(backlogDir, "completed")), ["BACK-1 - one.md"]);
+    assert.match(
+      fs.readFileSync(path.join(backlogDir, "completed", "BACK-1 - one.md"), "utf8"),
+      /Keep me/
+    );
+    assert.deepEqual(strays(backlogDir), []);
   });
 });
 
-describe("offline concurrent allocation is atomic", () => {
-  it("assigns distinct ids to parallel allocators with no overwrite or leaked lock/temp", async (t) => {
+describe("offline concurrent replacement is atomic", () => {
+  it("parallel writers leave a parseable single-record store with no lock or temp artifact", async (t) => {
     const { root, backlogDir } = makeOfflineStore(t);
-    const workerPath = path.join(root, "alloc-worker.js");
+    localAdapter(backlogDir).adapter.create({ title: "Shared" });
+    const worker = path.join(root, "update-worker.js");
     fs.writeFileSync(
-      workerPath,
-      `const { createLocalAdapter } = require(${JSON.stringify(LOCAL_TRACKER_PATH)});\n` +
-        "const [backlogDir, title] = process.argv.slice(2);\n" +
-        "try {\n" +
-        "  const id = createLocalAdapter({ backlogDir }).create({ title });\n" +
-        "  process.stdout.write(JSON.stringify(id));\n" +
-        "  process.exit(0);\n" +
-        "} catch (error) {\n" +
-        "  process.stderr.write(String(error && error.message));\n" +
-        "  process.exit(3);\n" +
-        "}\n"
+      worker,
+      [
+        `const { createLocalAdapter } = require(${JSON.stringify(LOCAL_TRACKER_PATH)});`,
+        "const [backlogDir, label] = process.argv.slice(2);",
+        "const adapter = createLocalAdapter({ backlogDir });",
+        "for (let i = 0; i < 50; i += 1) {",
+        "  adapter.update('BACK-1', { labels: [label], priority: i % 2 ? 'high' : 'low' });",
+        "}",
+      ].join("\n")
     );
 
-    const WORKERS = 8;
-    const results = await Promise.all(
-      Array.from({ length: WORKERS }, (_unused, index) =>
-        new Promise((resolve, reject) => {
-          const child = spawn(process.execPath, [workerPath, backlogDir, `Parallel task ${index}`], {
-            stdio: ["ignore", "pipe", "pipe"],
-          });
-          let out = "";
-          let err = "";
-          child.stdout.on("data", (chunk) => { out += chunk; });
-          child.stderr.on("data", (chunk) => { err += chunk; });
-          child.on("close", (code) => {
-            if (code === 0) resolve(JSON.parse(out));
-            else reject(new Error(`worker ${index} exited ${code}: ${err}`));
-          });
-        })
-      )
+    const children = ["one", "two", "three", "four"].map((label) =>
+      spawn(process.execPath, [worker, backlogDir, label], {
+        stdio: ["ignore", "ignore", "pipe"],
+      })
     );
+    const failures = [];
+    await Promise.all(children.map((child) => new Promise((resolve, reject) => {
+      let stderr = "";
+      child.stderr.on("data", (chunk) => {
+        stderr += chunk;
+      });
+      child.on("error", reject);
+      child.on("close", (code) => {
+        if (code !== 0) failures.push(`exit ${code}: ${stderr}`);
+        resolve();
+      });
+    })));
 
-    const ids = results.map((identity) => Number(identity.id)).sort((a, b) => a - b);
-    assert.deepEqual(ids, Array.from({ length: WORKERS }, (_unused, index) => index + 1), "ids must be distinct 1..N");
-
-    const files = fs.readdirSync(path.join(backlogDir, "tasks")).filter((name) => name.endsWith(".md"));
-    assert.equal(files.length, WORKERS, "one file per allocation, none overwritten");
-    assert.equal(new Set(files.map((name) => name.split(" - ")[0])).size, WORKERS);
-
-    // no leaked lock or temp files remain
-    assert.equal(fs.existsSync(path.join(backlogDir, ".local-tracker.lock")), false);
-    const strays = fs.readdirSync(path.join(backlogDir, "tasks")).filter((name) => name.includes(".tmp"));
-    assert.deepEqual(strays, []);
+    assert.deepEqual(failures, []);
+    const stored = canonical(backlogDir);
+    assert.equal(stored.version, 1);
+    assert.equal(stored.tasks.length, 1);
+    assert.equal(stored.tasks[0].id, "1");
+    assert.ok(["one", "two", "three", "four"].includes(stored.tasks[0].labels[0]));
+    assert.deepEqual(strays(backlogDir), []);
   });
 });

--- a/skills/dev-backlog/scripts/local-tracker.integration.test.js
+++ b/skills/dev-backlog/scripts/local-tracker.integration.test.js
@@ -54,7 +54,7 @@ function strays(backlogDir) {
       const full = path.join(dir, name);
       const stat = fs.lstatSync(full);
       if (stat.isDirectory()) walk(full);
-      else if (name.endsWith(".tmp") || name === ".local-tracker.lock" || name === ".local-tracker.close") {
+      else if (name.endsWith(".tmp") || name.startsWith(".local-tracker.revision-")) {
         result.push(full);
       }
     }
@@ -79,14 +79,15 @@ async function runConcurrentWriters(root, backlogDir, operations) {
       "fs.writeFileSync(ready, 'ready');",
       "while (!fs.existsSync(go)) Atomics.wait(wait, 0, 0, 5);",
       "const adapter = createLocalAdapter({ backlogDir, testHooks: {",
-      "  beforeStoreRename() {",
+      "  linkRevision: process.env.NAIVE_RMW ?",
+      "    (tmp) => fs.renameSync(`${tmp}.naive`, path.join(backlogDir, 'local-tracker.json')) : undefined,",
+      "  beforeRevisionClaim(tmp) {",
+      "    if (process.env.NAIVE_RMW) fs.copyFileSync(tmp, `${tmp}.naive`);",
       "    fs.writeFileSync(renameReady, 'ready');",
-      "    if (!fs.existsSync(path.join(backlogDir, '.local-tracker.lock'))) {",
-      "      const deadline = Date.now() + 5000;",
-      "      while (fs.readdirSync(renameDir).length < Number(count)) {",
-      "        if (Date.now() > deadline) throw new Error('rename barrier timed out');",
-      "        Atomics.wait(wait, 0, 0, 5);",
-      "      }",
+      "    const deadline = Date.now() + 5000;",
+      "    while (fs.readdirSync(renameDir).length < Number(count)) {",
+      "      if (Date.now() > deadline) throw new Error('revision barrier timed out');",
+      "      Atomics.wait(wait, 0, 0, 5);",
       "    }",
       "    Atomics.wait(wait, 0, 0, 50);",
       "  },",
@@ -235,7 +236,7 @@ describe("offline local core sprint cycle", () => {
 });
 
 describe("offline local close crash recovery", () => {
-  it("keeps one canonical task when the process dies after atomic rename and heals mirrors", (t) => {
+  it("a writer killed after claiming a revision cannot wedge the next mutation", (t) => {
     const { root, backlogDir } = makeOfflineStore(t);
     const { adapter } = localAdapter(backlogDir);
     adapter.create({ title: "One", body: "Keep me" });
@@ -248,7 +249,7 @@ describe("offline local close crash recovery", () => {
         "const [backlogDir] = process.argv.slice(2);",
         "const adapter = createLocalAdapter({",
         "  backlogDir,",
-        "  testHooks: { afterStoreRename() { process.exit(99); } },",
+        "  testHooks: { afterRevisionClaim() { process.exit(99); } },",
         "});",
         "adapter.close('BACK-1');",
       ].join("\n")
@@ -256,15 +257,26 @@ describe("offline local close crash recovery", () => {
     const crashed = spawnSync(process.execPath, [worker, backlogDir], { encoding: "utf8" });
     assert.equal(crashed.status, 99);
 
+    const beforeRecovery = canonical(backlogDir);
+    assert.equal(beforeRecovery.revision, 1, "the killed writer did not reach its store rename");
+    assert.equal(beforeRecovery.tasks[0].state, "open");
+    assert.equal(
+      strays(backlogDir).some((file) => file.endsWith(".local-tracker.revision-2.json")),
+      true,
+      "the child died after the no-overwrite claim and before the store rename"
+    );
+
+    const recovered = adapter.create({ title: "After crash" });
+    assert.equal(recovered.id, "2");
     const stored = canonical(backlogDir);
-    assert.equal(stored.tasks.length, 1);
+    assert.equal(stored.revision, 3);
+    assert.equal(stored.tasks.length, 2);
     assert.equal(stored.tasks[0].id, "1");
     assert.equal(stored.tasks[0].state, "closed");
     assert.equal(stored.tasks[0].status, "Done");
     assert.equal(adapter.read("BACK-1").state, "closed");
-
-    adapter.close("BACK-1");
-    assert.deepEqual(fs.readdirSync(path.join(backlogDir, "tasks")), []);
+    assert.equal(adapter.read("BACK-2").title, "After crash");
+    assert.deepEqual(fs.readdirSync(path.join(backlogDir, "tasks")), ["BACK-2 - after-crash.md"]);
     assert.deepEqual(fs.readdirSync(path.join(backlogDir, "completed")), ["BACK-1 - one.md"]);
     assert.match(
       fs.readFileSync(path.join(backlogDir, "completed", "BACK-1 - one.md"), "utf8"),
@@ -281,7 +293,7 @@ describe("offline concurrent mutations preserve canonical tasks", () => {
     adapter.create({ id: "1", title: "Active floor" });
     adapter.create({ id: "11", title: "Completed floor" });
     adapter.close("BACK-11");
-    const titles = ["Create alpha", "Create beta", "Create gamma", "Create delta"];
+    const titles = ["Create alpha", "Create beta"];
     const failures = await runConcurrentWriters(
       root,
       backlogDir,
@@ -292,12 +304,12 @@ describe("offline concurrent mutations preserve canonical tasks", () => {
     const created = stored.tasks.filter((task) => titles.includes(task.title));
     assert.equal(created.length, titles.length);
     assert.deepEqual(new Set(created.map((task) => task.id)).size, titles.length);
-    assert.deepEqual(created.map((task) => task.id).sort(), ["12", "13", "14", "15"]);
+    assert.deepEqual(created.map((task) => task.id).sort(), ["12", "13"]);
     assert.equal(stored.tasks.find((task) => task.id === "11").state, "closed");
     assert.deepEqual(strays(backlogDir), []);
   });
 
-  it("different-task updates and a racing create all persist on every platform", async (t) => {
+  it("parallel updates to different tasks both persist on every platform", async (t) => {
     const { root, backlogDir } = makeOfflineStore(t);
     const adapter = localAdapter(backlogDir).adapter;
     adapter.create({ title: "One" });
@@ -313,14 +325,12 @@ describe("offline concurrent mutations preserve canonical tasks", () => {
         selector: "BACK-2",
         changes: { labels: ["updated-two"], status: "In Progress" },
       },
-      { kind: "create", input: { title: "Three created" } },
     ]);
     assert.deepEqual(failures, []);
     assert.equal(adapter.read("BACK-1").title, "One updated");
     assert.equal(adapter.read("BACK-1").priority, "high");
     assert.deepEqual(adapter.read("BACK-2").labels, ["updated-two"]);
     assert.equal(adapter.read("BACK-2").status, "In Progress");
-    assert.equal(adapter.read("BACK-3").title, "Three created");
     assert.deepEqual(strays(backlogDir), []);
   });
 });

--- a/skills/dev-backlog/scripts/local-tracker.integration.test.js
+++ b/skills/dev-backlog/scripts/local-tracker.integration.test.js
@@ -63,6 +63,68 @@ function strays(backlogDir) {
   return result;
 }
 
+async function runConcurrentWriters(root, backlogDir, operations) {
+  const worker = path.join(root, `concurrent-worker-${Date.now()}.js`);
+  const gateDir = path.join(root, `concurrent-gate-${Date.now()}`);
+  const renameDir = path.join(gateDir, "rename-ready");
+  fs.mkdirSync(renameDir, { recursive: true });
+  fs.writeFileSync(
+    worker,
+    [
+      "const fs = require('node:fs');",
+      "const path = require('node:path');",
+      `const { createLocalAdapter } = require(${JSON.stringify(LOCAL_TRACKER_PATH)});`,
+      "const [backlogDir, ready, go, renameReady, renameDir, count, json] = process.argv.slice(2);",
+      "const wait = new Int32Array(new SharedArrayBuffer(4));",
+      "fs.writeFileSync(ready, 'ready');",
+      "while (!fs.existsSync(go)) Atomics.wait(wait, 0, 0, 5);",
+      "const adapter = createLocalAdapter({ backlogDir, testHooks: {",
+      "  beforeStoreRename() {",
+      "    fs.writeFileSync(renameReady, 'ready');",
+      "    if (!fs.existsSync(path.join(backlogDir, '.local-tracker.lock'))) {",
+      "      const deadline = Date.now() + 5000;",
+      "      while (fs.readdirSync(renameDir).length < Number(count)) {",
+      "        if (Date.now() > deadline) throw new Error('rename barrier timed out');",
+      "        Atomics.wait(wait, 0, 0, 5);",
+      "      }",
+      "    }",
+      "    Atomics.wait(wait, 0, 0, 50);",
+      "  },",
+      "} });",
+      "const operation = JSON.parse(json);",
+      "if (operation.kind === 'create') adapter.create(operation.input);",
+      "else adapter.update(operation.selector, operation.changes);",
+    ].join("\n")
+  );
+  const go = path.join(gateDir, "go");
+  const children = operations.map((operation, index) => {
+    const ready = path.join(gateDir, `ready-${index}`);
+    const renameReady = path.join(renameDir, String(index));
+    const child = spawn(
+      process.execPath,
+      [
+        worker, backlogDir, ready, go, renameReady, renameDir,
+        String(operations.length), JSON.stringify(operation),
+      ],
+      { stdio: ["ignore", "ignore", "pipe"] }
+    );
+    return { child, ready };
+  });
+  const started = Date.now();
+  while (!children.every(({ ready }) => fs.existsSync(ready))) {
+    if (Date.now() - started > 5000) throw new Error("concurrent writer start barrier timed out");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  const completions = children.map(({ child }) => new Promise((resolve, reject) => {
+    let stderr = "";
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", reject);
+    child.on("close", (code) => resolve(code === 0 ? null : `exit ${code}: ${stderr}`));
+  }));
+  fs.writeFileSync(go, "go");
+  return (await Promise.all(completions)).filter(Boolean);
+}
+
 describe("offline local core sprint cycle", () => {
   it("runs create → Plan → status/next → read → work-state update → close/archive with no gh", (t) => {
     const { root, backlogDir } = makeOfflineStore(t);
@@ -212,47 +274,53 @@ describe("offline local close crash recovery", () => {
   });
 });
 
-describe("offline concurrent replacement is atomic", () => {
-  it("parallel writers leave a parseable single-record store with no lock or temp artifact", async (t) => {
+describe("offline concurrent mutations preserve canonical tasks", () => {
+  it("parallel creates all survive with distinct ids above active and completed tasks", async (t) => {
     const { root, backlogDir } = makeOfflineStore(t);
-    localAdapter(backlogDir).adapter.create({ title: "Shared" });
-    const worker = path.join(root, "update-worker.js");
-    fs.writeFileSync(
-      worker,
-      [
-        `const { createLocalAdapter } = require(${JSON.stringify(LOCAL_TRACKER_PATH)});`,
-        "const [backlogDir, label] = process.argv.slice(2);",
-        "const adapter = createLocalAdapter({ backlogDir });",
-        "for (let i = 0; i < 50; i += 1) {",
-        "  adapter.update('BACK-1', { labels: [label], priority: i % 2 ? 'high' : 'low' });",
-        "}",
-      ].join("\n")
+    const adapter = localAdapter(backlogDir).adapter;
+    adapter.create({ id: "1", title: "Active floor" });
+    adapter.create({ id: "11", title: "Completed floor" });
+    adapter.close("BACK-11");
+    const titles = ["Create alpha", "Create beta", "Create gamma", "Create delta"];
+    const failures = await runConcurrentWriters(
+      root,
+      backlogDir,
+      titles.map((title) => ({ kind: "create", input: { title } }))
     );
-
-    const children = ["one", "two", "three", "four"].map((label) =>
-      spawn(process.execPath, [worker, backlogDir, label], {
-        stdio: ["ignore", "ignore", "pipe"],
-      })
-    );
-    const failures = [];
-    await Promise.all(children.map((child) => new Promise((resolve, reject) => {
-      let stderr = "";
-      child.stderr.on("data", (chunk) => {
-        stderr += chunk;
-      });
-      child.on("error", reject);
-      child.on("close", (code) => {
-        if (code !== 0) failures.push(`exit ${code}: ${stderr}`);
-        resolve();
-      });
-    })));
-
     assert.deepEqual(failures, []);
     const stored = canonical(backlogDir);
-    assert.equal(stored.version, 1);
-    assert.equal(stored.tasks.length, 1);
-    assert.equal(stored.tasks[0].id, "1");
-    assert.ok(["one", "two", "three", "four"].includes(stored.tasks[0].labels[0]));
+    const created = stored.tasks.filter((task) => titles.includes(task.title));
+    assert.equal(created.length, titles.length);
+    assert.deepEqual(new Set(created.map((task) => task.id)).size, titles.length);
+    assert.deepEqual(created.map((task) => task.id).sort(), ["12", "13", "14", "15"]);
+    assert.equal(stored.tasks.find((task) => task.id === "11").state, "closed");
+    assert.deepEqual(strays(backlogDir), []);
+  });
+
+  it("different-task updates and a racing create all persist on every platform", async (t) => {
+    const { root, backlogDir } = makeOfflineStore(t);
+    const adapter = localAdapter(backlogDir).adapter;
+    adapter.create({ title: "One" });
+    adapter.create({ title: "Two" });
+    const failures = await runConcurrentWriters(root, backlogDir, [
+      {
+        kind: "update",
+        selector: "BACK-1",
+        changes: { title: "One updated", priority: "high" },
+      },
+      {
+        kind: "update",
+        selector: "BACK-2",
+        changes: { labels: ["updated-two"], status: "In Progress" },
+      },
+      { kind: "create", input: { title: "Three created" } },
+    ]);
+    assert.deepEqual(failures, []);
+    assert.equal(adapter.read("BACK-1").title, "One updated");
+    assert.equal(adapter.read("BACK-1").priority, "high");
+    assert.deepEqual(adapter.read("BACK-2").labels, ["updated-two"]);
+    assert.equal(adapter.read("BACK-2").status, "In Progress");
+    assert.equal(adapter.read("BACK-3").title, "Three created");
     assert.deepEqual(strays(backlogDir), []);
   });
 });

--- a/skills/dev-backlog/scripts/local-tracker.js
+++ b/skills/dev-backlog/scripts/local-tracker.js
@@ -19,39 +19,21 @@ const TASKS_DIR = "tasks";
 const COMPLETED_DIR = "completed";
 const DONE_STATUS = "Done";
 const STORE_VERSION = 1;
-const LOCK_FILE = ".local-tracker.lock";
-const LOCK_WAIT = new Int32Array(new SharedArrayBuffer(4));
+const CAS_RETRIES = 100;
+const REVISION_TEMP_RE = /^\.local-tracker\.revision-(\d+)\..+\.tmp$/;
 
 const CREATE_OPTIONS = Object.freeze([
-  "title",
-  "id",
-  "body",
-  "status",
-  "labels",
-  "priority",
-  "dependencies",
+  "title", "id", "body", "status", "labels", "priority", "dependencies",
 ]);
 const UPDATE_OPTIONS = Object.freeze([
-  "title",
-  "status",
-  "priority",
-  "labels",
-  "dependencies",
-  "body",
-  "updated_date",
+  "title", "status", "priority", "labels", "dependencies", "body", "updated_date",
 ]);
 const LIST_STATES = Object.freeze(["open", "closed", "all"]);
 const SCALAR_FIELDS = Object.freeze([
-  "title",
-  "status",
-  "priority",
-  "milestone",
-  "created_date",
-  "updated_date",
+  "title", "status", "priority", "milestone", "created_date", "updated_date",
 ]);
 const LIST_FIELDS = Object.freeze(["labels", "dependencies"]);
 const CONTROL_CHAR_RE = /[\x00-\x1F\x7F]/;
-
 class LocalStoreError extends Error {
   constructor(message, options) {
     super(message, options);
@@ -59,7 +41,6 @@ class LocalStoreError extends Error {
     this.tracker = "local";
   }
 }
-
 function rejectUnsupportedOptions(operation, options, allowed) {
   if (options === null || typeof options !== "object" || Array.isArray(options)) return;
   const extra = Object.keys(options).filter((key) => !allowed.includes(key));
@@ -71,20 +52,16 @@ function rejectUnsupportedOptions(operation, options, allowed) {
     );
   }
 }
-
 function taskPrefixIssue(prefix) {
-  if (typeof prefix !== "string" || !prefix.length) {
-    return "task_prefix must be a non-empty string";
-  }
-  if (/[\s/\\\0]/.test(prefix)) {
-    return `task_prefix ${JSON.stringify(prefix)} must not contain whitespace, path separators, or NUL`;
-  }
-  if (prefix.includes("..")) {
-    return `task_prefix ${JSON.stringify(prefix)} must not contain traversal segments`;
-  }
+  if (typeof prefix !== "string" || !prefix.length) return "task_prefix must be a non-empty string";
+  if (/[\s/\\\0]/.test(prefix)) return (
+    `task_prefix ${JSON.stringify(prefix)} must not contain whitespace, path separators, or NUL`
+  );
+  if (prefix.includes("..")) return (
+    `task_prefix ${JSON.stringify(prefix)} must not contain traversal segments`
+  );
   return null;
 }
-
 function assertNoControlChars(field, value) {
   if (CONTROL_CHAR_RE.test(value)) {
     throw new LocalStoreError(
@@ -93,7 +70,6 @@ function assertNoControlChars(field, value) {
     );
   }
 }
-
 function cleanScalar(field, value, { nonEmpty = false } = {}) {
   const text = String(value);
   assertNoControlChars(field, text);
@@ -102,18 +78,11 @@ function cleanScalar(field, value, { nonEmpty = false } = {}) {
   }
   return text;
 }
-
 function cleanList(field, value) {
-  if (!Array.isArray(value)) {
-    throw new LocalStoreError(`local ${field} must be an array`);
-  }
+  if (!Array.isArray(value)) throw new LocalStoreError(`local ${field} must be an array`);
   return value.map((item) => cleanScalar(`${field} item`, item));
 }
-
-function emptyStore() {
-  return { version: STORE_VERSION, tasks: [] };
-}
-
+function emptyStore() { return { version: STORE_VERSION, revision: 0, tasks: [] }; }
 function compareByParentThenSub(left, right) {
   const key = (id) => {
     const [parent, sub] = id.split(".");
@@ -125,7 +94,6 @@ function compareByParentThenSub(left, right) {
   if (ls !== rs) return ls < rs ? -1 : 1;
   return 0;
 }
-
 function createLocalAdapter(options = {}) {
   const backlogDir = options.backlogDir;
   const now = options.now || (() => new Date());
@@ -136,18 +104,13 @@ function createLocalAdapter(options = {}) {
   const testHooks = options.testHooks || {};
   const refOptions = { taskPrefix };
   const storePath = path.join(backlogDir || "", STORE_FILE);
-  const lockPath = path.join(backlogDir || "", LOCK_FILE);
-  const lockRetries = options.lock?.retries ?? 1000;
-  const lockDelayMs = options.lock?.delayMs ?? 5;
-
-  function identityForId(id) {
-    return parseTaskRef(`${taskPrefix}-${id}`, refOptions);
-  }
-
+  const requestedRetries = options.cas?.retries;
+  const casRetries = Number.isSafeInteger(requestedRetries)
+    ? Math.max(0, Math.min(requestedRetries, CAS_RETRIES)) : CAS_RETRIES;
+  function identityForId(id) { return parseTaskRef(`${taskPrefix}-${id}`, refOptions); }
   function assertUsablePrefix() {
     if (prefixIssue) throw new LocalStoreError(`local tracker ${prefixIssue}`);
   }
-
   function resolveIdentity(selector) {
     if (selector && typeof selector === "object" && !Array.isArray(selector)) {
       if (selector.tracker !== "local") {
@@ -168,7 +131,6 @@ function createLocalAdapter(options = {}) {
     }
     throw new LocalStoreError(`unresolved local task selector: ${String(selector)}`);
   }
-
   function pathIssue(target, kind) {
     let stat;
     try {
@@ -182,7 +144,6 @@ function createLocalAdapter(options = {}) {
     if (kind !== "store" && !stat.isDirectory()) return `local ${kind} path ${target} is not a directory`;
     return null;
   }
-
   function canonicalPathIssue() {
     if (typeof backlogDir !== "string" || !backlogDir.trim()) {
       return "local tracker backlogDir is not configured";
@@ -198,12 +159,10 @@ function createLocalAdapter(options = {}) {
     }
     return null;
   }
-
   function assertCanonicalPaths() {
     const issue = canonicalPathIssue();
     if (issue) throw new LocalStoreError(issue);
   }
-
   function validateRecord(record, seen) {
     if (!record || typeof record !== "object" || Array.isArray(record)) {
       throw new LocalStoreError("local JSON store is malformed: every task must be an object");
@@ -236,21 +195,25 @@ function createLocalAdapter(options = {}) {
     for (const field of LIST_FIELDS) cleanList(field, record[field]);
     return record;
   }
-
   function validateStore(store) {
     if (!store || typeof store !== "object" || Array.isArray(store)) {
       throw new LocalStoreError("local JSON store is malformed: expected an object");
     }
-    if (store.version !== STORE_VERSION || !Array.isArray(store.tasks)) {
+    if (
+      store.version !== STORE_VERSION ||
+      !Number.isSafeInteger(store.revision) ||
+      store.revision < 0 ||
+      !Array.isArray(store.tasks)
+    ) {
       throw new LocalStoreError(
-        `local JSON store is malformed: expected version ${STORE_VERSION} with a tasks array`
+        `local JSON store is malformed: expected version ${STORE_VERSION}, a non-negative ` +
+          "integer revision, and a tasks array"
       );
     }
     const seen = new Set();
     for (const record of store.tasks) validateRecord(record, seen);
     return store;
   }
-
   function readStore() {
     assertCanonicalPaths();
     let raw;
@@ -267,47 +230,12 @@ function createLocalAdapter(options = {}) {
       throw new LocalStoreError(`local JSON store is malformed: ${error.message}`, { cause: error });
     }
   }
-
-  function withWriteLock(operation) {
-    assertCanonicalPaths();
-    fs.mkdirSync(backlogDir, { recursive: true });
-    let fd;
-    for (let attempt = 0; fd === undefined; attempt += 1) {
-      try {
-        fd = fs.openSync(lockPath, "wx");
-      } catch (error) {
-        if (error.code !== "EEXIST") throw new LocalStoreError(
-          `cannot acquire local store lock: ${error.message}`, { cause: error }
-        );
-        if (attempt >= lockRetries) {
-          throw new LocalStoreError(
-            `local store lock ${lockPath} remained held after ${lockRetries + 1} attempts; ` +
-              "wait for the active writer, or remove it only after confirming no writer is running"
-          );
-        }
-        Atomics.wait(LOCK_WAIT, 0, 0, lockDelayMs);
-      }
-    }
-    try {
-      return operation();
-    } finally {
-      let releaseError;
-      try { fs.closeSync(fd); } catch (error) { releaseError = error; }
-      try { fs.unlinkSync(lockPath); } catch (error) { releaseError ||= error; }
-      if (releaseError) throw new LocalStoreError(
-        `local store commit finished but its lock could not be released: ${releaseError.message}`,
-        { cause: releaseError }
-      );
-    }
-  }
-
   function tempPath(dir, label) {
     return path.join(
       dir,
       `.local-tracker.${process.pid}.${label}.${crypto.randomBytes(8).toString("hex")}.tmp`
     );
   }
-
   function writeCompleteTemp(tmp, content, hook) {
     if (hook) return hook(tmp, content);
     const fd = fs.openSync(tmp, "wx", 0o666);
@@ -318,7 +246,6 @@ function createLocalAdapter(options = {}) {
       fs.closeSync(fd);
     }
   }
-
   function fsyncDirectory(dir, target) {
     if (testHooks.beforeDirectoryFsync) testHooks.beforeDirectoryFsync(dir, target);
     let fd;
@@ -333,7 +260,6 @@ function createLocalAdapter(options = {}) {
       try { if (fd !== undefined) fs.closeSync(fd); } catch {}
     }
   }
-
   function replaceAtomic(target, content, hookName) {
     const dir = path.dirname(target);
     const issue = pathIssue(dir, path.basename(dir));
@@ -342,9 +268,6 @@ function createLocalAdapter(options = {}) {
     const tmp = tempPath(dir, path.basename(target).replace(/[^A-Za-z0-9.-]/g, "_"));
     try {
       writeCompleteTemp(tmp, content, testHooks[hookName]);
-      if (hookName === "writeStoreTemp" && testHooks.beforeStoreRename) {
-        testHooks.beforeStoreRename(tmp, target);
-      }
       if (hookName === "writeMirrorTemp" && testHooks.beforeMirrorRename) {
         testHooks.beforeMirrorRename(tmp, target);
       }
@@ -362,13 +285,81 @@ function createLocalAdapter(options = {}) {
       }
     }
   }
+  function revisionPath(revision) {
+    return path.join(backlogDir, `.local-tracker.revision-${revision}.json`);
+  }
 
-  function writeStore(store) {
+  function revisionTempPath(revision) {
+    const token = crypto.randomBytes(8).toString("hex");
+    return path.join(backlogDir, `.local-tracker.revision-${revision}.${process.pid}.${token}.tmp`);
+  }
+  function finishClaim(claimPath, revision) {
+    const currentRevision = readStore().revision;
+    if (currentRevision !== revision - 1) return;
+    try { fs.renameSync(claimPath, storePath); fsyncDirectory(backlogDir, storePath); }
+    catch (error) {
+      if (error.code !== "ENOENT") throw error;
+      // The claimant or another helper already completed this exact revision.
+    }
+  }
+  function cleanRevisionDebris(currentRevision) {
+    for (const name of fs.readdirSync(backlogDir)) {
+      const match = name.match(REVISION_TEMP_RE);
+      if (!match || Number(match[1]) > currentRevision) continue;
+      try { fs.unlinkSync(path.join(backlogDir, name)); }
+      catch (error) {
+        if (!["ENOENT", "EBUSY", "EPERM"].includes(error.code)) throw error;
+      }
+    }
+  }
+  function publishStore(store, baseRevision) {
     validateStore(store);
     assertCanonicalPaths();
     fs.mkdirSync(backlogDir, { recursive: true });
+    const revision = baseRevision + 1;
+    const claimPath = revisionPath(revision);
+    const tmp = revisionTempPath(revision);
     const content = `${JSON.stringify(store, null, 2)}\n`;
-    replaceAtomic(storePath, content, "writeStoreTemp");
+    try {
+      writeCompleteTemp(tmp, content, testHooks.writeStoreTemp);
+      if (testHooks.beforeRevisionClaim) testHooks.beforeRevisionClaim(tmp, claimPath);
+      try {
+        (testHooks.linkRevision || fs.linkSync)(tmp, claimPath);
+      } catch (error) {
+        if (error.code === "EEXIST") {
+          finishClaim(claimPath, revision);
+          return false;
+        }
+        // A winning writer may remove a stale contender's temp during cleanup.
+        if (error.code === "ENOENT") return false;
+        throw error;
+      }
+      if (testHooks.afterRevisionClaim) testHooks.afterRevisionClaim(claimPath, storePath);
+
+      const currentRevision = readStore().revision;
+      if (currentRevision !== baseRevision) {
+        // A helper can publish our complete claim before this recheck. Missing
+        // means that exact candidate won; an extant path is our stale claim.
+        if (!fs.existsSync(claimPath)) return true;
+        fs.unlinkSync(claimPath);
+        return false;
+      }
+      try { fs.renameSync(claimPath, storePath); fsyncDirectory(backlogDir, storePath); }
+      catch (error) {
+        if (error.code !== "ENOENT") throw error;
+        // Another writer helped this content-complete claim across the window.
+      }
+      return true;
+    } catch (error) {
+      throw error instanceof LocalStoreError
+        ? error
+        : new LocalStoreError(
+            `cannot compare-and-swap local store revision ${revision}: ${error.message}`,
+            { cause: error }
+          );
+    } finally {
+      try { fs.unlinkSync(tmp); } catch {}
+    }
   }
 
   function bodyForMirror(body) {
@@ -426,15 +417,24 @@ function createLocalAdapter(options = {}) {
   }
 
   function commitMutation(mutate) {
-    const result = withWriteLock(() => {
+    for (let attempt = 0; attempt <= casRetries; attempt += 1) {
       const store = readStore();
       const outcome = mutate(store);
-      if (outcome.changed) writeStore(store);
-      return outcome;
-    });
-    if (result.changed && testHooks.afterStoreRename) testHooks.afterStoreRename(storePath);
-    withWriteLock(() => refreshMirrors(readStore()));
-    return result.value;
+      if (!outcome.changed) {
+        refreshMirrors(readStore());
+        return outcome.value;
+      }
+      const baseRevision = store.revision;
+      store.revision += 1;
+      if (!publishStore(store, baseRevision)) continue;
+      cleanRevisionDebris(store.revision);
+      refreshMirrors(readStore());
+      return outcome.value;
+    }
+    throw new LocalStoreError(
+      `local store compare-and-swap exhausted after ${casRetries + 1} attempts; ` +
+        "concurrent writers kept claiming newer revisions, so no unconditional write was made"
+    );
   }
 
   function identityResult(id) {

--- a/skills/dev-backlog/scripts/local-tracker.js
+++ b/skills/dev-backlog/scripts/local-tracker.js
@@ -19,6 +19,8 @@ const TASKS_DIR = "tasks";
 const COMPLETED_DIR = "completed";
 const DONE_STATUS = "Done";
 const STORE_VERSION = 1;
+const LOCK_FILE = ".local-tracker.lock";
+const LOCK_WAIT = new Int32Array(new SharedArrayBuffer(4));
 
 const CREATE_OPTIONS = Object.freeze([
   "title",
@@ -134,6 +136,9 @@ function createLocalAdapter(options = {}) {
   const testHooks = options.testHooks || {};
   const refOptions = { taskPrefix };
   const storePath = path.join(backlogDir || "", STORE_FILE);
+  const lockPath = path.join(backlogDir || "", LOCK_FILE);
+  const lockRetries = options.lock?.retries ?? 1000;
+  const lockDelayMs = options.lock?.delayMs ?? 5;
 
   function identityForId(id) {
     return parseTaskRef(`${taskPrefix}-${id}`, refOptions);
@@ -263,6 +268,39 @@ function createLocalAdapter(options = {}) {
     }
   }
 
+  function withWriteLock(operation) {
+    assertCanonicalPaths();
+    fs.mkdirSync(backlogDir, { recursive: true });
+    let fd;
+    for (let attempt = 0; fd === undefined; attempt += 1) {
+      try {
+        fd = fs.openSync(lockPath, "wx");
+      } catch (error) {
+        if (error.code !== "EEXIST") throw new LocalStoreError(
+          `cannot acquire local store lock: ${error.message}`, { cause: error }
+        );
+        if (attempt >= lockRetries) {
+          throw new LocalStoreError(
+            `local store lock ${lockPath} remained held after ${lockRetries + 1} attempts; ` +
+              "wait for the active writer, or remove it only after confirming no writer is running"
+          );
+        }
+        Atomics.wait(LOCK_WAIT, 0, 0, lockDelayMs);
+      }
+    }
+    try {
+      return operation();
+    } finally {
+      let releaseError;
+      try { fs.closeSync(fd); } catch (error) { releaseError = error; }
+      try { fs.unlinkSync(lockPath); } catch (error) { releaseError ||= error; }
+      if (releaseError) throw new LocalStoreError(
+        `local store commit finished but its lock could not be released: ${releaseError.message}`,
+        { cause: releaseError }
+      );
+    }
+  }
+
   function tempPath(dir, label) {
     return path.join(
       dir,
@@ -281,6 +319,21 @@ function createLocalAdapter(options = {}) {
     }
   }
 
+  function fsyncDirectory(dir, target) {
+    if (testHooks.beforeDirectoryFsync) testHooks.beforeDirectoryFsync(dir, target);
+    let fd;
+    try {
+      fd = fs.openSync(dir, "r");
+      fs.fsyncSync(fd);
+    } catch (error) {
+      // Windows and some filesystems refuse directory handles/fsync. The rename
+      // is still atomic there, so degrade durability rather than fail the write.
+      if (!["EACCES", "EBADF", "EISDIR", "EINVAL", "ENOSYS", "ENOTSUP", "EPERM"].includes(error.code)) throw error;
+    } finally {
+      try { if (fd !== undefined) fs.closeSync(fd); } catch {}
+    }
+  }
+
   function replaceAtomic(target, content, hookName) {
     const dir = path.dirname(target);
     const issue = pathIssue(dir, path.basename(dir));
@@ -296,6 +349,7 @@ function createLocalAdapter(options = {}) {
         testHooks.beforeMirrorRename(tmp, target);
       }
       fs.renameSync(tmp, target);
+      fsyncDirectory(dir, target);
     } catch (error) {
       throw error instanceof LocalStoreError
         ? error
@@ -315,7 +369,6 @@ function createLocalAdapter(options = {}) {
     fs.mkdirSync(backlogDir, { recursive: true });
     const content = `${JSON.stringify(store, null, 2)}\n`;
     replaceAtomic(storePath, content, "writeStoreTemp");
-    if (testHooks.afterStoreRename) testHooks.afterStoreRename(storePath);
   }
 
   function bodyForMirror(body) {
@@ -370,6 +423,18 @@ function createLocalAdapter(options = {}) {
     if (testHooks.beforeMirrorRefresh) testHooks.beforeMirrorRefresh();
     refreshMirrorDir(TASKS_DIR, store.tasks.filter((task) => task.state === "open"));
     refreshMirrorDir(COMPLETED_DIR, store.tasks.filter((task) => task.state === "closed"));
+  }
+
+  function commitMutation(mutate) {
+    const result = withWriteLock(() => {
+      const store = readStore();
+      const outcome = mutate(store);
+      if (outcome.changed) writeStore(store);
+      return outcome;
+    });
+    if (result.changed && testHooks.afterStoreRename) testHooks.afterStoreRename(storePath);
+    withWriteLock(() => refreshMirrors(readStore()));
+    return result.value;
   }
 
   function identityResult(id) {
@@ -436,9 +501,7 @@ function createLocalAdapter(options = {}) {
     }
   }
 
-  function capabilities() {
-    return [];
-  }
+  function capabilities() { return []; }
 
   function list({ state = "open" } = {}) {
     if (!LIST_STATES.includes(state)) {
@@ -479,28 +542,19 @@ function createLocalAdapter(options = {}) {
       requestedId = parsed.id;
     }
 
-    const store = readStore();
-    const id = requestedId ?? allocateParentId(store);
-    if (store.tasks.some((task) => task.id === id)) {
-      throw new LocalStoreError(`local task ${taskPrefix}-${id} already exists`);
-    }
-    const created = dateToday();
-    store.tasks.push({
-      id,
-      title,
-      status,
-      labels,
-      priority,
-      dependencies,
-      milestone: "",
-      created_date: created,
-      updated_date: created,
-      body: bodyForMirror(input.body ?? ""),
-      state: "open",
+    return commitMutation((store) => {
+      const id = requestedId ?? allocateParentId(store);
+      if (store.tasks.some((task) => task.id === id)) {
+        throw new LocalStoreError(`local task ${taskPrefix}-${id} already exists`);
+      }
+      const created = dateToday();
+      store.tasks.push({
+        id, title, status, labels, priority, dependencies, milestone: "",
+        created_date: created, updated_date: created,
+        body: bodyForMirror(input.body ?? ""), state: "open",
+      });
+      return { changed: true, value: identityResult(id) };
     });
-    writeStore(store);
-    refreshMirrors(store);
-    return identityResult(id);
   }
 
   function update(selector, changes = {}) {
@@ -508,34 +562,30 @@ function createLocalAdapter(options = {}) {
     assertUsablePrefix();
     const identity = resolveIdentity(selector);
     const updateFields = buildUpdate(changes);
-    const store = readStore();
-    const record = store.tasks.find((task) => task.id === identity.id);
-    if (!record || record.state !== "open") {
-      throw new LocalStoreError(`no active local task to update: ${identity.ref}`);
-    }
-    const changed = Object.entries(updateFields).some(
-      ([key, value]) => JSON.stringify(record[key]) !== JSON.stringify(value)
-    );
-    Object.assign(record, updateFields);
-    if (changed) writeStore(store);
-    refreshMirrors(store);
-    return identityResult(identity.id);
+    return commitMutation((store) => {
+      const record = store.tasks.find((task) => task.id === identity.id);
+      if (!record || record.state !== "open") {
+        throw new LocalStoreError(`no active local task to update: ${identity.ref}`);
+      }
+      const changed = Object.entries(updateFields).some(
+        ([key, value]) => JSON.stringify(record[key]) !== JSON.stringify(value)
+      );
+      Object.assign(record, updateFields);
+      return { changed, value: identityResult(identity.id) };
+    });
   }
 
   function close(selector, closeOptions = {}) {
     rejectUnsupportedOptions("close", closeOptions, []);
     assertUsablePrefix();
     const identity = resolveIdentity(selector);
-    const store = readStore();
-    const record = store.tasks.find((task) => task.id === identity.id);
-    if (!record) throw new LocalStoreError(`local task not found: ${identity.ref}`);
-    if (record.state === "open") {
-      record.state = "closed";
-      record.status = DONE_STATUS;
-      writeStore(store);
-    }
-    refreshMirrors(store);
-    return identityResult(identity.id);
+    return commitMutation((store) => {
+      const record = store.tasks.find((task) => task.id === identity.id);
+      if (!record) throw new LocalStoreError(`local task not found: ${identity.ref}`);
+      const changed = record.state === "open";
+      if (changed) Object.assign(record, { state: "closed", status: DONE_STATUS });
+      return { changed, value: identityResult(identity.id) };
+    });
   }
 
   return Object.freeze({ availability, capabilities, list, read, create, update, close });

--- a/skills/dev-backlog/scripts/local-tracker.js
+++ b/skills/dev-backlog/scripts/local-tracker.js
@@ -1,51 +1,25 @@
 /**
- * Local filesystem implementation of the required seven-operation tracker
- * lifecycle.
+ * Local JSON storage substrate for the required tracker lifecycle.
  *
- * This module is the single owner of every local-store rule: task filenames,
- * frontmatter grammar, body preservation, ID allocation, and the atomic
- * publication primitives. Callers only ever see the seven operations and the
- * normalized `{ tracker: "local", id, ref }` identity — no URL, no filename,
- * and no frontmatter leak across the seam.
- *
- * Canonical tasks live in `backlog/tasks/` (open) and `backlog/completed/`
- * (closed) as Backlog.md-compatible `{PREFIX}-{N}[.M] - {slug}.md` files. The
- * adapter never invokes `gh`, opens a network socket, reads GitHub state, or
- * falls back to another tracker: local selection is authoritative.
+ * `backlog/local-tracker.json` is the only task authority. Markdown below
+ * `backlog/tasks/` and `backlog/completed/` is a derived, one-way projection
+ * with the same shape as GitHub issue mirrors. No lifecycle operation parses a
+ * mirror back into the store.
  */
 
 const fs = require("fs");
 const path = require("path");
 const crypto = require("crypto");
 
-const { readConfig, slugify, escapeYaml, parseSimpleYaml } = require("./lib.js");
-const {
-  parseTaskRef,
-  parseTaskFileName,
-} = require("./task-ref.js");
+const { readConfig, slugify, escapeYaml } = require("./lib.js");
+const { parseTaskRef, parseTaskFileName } = require("./task-ref.js");
 
+const STORE_FILE = "local-tracker.json";
 const TASKS_DIR = "tasks";
 const COMPLETED_DIR = "completed";
-const LOCK_FILE = ".local-tracker.lock";
-// Durable intent journal for close: written after the completed copy lands and
-// before the active source is removed, so a process that dies in that window is
-// finished (or discarded) on the next open instead of leaving two authorities.
-const CLOSE_MARKER_FILE = ".local-tracker.close";
 const DONE_STATUS = "Done";
+const STORE_VERSION = 1;
 
-// The only accepted list scopes. Any other `state` fails closed rather than
-// silently narrowing to the open store.
-const LIST_STATE_KINDS = Object.freeze({
-  open: [TASKS_DIR],
-  closed: [COMPLETED_DIR],
-  all: [TASKS_DIR, COMPLETED_DIR],
-});
-const DEFAULT_LOCK = Object.freeze({ retries: 100, delayMs: 20 });
-
-// Only provider-neutral fields are accepted; every other option (milestone,
-// pull-request relationship, mirror, progress issue, comment, closing reason,
-// …) maps to an optional capability the local store does not have and must be
-// rejected before any mutation rather than silently ignored.
 const CREATE_OPTIONS = Object.freeze([
   "title",
   "id",
@@ -64,10 +38,28 @@ const UPDATE_OPTIONS = Object.freeze([
   "body",
   "updated_date",
 ]);
-const CLOSE_OPTIONS = Object.freeze([]);
+const LIST_STATES = Object.freeze(["open", "closed", "all"]);
+const SCALAR_FIELDS = Object.freeze([
+  "title",
+  "status",
+  "priority",
+  "milestone",
+  "created_date",
+  "updated_date",
+]);
+const LIST_FIELDS = Object.freeze(["labels", "dependencies"]);
+const CONTROL_CHAR_RE = /[\x00-\x1F\x7F]/;
+
+class LocalStoreError extends Error {
+  constructor(message, options) {
+    super(message, options);
+    this.name = "LocalStoreError";
+    this.tracker = "local";
+  }
+}
 
 function rejectUnsupportedOptions(operation, options, allowed) {
-  if (options === null || typeof options !== "object") return;
+  if (options === null || typeof options !== "object" || Array.isArray(options)) return;
   const extra = Object.keys(options).filter((key) => !allowed.includes(key));
   if (extra.length) {
     throw new LocalStoreError(
@@ -78,202 +70,6 @@ function rejectUnsupportedOptions(operation, options, allowed) {
   }
 }
 
-/** Every recoverable local-store failure surfaces as this actionable type. */
-class LocalStoreError extends Error {
-  constructor(message, options) {
-    super(message, options);
-    this.name = "LocalStoreError";
-    this.tracker = "local";
-  }
-}
-
-// --- synchronous timing primitive (no busy spin) ---
-
-function sleepSync(ms) {
-  if (!(ms > 0)) return;
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-}
-
-// --- lock stamp inspection (crash detection, no reclamation) ---
-
-// The lock file stamps `${pid}:${token}`: the pid lets a later process tell a
-// crashed holder from a live one, while the token is a per-acquisition nonce so
-// release can bind its unlink to the exact file instance it created. Reclamation
-// is intentionally NOT automatic: a path-based rename/unlink cannot reclaim a
-// stale lock without racing a replacement holder, so a dead-PID lock is surfaced
-// as an actionable manual-cleanup error and left untouched.
-function readLockStamp(lockPath) {
-  // The lock must be a regular, non-symlink file; never follow a symlink planted
-  // at the lock path when judging ownership.
-  const stat = lstatSafe(lockPath);
-  if (!stat || !stat.isFile()) return null;
-  let raw;
-  try {
-    raw = fs.readFileSync(lockPath, "utf-8").trim();
-  } catch {
-    return null;
-  }
-  const colon = raw.indexOf(":");
-  const pid = Number.parseInt(colon === -1 ? raw : raw.slice(0, colon), 10);
-  if (!(Number.isInteger(pid) && pid > 0)) return null;
-  return { pid, token: colon === -1 ? "" : raw.slice(colon + 1) };
-}
-
-function processAlive(pid) {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return error.code === "EPERM"; // exists but not signalable by us
-  }
-}
-
-// --- frontmatter / body split, preserving human bytes verbatim ---
-
-const FRONTMATTER_RE = /^---(\r?\n)([\s\S]*?)\r?\n---(\r?\n[\s\S]*|$)/;
-
-function splitDocument(content) {
-  const match = content.match(FRONTMATTER_RE);
-  if (!match) return null;
-  // `eol` is the stored newline style, taken from the opening fence. The
-  // frontmatter is normalized to LF so value parsing sees clean logical lines
-  // (a trailing CR would otherwise make `id` read back as missing), while `eol`
-  // lets re-emission restore the original CRLF byte-for-byte. The body is kept
-  // verbatim so its own newline style is never rewritten.
-  const eol = match[1];
-  const frontmatter = match[2].replace(/\r\n/g, "\n");
-  return { frontmatter, body: match[3], eol };
-}
-
-/**
- * Parse a frontmatter block into ordered entries. Each entry keeps its raw
- * source lines so untouched keys are re-emitted byte-for-byte on update.
- */
-function parseFrontmatterEntries(frontmatter) {
-  const entries = [];
-  let current = null;
-  for (const line of frontmatter.split("\n")) {
-    const isKey = /^[A-Za-z0-9_-]+:/.test(line) && !/^\s/.test(line);
-    if (isKey) {
-      if (current) entries.push(current);
-      current = { key: line.slice(0, line.indexOf(":")), lines: [line] };
-    } else if (current) {
-      current.lines.push(line);
-    }
-  }
-  if (current) entries.push(current);
-  return entries;
-}
-
-/**
- * Resolve one entry to its value. Block sequences (`key:` followed by `  - x`
- * lines) are decoded here because the shared simple YAML parser only consumes
- * `key: value` lines and would otherwise return a malformed object for the
- * exact block syntax we render on create/update.
- */
-function entryValue(entry) {
-  const head = entry.lines[0] || "";
-  const colon = head.indexOf(":");
-  const inline = colon === -1 ? "" : head.slice(colon + 1).trim();
-  if (!inline) {
-    const items = [];
-    for (const line of entry.lines.slice(1)) {
-      const item = line.match(/^\s*-\s+(.*)$/);
-      if (item) items.push(unquoteBlockItem(item[1].trim()));
-    }
-    if (items.length) return items;
-  }
-  return parseSimpleYaml(entry.lines.join("\n"))[entry.key];
-}
-
-function unquoteBlockItem(text) {
-  if (
-    text.length >= 2 &&
-    ((text.startsWith('"') && text.endsWith('"')) ||
-      (text.startsWith("'") && text.endsWith("'")))
-  ) {
-    return text.slice(1, -1).replace(/''/g, "'");
-  }
-  return text;
-}
-
-function frontmatterObject(entries) {
-  const object = {};
-  for (const entry of entries) object[entry.key] = entryValue(entry);
-  return object;
-}
-
-const DATE_KEYS = new Set(["created_date", "updated_date"]);
-
-function renderScalar(key, value) {
-  const text = String(value);
-  if (DATE_KEYS.has(key)) return `${key}: '${text}'`;
-  return `${key}: ${escapeYaml(text)}`;
-}
-
-// A block-sequence item is left bare only when it is unambiguously a plain
-// string. Anything else — indicators (`#`, `[`, `{`, `-`, …), a mapping colon,
-// leading/trailing space, an empty value, or a token a YAML tool would resolve
-// to a boolean/null/number — is single-quoted so it round-trips as the exact
-// string it was given and never changes meaning for Backlog.md or any reader.
-const SAFE_PLAIN_ITEM_RE = /^[A-Za-z0-9_][A-Za-z0-9_./-]*$/;
-const YAML_RESERVED_RE = /^(?:true|false|yes|no|on|off|null|none|~)$/i;
-const NUMBERLIKE_RE = /^[-+]?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?$/;
-
-function encodeListItem(value) {
-  const text = String(value);
-  if (SAFE_PLAIN_ITEM_RE.test(text) && !YAML_RESERVED_RE.test(text) && !NUMBERLIKE_RE.test(text)) {
-    return text;
-  }
-  return `'${text.replace(/'/g, "''")}'`;
-}
-
-function renderFieldLines(key, value) {
-  if (Array.isArray(value)) {
-    if (value.length === 0) return [`${key}: []`];
-    return [`${key}:`, ...value.map((item) => `  - ${encodeListItem(item)}`)];
-  }
-  return [renderScalar(key, value)];
-}
-
-/**
- * Replace only the requested keys; append new keys at the end. Every other
- * entry is emitted from its raw source lines, so unrelated frontmatter and the
- * human body are never re-rendered or reordered.
- */
-function applyFrontmatterChanges(entries, changes) {
-  const next = entries.map((entry) => ({ ...entry, lines: [...entry.lines] }));
-  for (const [key, value] of Object.entries(changes)) {
-    if (value === undefined) continue;
-    const lines = renderFieldLines(key, value);
-    const existing = next.find((entry) => entry.key === key);
-    if (existing) existing.lines = lines;
-    else next.push({ key, lines });
-  }
-  return next;
-}
-
-function stringifyFrontmatter(entries, eol = "\n") {
-  const inner = entries.flatMap((entry) => entry.lines).join(eol);
-  return `---${eol}${inner}${eol}---`;
-}
-
-/**
- * A task body must be separated from the closing `---` by a newline; otherwise
- * `---body` collapses into the frontmatter fence and the file reads back as
- * malformed. Callers may pass a body without the leading newline, so normalize
- * it here rather than trusting the caller's byte layout.
- */
-function normalizeBody(body) {
-  return body.startsWith("\n") ? body : `\n${body}`;
-}
-
-/**
- * The configured task prefix flows into filenames and identity refs, so it must
- * never carry path separators, traversal, NUL, or whitespace that could steer a
- * write outside the canonical `tasks/` and `completed/` directories. Returns an
- * actionable reason string when the prefix is unusable, or null when it is safe.
- */
 function taskPrefixIssue(prefix) {
   if (typeof prefix !== "string" || !prefix.length) {
     return "task_prefix must be a non-empty string";
@@ -287,1093 +83,36 @@ function taskPrefixIssue(prefix) {
   return null;
 }
 
-// --- required-field and injection validation (fail closed) ---
-
-const REQUIRED_FRONTMATTER_KEYS = ["id", "title", "status"];
-const NEUTRAL_FIELDS = ["title", "status", "priority"];
-const NEUTRAL_LIST_FIELDS = ["labels", "dependencies"];
-
-// Control characters (the C0 set plus DEL) cannot survive the simple YAML
-// renderer: a raw newline in a scalar or list item re-parses as a fresh `key:`
-// line and injects arbitrary frontmatter. Reject them before any mutation.
-const CONTROL_CHAR_RE = /[\x00-\x1F\x7F]/;
-
 function assertNoControlChars(field, value) {
   if (CONTROL_CHAR_RE.test(value)) {
     throw new LocalStoreError(
       `local ${field} must not contain newlines or control characters; ` +
-        "they would inject frontmatter keys and break the task round trip"
+        "they would inject mirror frontmatter or corrupt task metadata"
     );
   }
 }
 
-function cleanScalar(field, value) {
+function cleanScalar(field, value, { nonEmpty = false } = {}) {
   const text = String(value);
   assertNoControlChars(field, text);
+  if (nonEmpty && !text.trim()) {
+    throw new LocalStoreError(`local ${field} must be a non-empty scalar`);
+  }
   return text;
 }
 
-/**
- * Require exactly one non-empty scalar `id`, `title`, and `status`, with the id
- * equal to the filename ref. Runs before every list/read/update/close so
- * missing, duplicate, wrong-typed, or empty required fields fail closed rather
- * than flowing into a normalized task or a mutation.
- */
-function requireValidFrontmatter(entries, ref) {
-  for (const key of REQUIRED_FRONTMATTER_KEYS) {
-    const matches = entries.filter((entry) => entry.key === key);
-    if (matches.length !== 1) {
-      const problem = matches.length === 0 ? "missing" : "duplicate";
-      throw new LocalStoreError(`local task ${ref} is malformed: ${problem} required '${key}' frontmatter`);
-    }
-    const value = entryValue(matches[0]);
-    // Arrays and mappings both report as objects; a required field must be scalar.
-    if (value !== null && typeof value === "object") {
-      throw new LocalStoreError(`local task ${ref} is malformed: '${key}' must be a single scalar value`);
-    }
-    const text = value === undefined || value === null ? "" : String(value).trim();
-    if (!text) {
-      throw new LocalStoreError(`local task ${ref} is malformed: '${key}' must be a non-empty scalar`);
-    }
-    if (key === "id" && String(value) !== ref) {
-      throw new LocalStoreError(
-        `local task ${ref} is corrupt: frontmatter id ${JSON.stringify(String(value))} does not match its filename`
-      );
-    }
+function cleanList(field, value) {
+  if (!Array.isArray(value)) {
+    throw new LocalStoreError(`local ${field} must be an array`);
   }
+  return value.map((item) => cleanScalar(`${field} item`, item));
 }
 
-function buildUpdateFieldChanges(changes) {
-  const fieldChanges = {};
-  for (const field of NEUTRAL_FIELDS) {
-    if (changes[field] !== undefined) fieldChanges[field] = cleanScalar(field, changes[field]);
-  }
-  for (const field of NEUTRAL_LIST_FIELDS) {
-    if (changes[field] === undefined) continue;
-    if (!Array.isArray(changes[field])) {
-      throw new LocalStoreError(`local update ${field} must be an array`);
-    }
-    fieldChanges[field] = changes[field].map((item) => cleanScalar(`${field} item`, item));
-  }
-  if (changes.updated_date !== undefined) {
-    fieldChanges.updated_date = cleanScalar("updated_date", changes.updated_date);
-  }
-  return fieldChanges;
-}
-
-// --- filesystem-boundary guards ---
-
-function contentHash(content) {
-  return crypto.createHash("sha256").update(content, "utf-8").digest("hex");
-}
-
-function lstatSafe(target) {
-  try {
-    return fs.lstatSync(target);
-  } catch {
-    return null;
-  }
-}
-
-// A canonical task must be a real file. A symlinked task file would let a read
-// or close follow the link and touch bytes outside the backlog, so reject any
-// non-regular file (symlink, directory, socket) before it is read or archived.
-function assertRegularFile(full, ref) {
-  const stat = lstatSafe(full);
-  if (!stat) {
-    throw new LocalStoreError(`cannot access local task ${ref}: file is missing or unreadable`);
-  }
-  if (!stat.isFile()) {
-    throw new LocalStoreError(`local task ${ref} is not a regular file; symlinked task files are refused`);
-  }
-}
-
-/** True only when `dest`'s resolved parent is exactly `dir` (no traversal). */
-function withinDir(dir, dest) {
-  return path.resolve(path.dirname(dest)) === path.resolve(dir);
-}
-
-// A canonical store directory is sound only when the path is absent (created
-// lazily on first write) or a real, non-symlink directory. A symlink or plain
-// file here would let a lifecycle operation read or write outside the backlog,
-// so it is refused. Returns an actionable reason, or null when the path is safe.
-function realDirIssue(dir) {
-  let stat;
-  try {
-    // lstat, not stat: a symlinked directory must be refused, not resolved.
-    stat = fs.lstatSync(dir);
-  } catch (error) {
-    if (error.code === "ENOENT") return null; // created lazily on first write
-    return `local store path ${dir} is unusable: ${error.message}`;
-  }
-  if (stat.isSymbolicLink()) return `local store path ${dir} must not be a symlink`;
-  if (!stat.isDirectory()) return `local store path ${dir} is not a directory`;
-  return null;
-}
-
-// --- close compensation: identity-and-content-checked rollback ---
-
-function fileEvidence(target) {
-  // Bind the content hash to the same inode represented by the evidence: path
-  // stat followed by path read could itself observe two different files.
-  const fd = fs.openSync(target, "r");
-  try {
-    const stat = fs.fstatSync(fd);
-    if (!stat.isFile()) {
-      const error = new Error(`rollback target is not a regular file: ${target}`);
-      error.code = "EINVAL";
-      throw error;
-    }
-    return { dev: stat.dev, ino: stat.ino, hash: contentHash(fs.readFileSync(fd)) };
-  } finally {
-    fs.closeSync(fd);
-  }
-}
-
-function sameFileEvidence(a, b) {
-  return a.dev === b.dev && a.ino === b.ino && a.hash === b.hash;
-}
-
-function closeSourceRetained(identity, src, cause) {
-  return new LocalStoreError(
-    `local close of ${identity.ref} could not remove the active source ${src}, so the ` +
-      "completed copy was rolled back; the task is unchanged and still open. " +
-      `Retry once the source is writable. Cause: ${cause.message}`,
-    { cause }
-  );
-}
-
-function closeSplitStore(identity, src, dest, unlinkError, rollbackError) {
-  const note = rollbackError
-    ? `rolling the completed copy back also failed (${rollbackError.message})`
-    : "the completed copy was replaced by another writer and was left untouched";
-  return new LocalStoreError(
-    `local close of ${identity.ref} could not remove the active source ${src} ` +
-      `(${unlinkError.message}) and ${note}; both ${src} and ${dest} remain. ` +
-      "Resolve the duplicate manually before continuing.",
-    { cause: unlinkError }
-  );
-}
-
-// --- normalized task shape ---
-
-function normalizeTask({ identity, object, body, state }) {
-  const labels = Array.isArray(object.labels)
-    ? object.labels
-    : object.labels
-      ? [object.labels]
-      : [];
-  const dependencies = Array.isArray(object.dependencies)
-    ? object.dependencies
-    : object.dependencies
-      ? [object.dependencies]
-      : [];
-  return {
-    tracker: "local",
-    id: identity.id,
-    ref: identity.ref,
-    title: object.title === undefined ? "" : String(object.title),
-    status: object.status === undefined ? "" : String(object.status),
-    labels,
-    priority: object.priority === undefined ? "" : String(object.priority),
-    dependencies,
-    created_date: object.created_date === undefined ? "" : String(object.created_date),
-    updated_date: object.updated_date === undefined ? "" : String(object.updated_date),
-    body,
-    state,
-  };
-}
-
-function createLocalAdapter(options = {}) {
-  const backlogDir = options.backlogDir;
-  const now = options.now || (() => new Date());
-  const config = options.config || readConfig(backlogDir);
-  const taskPrefix = config.task_prefix || "BACK";
-  const defaultStatus = config.default_status || "To Do";
-  const lockConfig = { ...DEFAULT_LOCK, ...(options.lock || {}) };
-  const testHooks = options.testHooks || {};
-  const refOptions = { taskPrefix };
-  const prefixIssue = taskPrefixIssue(taskPrefix);
-
-  function assertUsablePrefix() {
-    if (prefixIssue) throw new LocalStoreError(`local tracker ${prefixIssue}`);
-  }
-
-  function dirPath(kind) {
-    return path.join(backlogDir, kind);
-  }
-
-  /** Refuse any write whose resolved parent is not exactly the target dir. */
-  function assertWithin(dir, dest) {
-    if (!withinDir(dir, dest)) {
-      throw new LocalStoreError(
-        `refusing to write a local task outside its canonical directory: ${dest}`
-      );
-    }
-  }
-
-  // Report the first canonical directory (backlog root, tasks/, completed/) that
-  // is not a real non-symlink directory. Powers both the structured availability
-  // probe and the per-operation integrity guards below.
-  function canonicalDirIssue() {
-    for (const probe of [backlogDir, dirPath(TASKS_DIR), dirPath(COMPLETED_DIR)]) {
-      const issue = realDirIssue(probe);
-      if (issue) return issue;
-    }
-    return null;
-  }
-
-  // Enforce canonical-directory integrity at every lifecycle boundary — not just
-  // in availability(). Called at the entry of list/read/create/update/close and
-  // again under the store lock, so a directory swapped for a symlink or a plain
-  // file after the initial probe can never route a read or write outside the
-  // backlog. Absent directories are allowed (create materializes them).
-  function assertCanonicalDirs() {
-    const issue = canonicalDirIssue();
-    if (issue) throw new LocalStoreError(issue);
-  }
-
-  // The tightest boundary check: a single directory must be absent or a real
-  // non-symlink directory immediately before we mkdir/link/rename into it.
-  function assertRealDir(dir) {
-    const issue = realDirIssue(dir);
-    if (issue) throw new LocalStoreError(issue);
-  }
-
-  function today() {
-    return now().toISOString().slice(0, 10);
-  }
-
-  // --- identity resolution (no foreign-prefix inference) ---
-
-  function resolveIdentity(selector) {
-    if (selector && typeof selector === "object") {
-      if (selector.tracker !== "local") {
-        throw new LocalStoreError("local read/update/close requires a local task identity");
-      }
-      const bare = parseTaskRef(`${taskPrefix}-${selector.id}`, refOptions);
-      if (!bare) throw new LocalStoreError(`invalid local task id: ${String(selector.id)}`);
-      if (selector.ref !== undefined && selector.ref !== bare.ref) {
-        throw new LocalStoreError(`local task ref ${selector.ref} does not match ${bare.ref}`);
-      }
-      return bare;
-    }
-    if (typeof selector === "string") {
-      const asRef = parseTaskRef(selector, refOptions);
-      if (asRef && asRef.tracker === "local") return asRef;
-      const asId = parseTaskRef(`${taskPrefix}-${selector}`, refOptions);
-      if (asId) return asId;
-    }
-    throw new LocalStoreError(`unresolved local task selector: ${String(selector)}`);
-  }
-
-  // --- directory scanning ---
-
-  function listDir(kind) {
-    const dir = dirPath(kind);
-    let names;
-    try {
-      names = fs.readdirSync(dir);
-    } catch (error) {
-      if (error.code === "ENOENT") return [];
-      throw new LocalStoreError(`cannot read local ${kind} directory: ${error.message}`, { cause: error });
-    }
-    const found = [];
-    const byId = new Map();
-    for (const name of names) {
-      if (!name.endsWith(".md")) continue;
-      const identity = parseTaskFileName(name, { taskPrefix, tracker: "local" });
-      if (!identity) continue;
-      const seen = byId.get(identity.id);
-      if (seen) {
-        throw new LocalStoreError(
-          `local ${kind} store is corrupt: ${identity.ref} is claimed by multiple files ` +
-            `(${seen}, ${name}); resolve the duplicate before continuing`
-        );
-      }
-      byId.set(identity.id, name);
-      found.push({ identity, file: name });
-    }
-    return found;
-  }
-
-  function findEntry(kind, identity) {
-    return listDir(kind).find((entry) => entry.identity.id === identity.id);
-  }
-
-  /**
-   * Locate one identity across both stores. Presence in both stores is
-   * canonical-store corruption (an exact id must be unique store-wide), so the
-   * caller decides how to fail rather than silently first-matching.
-   */
-  function locateEntry(identity) {
-    const active = findEntry(TASKS_DIR, identity);
-    const completed = findEntry(COMPLETED_DIR, identity);
-    if (active && completed) {
-      throw new LocalStoreError(
-        `local task ${identity.ref} exists in both active and completed stores; ` +
-          "an exact id must be unique across the canonical stores"
-      );
-    }
-    return { active, completed };
-  }
-
-  function readTask(kind, entry) {
-    const full = path.join(dirPath(kind), entry.file);
-    assertRegularFile(full, entry.identity.ref);
-    const content = fs.readFileSync(full, "utf-8");
-    const split = splitDocument(content);
-    if (!split) {
-      throw new LocalStoreError(
-        `local task ${entry.identity.ref} is malformed: missing Backlog.md frontmatter`
-      );
-    }
-    const entries = parseFrontmatterEntries(split.frontmatter);
-    requireValidFrontmatter(entries, entry.identity.ref);
-    const object = frontmatterObject(entries);
-    const state = kind === COMPLETED_DIR ? "closed" : "open";
-    return normalizeTask({ identity: entry.identity, object, body: split.body, state });
-  }
-
-  // --- allocation critical section ---
-
-  function tempPath(dir, id) {
-    const token = crypto.randomBytes(6).toString("hex");
-    return path.join(dir, `.local-tracker.${process.pid}.${id}.${token}.tmp`);
-  }
-
-  function acquireLock() {
-    assertRealDir(backlogDir); // never create the lock through a symlinked root
-    fs.mkdirSync(backlogDir, { recursive: true });
-    const lockPath = path.join(backlogDir, LOCK_FILE);
-    const token = crypto.randomBytes(12).toString("hex");
-    for (let attempt = 0; attempt <= lockConfig.retries; attempt += 1) {
-      try {
-        const fd = fs.openSync(lockPath, "wx");
-        // Stamp `${pid}:${token}` so a later process can tell a crashed holder
-        // from a live one (pid) and bind release to this exact lock instance
-        // (token + file identity) rather than to the path alone.
-        try {
-          fs.writeSync(fd, `${process.pid}:${token}`);
-        } catch {
-          /* the lock is held regardless of whether the stamp lands */
-        }
-        return { fd, token };
-      } catch (error) {
-        if (error.code !== "EEXIST") {
-          throw new LocalStoreError(`cannot acquire local allocation lock: ${error.message}`, { cause: error });
-        }
-        if (attempt < lockConfig.retries) sleepSync(lockConfig.delayMs);
-      }
-    }
-    // Exhausted: never reclaim automatically. A path-based rename/unlink cannot
-    // evict a stale lock without racing a replacement holder, so a dead-PID lock
-    // is surfaced as an actionable manual-cleanup error and left untouched.
-    throw lockContentionError(path.join(backlogDir, LOCK_FILE));
-  }
-
-  // Distinguish a provably-dead holder (stale lock, needs manual cleanup) from
-  // live contention. Neither case touches the lock: reclamation is deliberately
-  // manual because there is no race-free path-based way to reclaim it.
-  function lockContentionError(lockPath) {
-    const stamp = readLockStamp(lockPath);
-    if (stamp && !processAlive(stamp.pid)) {
-      return new LocalStoreError(
-        `the local allocation lock ${lockPath} is held by pid ${stamp.pid}, which is no longer ` +
-          "running (stale lock). It is not reclaimed automatically because a path-based reclaim " +
-          "cannot avoid racing a replacement holder. After confirming no allocator is running, " +
-          "remove the lock file manually to proceed."
-      );
-    }
-    return new LocalStoreError(
-      `another local allocation holds the store lock ${lockPath}; retry once it releases ` +
-        "(remove it manually only if you are certain no allocator is running)."
-    );
-  }
-
-  function releaseLock(handle) {
-    const lockPath = path.join(backlogDir, LOCK_FILE);
-    if (testHooks.beforeReleaseLock) testHooks.beforeReleaseLock(lockPath);
-    // Bind release to BOTH the token we stamped and the exact file instance we
-    // opened. Our fd keeps pointing at the file we created even after the path is
-    // unlinked or replaced, so comparing the fd's identity to whatever now sits
-    // at the path reveals a replacement owner. If ownership or file identity
-    // changed, preserve the replacement and fail clearly rather than evict a live
-    // holder — a normal release only removes the lock still proven to be ours.
-    let held = null;
-    try {
-      held = fs.fstatSync(handle.fd);
-    } catch {
-      /* fd already invalid */
-    }
-    const atPath = lstatSafe(lockPath);
-    const stamp = readLockStamp(lockPath);
-    if (atPath === null) {
-      try {
-        fs.closeSync(handle.fd);
-      } catch {
-        /* fd already closed */
-      }
-      return; // lock already gone: nothing of ours to release
-    }
-    // File identity is definitive while our fd is open: the inode we created
-    // cannot be recycled under the path, so a matching dev/ino proves it is our
-    // instance. The token is the second binding and must also match; a missing or
-    // malformed stamp cannot be treated as authority to remove a lock.
-    const identityMatch =
-      held !== null &&
-      atPath.isFile() &&
-      atPath.dev === held.dev &&
-      atPath.ino === held.ino;
-    const tokenOk = stamp !== null && stamp.token === handle.token;
-    const stillOurs = identityMatch && tokenOk;
-    if (!stillOurs) {
-      try {
-        fs.closeSync(handle.fd);
-      } catch {
-        /* fd already closed */
-      }
-      throw new LocalStoreError(
-        `local allocation lock ${lockPath} changed owner before release and was left ` +
-          "untouched to protect the replacement holder; a concurrent allocator may be running. " +
-          "Resolve the contention and remove the lock manually only if you are certain none is."
-      );
-    }
-
-    // A check followed by unlink(lockPath) is still racy: another owner can
-    // replace the canonical pathname after the check and before the unlink. Move
-    // exactly what is at the pathname to an unguessable private capture first.
-    // The rename is the atomic ownership boundary; we only unlink the capture
-    // after proving that the captured inode/token are the lock represented by our
-    // still-open fd.
-    if (testHooks.afterReleaseLockValidation) testHooks.afterReleaseLockValidation(lockPath);
-    const capturePath = path.join(
-      backlogDir,
-      `${LOCK_FILE}.release.${process.pid}.${crypto.randomBytes(12).toString("hex")}`
-    );
-    try {
-      fs.renameSync(lockPath, capturePath);
-    } catch (error) {
-      try {
-        fs.closeSync(handle.fd);
-      } catch {
-        /* fd already closed */
-      }
-      if (error.code === "ENOENT") return; // removed by someone else; never chase a replacement
-      throw new LocalStoreError(`cannot capture local allocation lock for safe release: ${error.message}`, {
-        cause: error,
-      });
-    }
-
-    const captured = lstatSafe(capturePath);
-    const capturedStamp = readLockStamp(capturePath);
-    const capturedIdentityMatch =
-      held !== null &&
-      captured !== null &&
-      captured.isFile() &&
-      captured.dev === held.dev &&
-      captured.ino === held.ino;
-    const capturedTokenOk = capturedStamp !== null && capturedStamp.token === handle.token;
-    const capturedOurs = capturedIdentityMatch && capturedTokenOk;
-    try {
-      fs.closeSync(handle.fd);
-    } catch {
-      /* fd already closed */
-    }
-
-    if (capturedOurs) {
-      try {
-        fs.unlinkSync(capturePath);
-      } catch (error) {
-        if (error.code !== "ENOENT") {
-          throw new LocalStoreError(
-            `captured local allocation lock could not be removed safely: ${error.message}`,
-            { cause: error }
-          );
-        }
-      }
-      return;
-    }
-
-    // The pathname was replaced after validation, so the capture belongs to a
-    // foreign owner. Restore it without overwriting a newer canonical owner:
-    // link() is atomic and fails with EEXIST. Deliberately retain the capture in
-    // every outcome, including successful restoration, so release never deletes
-    // the foreign inode and an operator can inspect/reconcile both authorities.
-    let restoration;
-    if (testHooks.beforeForeignLockRestore) {
-      testHooks.beforeForeignLockRestore(capturePath, lockPath);
-    }
-    try {
-      fs.linkSync(capturePath, lockPath);
-      restoration = `restored without overwrite at ${lockPath}`;
-    } catch (error) {
-      if (error.code === "EEXIST") {
-        restoration = `a newer owner already occupies ${lockPath}; both locks were preserved`;
-      } else {
-        restoration = `could not restore ${lockPath} without overwrite (${error.message})`;
-      }
-    }
-    throw new LocalStoreError(
-      `local allocation lock changed owner during release; the foreign lock was preserved at ` +
-        `${capturePath} and ${restoration}. Stop concurrent allocators and reconcile these lock ` +
-        "files manually before retrying."
-    );
-  }
-
-  // --- crash-recoverable close journal ---
-
-  function closeMarkerPath() {
-    return path.join(backlogDir, CLOSE_MARKER_FILE);
-  }
-
-  function writeCloseMarker(marker) {
-    const fd = fs.openSync(closeMarkerPath(), "w");
-    try {
-      fs.writeSync(fd, JSON.stringify(marker));
-      fs.fsyncSync(fd); // durable so the intent survives a power loss / crash
-    } finally {
-      fs.closeSync(fd);
-    }
-  }
-
-  function removeCloseMarker() {
-    try {
-      fs.unlinkSync(closeMarkerPath());
-    } catch {
-      /* already gone */
-    }
-  }
-
-  // The close journal is untrusted data. Accept only a marker whose filename is
-  // a safe basename that parses back to the journaled identity; a malformed or
-  // mismatched marker returns null so recovery fails closed instead of acting on
-  // an attacker-controlled path. Absolute src/dest strings are never trusted —
-  // the paths are reconstructed from the validated relative filename below.
-  function validateCloseMarker(marker) {
-    if (!marker || typeof marker !== "object") return null;
-    if (marker.v !== 1 || marker.phase !== "publish") return null;
-    const { id, ref, file, destHash } = marker;
-    if (typeof id !== "string" || typeof ref !== "string") return null;
-    if (typeof file !== "string" || typeof destHash !== "string") return null;
-    if (!/^[0-9a-f]{64}$/.test(destHash)) return null;
-    if (file !== path.basename(file) || /[\\/]/.test(file)) return null;
-    const parsed = parseTaskFileName(file, { taskPrefix, tracker: "local" });
-    if (!parsed || parsed.id !== id || parsed.ref !== ref) return null;
-    return { id, ref, file, destHash };
-  }
-
-  // Read a canonical file's frontmatter id and content hash without following a
-  // symlink. Returns null for anything that is not a regular file, so a
-  // symlinked src/dest can never be promoted or deleted by recovery.
-  function readIdentityAndHash(target) {
-    const stat = lstatSafe(target);
-    if (!stat || !stat.isFile()) return null;
-    let content;
-    try {
-      content = fs.readFileSync(target, "utf-8");
-    } catch {
-      return null;
-    }
-    const split = splitDocument(content);
-    let id = null;
-    if (split) {
-      const idEntry = parseFrontmatterEntries(split.frontmatter).find((entry) => entry.key === "id");
-      if (idEntry) id = String(entryValue(idEntry));
-    }
-    return { id, hash: contentHash(content) };
-  }
-
-  // The destination is this close's publication only if it is a regular file
-  // whose exact bytes (content evidence) and frontmatter id (identity evidence)
-  // match the journaled intent — never an external or partially written file.
-  function publishedMatches(dest, ref, destHash) {
-    const info = readIdentityAndHash(dest);
-    return !!info && info.hash === destHash && info.id === ref;
-  }
-
-  // Independently recompute the exact Done bytes a faithful close of the active
-  // source would publish, so roll-forward is verified against the real
-  // authoritative content instead of the untrusted marker hash. The source is
-  // fully validated first (regular file, well-formed frontmatter, id === ref);
-  // returns the derived bytes and their hash, or null when it cannot be derived.
-  function deriveExpectedDone(src, ref) {
-    const stat = lstatSafe(src);
-    if (!stat || !stat.isFile()) return null;
-    let content;
-    try {
-      content = fs.readFileSync(src, "utf-8");
-    } catch {
-      return null;
-    }
-    const split = splitDocument(content);
-    if (!split) return null;
-    const entries = parseFrontmatterEntries(split.frontmatter);
-    try {
-      requireValidFrontmatter(entries, ref);
-    } catch {
-      return null; // an unvalidatable source is not authoritative to derive from
-    }
-    const doneEntries = applyFrontmatterChanges(entries, { status: DONE_STATUS });
-    const doneContent = `${stringifyFrontmatter(doneEntries, split.eol)}${split.body}`;
-    return { content: doneContent, hash: contentHash(doneContent) };
-  }
-
-  // Finish or discard a close a previous process left half-applied. MUST run
-  // under the store lock. The journal records only the intent to publish; every
-  // field — including destHash — is untrusted. Recovery derives the exact Done
-  // bytes independently from the fully validated active source and rolls the move
-  // forward ONLY when the derived hash, the journaled hash, and the destination's
-  // actual bytes+id ALL agree:
-  //   - all three agree -> the destination is a faithful publication of this
-  //     source; retire the active source (roll the move forward).
-  //   - any disagreement (including a valid, self-consistent marker/destination
-  //     pair whose bytes differ from the active body) -> roll-forward is refused
-  //     and every file is preserved (fail closed). A surviving duplicate then
-  //     fails closed on the next read/list via the exact-id guard.
-  // Nothing outside the canonical stores, and nothing whose derived identity we
-  // cannot confirm, is ever deleted or promoted; the spent marker is then cleared.
-  function recover() {
-    const markerPath = closeMarkerPath();
-    const markerStat = lstatSafe(markerPath);
-    if (markerStat === null) return; // no interrupted close to reconcile
-    if (!markerStat.isFile()) {
-      removeCloseMarker(); // a symlink/dir at the marker path is untrusted
-      return;
-    }
-    let raw;
-    try {
-      raw = fs.readFileSync(markerPath, "utf-8");
-    } catch (error) {
-      if (error.code === "ENOENT") return;
-      throw new LocalStoreError(`cannot read local recovery marker: ${error.message}`, { cause: error });
-    }
-    let marker;
-    try {
-      marker = JSON.parse(raw);
-    } catch {
-      removeCloseMarker(); // an unreadable marker cannot be acted on
-      return;
-    }
-    const plan = validateCloseMarker(marker);
-    if (!plan) {
-      removeCloseMarker(); // malformed/untrusted marker: fail closed, touch nothing
-      return;
-    }
-    const src = path.join(dirPath(TASKS_DIR), plan.file);
-    const dest = path.join(dirPath(COMPLETED_DIR), plan.file);
-    // Containment: the reconstructed paths must resolve exactly into their
-    // canonical directories (validation guarantees this; verify defensively).
-    if (!withinDir(dirPath(TASKS_DIR), src) || !withinDir(dirPath(COMPLETED_DIR), dest)) {
-      removeCloseMarker();
-      return;
-    }
-    // Derive the expected Done bytes from the active source itself, then require
-    // derived === journaled === destination (bytes and id). A marker that merely
-    // matches the destination is not enough: without this the destination could
-    // be self-consistent completed bytes for the same ref that were never the
-    // publication of THIS active body, and rolling forward would delete
-    // authoritative content.
-    const derived = deriveExpectedDone(src, plan.ref);
-    const rollForward =
-      derived !== null &&
-      derived.hash === plan.destHash &&
-      publishedMatches(dest, plan.ref, derived.hash);
-    if (rollForward) {
-      try {
-        fs.unlinkSync(src);
-      } catch {
-        return; // roll-forward proven but the source is not yet writable; retry later
-      }
-    }
-    // Proven-and-completed, or refused-and-every-file-preserved: the untrusted
-    // intent is spent either way, so clear it. A refused roll-forward leaves the
-    // active source intact and any duplicate to the exact-id guard.
-    removeCloseMarker();
-  }
-
-  // Every create/update/close mutation runs inside this single exclusive
-  // section so reads and writes across the two stores are serializable; a close
-  // can never race an update into archiving stale bytes. Recovery runs first so
-  // any interrupted close is healed before the next mutation observes the store.
-  // Recovery never runs on the read paths (list/read), which stay non-mutating.
-  function withStoreLock(fn) {
-    const handle = acquireLock();
-    try {
-      // Re-verify canonical-directory integrity under the lock (the mutation
-      // boundary) so a directory swapped for a symlink between the entry probe and
-      // now cannot route recovery or the mutation outside the backlog.
-      assertCanonicalDirs();
-      recover();
-      return fn();
-    } finally {
-      releaseLock(handle);
-    }
-  }
-
-  function allocateParentId() {
-    // Compare and increment as BigInt so an existing parent beyond
-    // Number.MAX_SAFE_INTEGER (e.g. BACK-9007199254740993) is not silently
-    // rounded down, which would allocate a colliding/backwards id.
-    let max = 0n;
-    for (const kind of [TASKS_DIR, COMPLETED_DIR]) {
-      for (const { identity } of listDir(kind)) {
-        const parent = BigInt(identity.id.split(".")[0]);
-        if (parent > max) max = parent;
-      }
-    }
-    return String(max + 1n);
-  }
-
-  function idExists(id) {
-    return [TASKS_DIR, COMPLETED_DIR].some((kind) =>
-      listDir(kind).some((entry) => entry.identity.id === id)
-    );
-  }
-
-  // --- atomic publication: temp on same fs, hard-link (no overwrite), unlink ---
-
-  // Route temp writes through an injectable writer so a test can reproduce a
-  // partial-write ENOSPC that leaves bytes on disk. The `wx` flag makes the temp
-  // a fresh regular file: a symlink (or any entry) pre-planted at the temp path
-  // fails the create instead of being followed or overwritten.
-  function writeTemp(tmp, content) {
-    if (testHooks.writeFile) return testHooks.writeFile(tmp, content);
-    return fs.writeFileSync(tmp, content, { flag: "wx" });
-  }
-
-  function publishNewFile(dir, fileName, content) {
-    const dest = path.join(dir, fileName);
-    assertWithin(dir, dest);
-    assertRealDir(dir); // final boundary: never link into a symlinked target dir
-    fs.mkdirSync(dir, { recursive: true });
-    const tmp = tempPath(dir, path.basename(fileName));
-    // The temp write is inside the try so a partial write (e.g. ENOSPC) is
-    // cleaned by the finally instead of leaking a stray `.tmp`.
-    try {
-      writeTemp(tmp, content);
-      if (testHooks.beforePublish) testHooks.beforePublish(dest);
-      fs.linkSync(tmp, dest);
-    } catch (error) {
-      if (error.code === "EEXIST") {
-        throw new LocalStoreError(`local task file already exists: ${fileName}`, { cause: error });
-      }
-      throw error;
-    } finally {
-      try {
-        fs.unlinkSync(tmp);
-      } catch {
-        /* temp already gone or never created */
-      }
-    }
-    return dest;
-  }
-
-  function replaceFileAtomic(dir, fileName, content) {
-    const dest = path.join(dir, fileName);
-    assertWithin(dir, dest);
-    assertRealDir(dir); // final boundary: never rename into a symlinked target dir
-    const tmp = tempPath(dir, path.basename(fileName));
-    // A successful rename consumes the temp; any earlier failure (partial write
-    // or failed rename) is cleaned here so no stray `.tmp` survives.
-    try {
-      writeTemp(tmp, content);
-      fs.renameSync(tmp, dest);
-    } catch (error) {
-      try {
-        fs.unlinkSync(tmp);
-      } catch {
-        /* temp already gone or never created */
-      }
-      throw error;
-    }
-    return dest;
-  }
-
-  // After the completed copy is published, remove the active source to finish the
-  // move. A failed unlink means both stores momentarily claim the id, so roll the
-  // publication back — leaving the active source as the single authoritative task.
-  function rollbackEvidence(target) {
-    const evidence = fileEvidence(target);
-    // Deterministically model inode reuse in regression tests without allowing a
-    // hook to alter the content proof used by production rollback decisions.
-    if (!testHooks.rollbackFileIdentity) return evidence;
-    const projected = testHooks.rollbackFileIdentity(target, evidence);
-    return { ...evidence, dev: projected.dev, ino: projected.ino };
-  }
-
-  function retireSourceAfterPublish(identity, src, dest, expectedHash) {
-    const published = rollbackEvidence(dest);
-    if (published.hash !== expectedHash) {
-      throw closeSplitStore(
-        identity,
-        src,
-        dest,
-        new Error("completed publication did not retain its exact intended bytes"),
-        null
-      );
-    }
-    try {
-      if (testHooks.beforeUnlinkSource) testHooks.beforeUnlinkSource(src);
-      fs.unlinkSync(src);
-    } catch (unlinkError) {
-      rollbackPublishedCopy(identity, src, dest, published, unlinkError);
-    }
-  }
-
-  // Undo exactly the copy this close created. Re-stat the destination first: if
-  // it vanished the source already survives alone; if either its inode OR exact
-  // SHA-256 content differs from our publication, an external writer replaced it
-  // (including Linux inode reuse) and we must not erase it.
-  function rollbackPublishedCopy(identity, src, dest, published, unlinkError) {
-    let live;
-    try {
-      live = rollbackEvidence(dest);
-    } catch (statError) {
-      if (statError.code === "ENOENT") throw closeSourceRetained(identity, src, unlinkError);
-      throw closeSplitStore(identity, src, dest, unlinkError, statError);
-    }
-    if (!sameFileEvidence(live, published)) {
-      throw closeSplitStore(identity, src, dest, unlinkError, null);
-    }
-    try {
-      if (testHooks.beforeRollback) testHooks.beforeRollback(dest);
-      fs.unlinkSync(dest);
-    } catch (rollbackError) {
-      throw closeSplitStore(identity, src, dest, unlinkError, rollbackError);
-    }
-    throw closeSourceRetained(identity, src, unlinkError);
-  }
-
-  // --- rendered content builders ---
-
-  function buildFilename(identity, title) {
-    const slug = slugify(title) || identity.id;
-    return `${identity.ref} - ${slug}.md`;
-  }
-
-  function buildNewContent({ identity, title, status, labels, priority, dependencies, body }) {
-    const entries = [
-      { key: "id", lines: [`id: ${identity.ref}`] },
-      { key: "title", lines: renderFieldLines("title", title) },
-      { key: "status", lines: renderFieldLines("status", status) },
-      { key: "labels", lines: renderFieldLines("labels", labels) },
-      { key: "priority", lines: renderFieldLines("priority", priority) },
-    ];
-    if (dependencies.length) entries.push({ key: "dependencies", lines: renderFieldLines("dependencies", dependencies) });
-    entries.push({ key: "created_date", lines: [renderScalar("created_date", today())] });
-    return `${stringifyFrontmatter(entries)}${normalizeBody(body)}`;
-  }
-
-  // --- the seven required operations ---
-
-  function availability() {
-    if (typeof backlogDir !== "string" || !backlogDir.trim()) {
-      return { available: false, reason: "local tracker backlogDir is not configured" };
-    }
-    if (prefixIssue) {
-      return { available: false, reason: `local tracker ${prefixIssue}` };
-    }
-    // The same canonical-directory integrity the lifecycle operations enforce on
-    // every call: a symlinked or non-directory backlog root, tasks/, or completed/
-    // is refused (an absent one is created lazily on first write).
-    const issue = canonicalDirIssue();
-    if (issue) return { available: false, reason: issue };
-    return { available: true };
-  }
-
-  function capabilities() {
-    return [];
-  }
-
-  function list({ state = "open" } = {}) {
-    if (!Object.prototype.hasOwnProperty.call(LIST_STATE_KINDS, state)) {
-      throw new LocalStoreError(
-        `invalid local list state ${JSON.stringify(state)}; expected one of open, closed, all`
-      );
-    }
-    assertCanonicalDirs(); // refuse a symlinked/foreign store before reading it
-    // list never mutates: an interrupted close is healed on the next mutation,
-    // not here. Duplicate copies from a crash surface as a fail-closed error.
-    // Integrity is store-wide, independent of the requested result state: an
-    // active/completed twin must make open, closed, and all views fail alike.
-    const entriesByKind = {
-      [TASKS_DIR]: listDir(TASKS_DIR),
-      [COMPLETED_DIR]: listDir(COMPLETED_DIR),
-    };
-    const activeIds = new Set(entriesByKind[TASKS_DIR].map((entry) => entry.identity.id));
-    for (const entry of entriesByKind[COMPLETED_DIR]) {
-      if (activeIds.has(entry.identity.id)) {
-        throw new LocalStoreError(
-          `local task ${entry.identity.ref} exists in both active and completed stores; ` +
-            "an exact id must be unique across the canonical stores"
-        );
-      }
-    }
-
-    const kinds = LIST_STATE_KINDS[state];
-    const tasks = [];
-    for (const kind of kinds) {
-      for (const entry of entriesByKind[kind]) {
-        tasks.push(readTask(kind, entry));
-      }
-    }
-    return tasks.sort(compareByParentThenSub);
-  }
-
-  function read(selector) {
-    assertCanonicalDirs(); // refuse a symlinked/foreign store before reading it
-    const identity = resolveIdentity(selector);
-    // read never mutates; recovery of an interrupted close is deferred to the
-    // next create/update/close under the store lock.
-    const { active, completed } = locateEntry(identity);
-    const kind = active ? TASKS_DIR : COMPLETED_DIR;
-    const entry = active || completed;
-    if (!entry) throw new LocalStoreError(`local task not found: ${identity.ref}`);
-    return readTask(kind, entry);
-  }
-
-  function create(input = {}) {
-    rejectUnsupportedOptions("create", input, CREATE_OPTIONS);
-    assertUsablePrefix();
-    assertCanonicalDirs(); // refuse a symlinked/foreign store before any mutation
-    const title = input.title;
-    if (typeof title !== "string" || !title.trim()) {
-      throw new LocalStoreError("local task creation requires a non-empty title");
-    }
-    // Reject injection before the lock so no mkdir/temp/mtime mutation occurs.
-    assertNoControlChars("title", title);
-    if (input.status != null) assertNoControlChars("status", String(input.status));
-    if (input.priority != null) assertNoControlChars("priority", String(input.priority));
-    for (const field of NEUTRAL_LIST_FIELDS) {
-      if (Array.isArray(input[field])) {
-        for (const item of input[field]) assertNoControlChars(`${field} item`, String(item));
-      }
-    }
-    let requestedId = null;
-    if (input.id !== undefined && input.id !== null) {
-      const parsed = parseTaskRef(`${taskPrefix}-${input.id}`, refOptions);
-      if (!parsed) throw new LocalStoreError(`invalid explicit local task id: ${String(input.id)}`);
-      requestedId = parsed.id;
-    }
-
-    return withStoreLock(() => {
-      const id = requestedId ?? allocateParentId();
-      if (idExists(id)) {
-        throw new LocalStoreError(`local task ${taskPrefix}-${id} already exists`);
-      }
-      const identity = parseTaskRef(`${taskPrefix}-${id}`, refOptions);
-      const body = input.body !== undefined ? String(input.body) : "\n## Description\n(No description provided)\n";
-      const content = buildNewContent({
-        identity,
-        title,
-        status: input.status ? String(input.status) : defaultStatus,
-        labels: Array.isArray(input.labels) ? input.labels : [],
-        priority: input.priority ? String(input.priority) : "medium",
-        dependencies: Array.isArray(input.dependencies) ? input.dependencies : [],
-        body,
-      });
-      publishNewFile(dirPath(TASKS_DIR), buildFilename(identity, title), content);
-      return { tracker: "local", id: identity.id, ref: identity.ref };
-    });
-  }
-
-  function update(selector, changes = {}) {
-    rejectUnsupportedOptions("update", changes, UPDATE_OPTIONS);
-    assertUsablePrefix();
-    assertCanonicalDirs(); // refuse a symlinked/foreign store before any mutation
-    const identity = resolveIdentity(selector);
-    // Validate and coerce every field before the lock so a rejected injection or
-    // wrong-typed list never triggers an mkdir/lock/temp/mtime mutation.
-    const fieldChanges = buildUpdateFieldChanges(changes);
-
-    return withStoreLock(() => {
-      const { active: entry } = locateEntry(identity);
-      if (!entry) {
-        throw new LocalStoreError(`no active local task to update: ${identity.ref}`);
-      }
-      const full = path.join(dirPath(TASKS_DIR), entry.file);
-      assertRegularFile(full, identity.ref);
-      const content = fs.readFileSync(full, "utf-8");
-      const split = splitDocument(content);
-      if (!split) throw new LocalStoreError(`local task file for ${identity.ref} is malformed`);
-      const currentEntries = parseFrontmatterEntries(split.frontmatter);
-      requireValidFrontmatter(currentEntries, identity.ref);
-
-      const entries = applyFrontmatterChanges(currentEntries, fieldChanges);
-      const body = changes.body !== undefined ? normalizeBody(String(changes.body)) : split.body;
-      const nextContent = `${stringifyFrontmatter(entries, split.eol)}${body}`;
-      // A change-free update (or one that resolves to identical bytes) must not
-      // rewrite the file, so the mtime and inode stay stable.
-      if (nextContent !== content) {
-        replaceFileAtomic(dirPath(TASKS_DIR), entry.file, nextContent);
-      }
-      return { tracker: "local", id: identity.id, ref: identity.ref };
-    });
-  }
-
-  function close(selector, options = {}) {
-    rejectUnsupportedOptions("close", options, CLOSE_OPTIONS);
-    assertUsablePrefix();
-    assertCanonicalDirs(); // refuse a symlinked/foreign store before any mutation
-    const identity = resolveIdentity(selector);
-
-    return withStoreLock(() => {
-      // locateEntry rejects the store-wide exact-id collision (active + a
-      // completed twin under a different slug) before any bytes are touched, so
-      // close can never publish a second completed twin over a duplicate id.
-      const { active: activeEntry, completed: completedEntry } = locateEntry(identity);
-      if (!activeEntry) {
-        if (completedEntry) {
-          return { tracker: "local", id: identity.id, ref: identity.ref };
-        }
-        throw new LocalStoreError(`local task not found: ${identity.ref}`);
-      }
-
-      const src = path.join(dirPath(TASKS_DIR), activeEntry.file);
-      assertRegularFile(src, identity.ref);
-      const content = fs.readFileSync(src, "utf-8");
-      const split = splitDocument(content);
-      if (!split) throw new LocalStoreError(`local task file for ${identity.ref} is malformed`);
-      const currentEntries = parseFrontmatterEntries(split.frontmatter);
-      requireValidFrontmatter(currentEntries, identity.ref);
-
-      const entries = applyFrontmatterChanges(currentEntries, { status: DONE_STATUS });
-      const doneContent = `${stringifyFrontmatter(entries, split.eol)}${split.body}`;
-      const destHash = contentHash(doneContent);
-      const dest = path.join(dirPath(COMPLETED_DIR), activeEntry.file);
-      // Journal only the validated relative identity/filename plus the exact
-      // bytes we intend to publish (destHash). A crash anywhere between here and
-      // the source unlink is reconciled to a single authority on the next
-      // mutation: recovery reconstructs src/dest inside the canonical dirs and
-      // rolls forward only when the destination proves it is this publication —
-      // never a raw path taken from the marker.
-      writeCloseMarker({
-        v: 1,
-        phase: "publish",
-        id: identity.id,
-        ref: identity.ref,
-        file: activeEntry.file,
-        destHash,
-      });
-      try {
-        publishNewFile(dirPath(COMPLETED_DIR), activeEntry.file, doneContent);
-        retireSourceAfterPublish(identity, src, dest, destHash);
-      } catch (error) {
-        removeCloseMarker();
-        throw error;
-      }
-      removeCloseMarker();
-      return { tracker: "local", id: identity.id, ref: identity.ref };
-    });
-  }
-
-  return Object.freeze({ availability, capabilities, list, read, create, update, close });
+function emptyStore() {
+  return { version: STORE_VERSION, tasks: [] };
 }
 
 function compareByParentThenSub(left, right) {
-  // BigInt keys so large ids (past Number's safe range) still order correctly;
-  // a bare parent sorts before its decimal subtasks via the -1 sentinel.
   const key = (id) => {
     const [parent, sub] = id.split(".");
     return [BigInt(parent), sub === undefined ? -1n : BigInt(sub)];
@@ -1383,6 +122,423 @@ function compareByParentThenSub(left, right) {
   if (lp !== rp) return lp < rp ? -1 : 1;
   if (ls !== rs) return ls < rs ? -1 : 1;
   return 0;
+}
+
+function createLocalAdapter(options = {}) {
+  const backlogDir = options.backlogDir;
+  const now = options.now || (() => new Date());
+  const config = options.config || readConfig(backlogDir);
+  const taskPrefix = config.task_prefix ?? "BACK";
+  const defaultStatus = config.default_status ?? "To Do";
+  const prefixIssue = taskPrefixIssue(taskPrefix);
+  const testHooks = options.testHooks || {};
+  const refOptions = { taskPrefix };
+  const storePath = path.join(backlogDir || "", STORE_FILE);
+
+  function identityForId(id) {
+    return parseTaskRef(`${taskPrefix}-${id}`, refOptions);
+  }
+
+  function assertUsablePrefix() {
+    if (prefixIssue) throw new LocalStoreError(`local tracker ${prefixIssue}`);
+  }
+
+  function resolveIdentity(selector) {
+    if (selector && typeof selector === "object" && !Array.isArray(selector)) {
+      if (selector.tracker !== "local") {
+        throw new LocalStoreError("local read/update/close requires a local task identity");
+      }
+      const identity = identityForId(String(selector.id));
+      if (!identity) throw new LocalStoreError(`invalid local task id: ${String(selector.id)}`);
+      if (selector.ref !== undefined && selector.ref !== identity.ref) {
+        throw new LocalStoreError(`local task ref ${selector.ref} does not match ${identity.ref}`);
+      }
+      return identity;
+    }
+    if (typeof selector === "string") {
+      const byRef = parseTaskRef(selector, refOptions);
+      if (byRef?.tracker === "local") return byRef;
+      const byId = identityForId(selector);
+      if (byId) return byId;
+    }
+    throw new LocalStoreError(`unresolved local task selector: ${String(selector)}`);
+  }
+
+  function pathIssue(target, kind) {
+    let stat;
+    try {
+      stat = fs.lstatSync(target);
+    } catch (error) {
+      if (error.code === "ENOENT") return null;
+      return `local ${kind} path ${target} is unusable: ${error.message}`;
+    }
+    if (stat.isSymbolicLink()) return `local ${kind} path ${target} must not be a symlink`;
+    if (kind === "store" && !stat.isFile()) return `local store path ${target} is not a regular file`;
+    if (kind !== "store" && !stat.isDirectory()) return `local ${kind} path ${target} is not a directory`;
+    return null;
+  }
+
+  function canonicalPathIssue() {
+    if (typeof backlogDir !== "string" || !backlogDir.trim()) {
+      return "local tracker backlogDir is not configured";
+    }
+    for (const [target, kind] of [
+      [backlogDir, "backlog"],
+      [path.join(backlogDir, TASKS_DIR), TASKS_DIR],
+      [path.join(backlogDir, COMPLETED_DIR), COMPLETED_DIR],
+      [storePath, "store"],
+    ]) {
+      const issue = pathIssue(target, kind);
+      if (issue) return issue;
+    }
+    return null;
+  }
+
+  function assertCanonicalPaths() {
+    const issue = canonicalPathIssue();
+    if (issue) throw new LocalStoreError(issue);
+  }
+
+  function validateRecord(record, seen) {
+    if (!record || typeof record !== "object" || Array.isArray(record)) {
+      throw new LocalStoreError("local JSON store is malformed: every task must be an object");
+    }
+    if (typeof record.id !== "string" || !identityForId(record.id)) {
+      throw new LocalStoreError(`local JSON store has an invalid task id: ${String(record.id)}`);
+    }
+    if (seen.has(record.id)) {
+      throw new LocalStoreError(
+        `local JSON store is corrupt: ${taskPrefix}-${record.id} appears more than once`
+      );
+    }
+    seen.add(record.id);
+    if (!["open", "closed"].includes(record.state)) {
+      throw new LocalStoreError(
+        `local task ${taskPrefix}-${record.id} has invalid state ${JSON.stringify(record.state)}`
+      );
+    }
+    if (typeof record.body !== "string") {
+      throw new LocalStoreError(`local task ${taskPrefix}-${record.id} has a non-string body`);
+    }
+    for (const field of SCALAR_FIELDS) {
+      if (typeof record[field] !== "string") {
+        throw new LocalStoreError(
+          `local task ${taskPrefix}-${record.id} has a non-string ${field}`
+        );
+      }
+      cleanScalar(field, record[field], { nonEmpty: field === "title" || field === "status" });
+    }
+    for (const field of LIST_FIELDS) cleanList(field, record[field]);
+    return record;
+  }
+
+  function validateStore(store) {
+    if (!store || typeof store !== "object" || Array.isArray(store)) {
+      throw new LocalStoreError("local JSON store is malformed: expected an object");
+    }
+    if (store.version !== STORE_VERSION || !Array.isArray(store.tasks)) {
+      throw new LocalStoreError(
+        `local JSON store is malformed: expected version ${STORE_VERSION} with a tasks array`
+      );
+    }
+    const seen = new Set();
+    for (const record of store.tasks) validateRecord(record, seen);
+    return store;
+  }
+
+  function readStore() {
+    assertCanonicalPaths();
+    let raw;
+    try {
+      raw = fs.readFileSync(storePath, "utf8");
+    } catch (error) {
+      if (error.code === "ENOENT") return emptyStore();
+      throw new LocalStoreError(`cannot read local JSON store: ${error.message}`, { cause: error });
+    }
+    try {
+      return validateStore(JSON.parse(raw));
+    } catch (error) {
+      if (error instanceof LocalStoreError) throw error;
+      throw new LocalStoreError(`local JSON store is malformed: ${error.message}`, { cause: error });
+    }
+  }
+
+  function tempPath(dir, label) {
+    return path.join(
+      dir,
+      `.local-tracker.${process.pid}.${label}.${crypto.randomBytes(8).toString("hex")}.tmp`
+    );
+  }
+
+  function writeCompleteTemp(tmp, content, hook) {
+    if (hook) return hook(tmp, content);
+    const fd = fs.openSync(tmp, "wx", 0o666);
+    try {
+      fs.writeFileSync(fd, content, "utf8");
+      fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+  }
+
+  function replaceAtomic(target, content, hookName) {
+    const dir = path.dirname(target);
+    const issue = pathIssue(dir, path.basename(dir));
+    if (issue) throw new LocalStoreError(issue);
+    fs.mkdirSync(dir, { recursive: true });
+    const tmp = tempPath(dir, path.basename(target).replace(/[^A-Za-z0-9.-]/g, "_"));
+    try {
+      writeCompleteTemp(tmp, content, testHooks[hookName]);
+      if (hookName === "writeStoreTemp" && testHooks.beforeStoreRename) {
+        testHooks.beforeStoreRename(tmp, target);
+      }
+      if (hookName === "writeMirrorTemp" && testHooks.beforeMirrorRename) {
+        testHooks.beforeMirrorRename(tmp, target);
+      }
+      fs.renameSync(tmp, target);
+    } catch (error) {
+      throw error instanceof LocalStoreError
+        ? error
+        : new LocalStoreError(`cannot atomically replace ${target}: ${error.message}`, { cause: error });
+    } finally {
+      try {
+        fs.unlinkSync(tmp);
+      } catch {
+        // A successful rename consumed the temp; a failed partial write is cleaned.
+      }
+    }
+  }
+
+  function writeStore(store) {
+    validateStore(store);
+    assertCanonicalPaths();
+    fs.mkdirSync(backlogDir, { recursive: true });
+    const content = `${JSON.stringify(store, null, 2)}\n`;
+    replaceAtomic(storePath, content, "writeStoreTemp");
+    if (testHooks.afterStoreRename) testHooks.afterStoreRename(storePath);
+  }
+
+  function bodyForMirror(body) {
+    const text = String(body);
+    const core = text.replace(/^\n/, "").replace(/\n$/, "");
+    if (!core) return "\n## Description\n(No description provided)\n";
+    if (/^##\s+Description/m.test(core)) return `\n${core}\n`;
+    return `\n## Description\n${core}\n`;
+  }
+
+  function mirrorName(record) {
+    const slug = slugify(record.title) || record.id;
+    return `${taskPrefix}-${record.id} - ${slug}.md`;
+  }
+
+  function renderMirror(record) {
+    const labels = record.labels.length
+      ? `\n${record.labels.map((label) => `  - ${escapeYaml(label)}`).join("\n")}`
+      : " []";
+    return [
+      "---",
+      `id: ${taskPrefix}-${record.id}`,
+      `title: ${escapeYaml(record.title)}`,
+      `status: ${escapeYaml(record.status)}`,
+      `labels:${labels}`,
+      `priority: ${escapeYaml(record.priority)}`,
+      `milestone: ${escapeYaml(record.milestone)}`,
+      `created_date: '${record.created_date}'`,
+      "---",
+    ].join("\n") + bodyForMirror(record.body);
+  }
+
+  function refreshMirrorDir(kind, records) {
+    const dir = path.join(backlogDir, kind);
+    const issue = pathIssue(dir, kind);
+    if (issue) throw new LocalStoreError(issue);
+    fs.mkdirSync(dir, { recursive: true });
+    const expected = new Set();
+    for (const record of records) {
+      const name = mirrorName(record);
+      expected.add(name);
+      replaceAtomic(path.join(dir, name), renderMirror(record), "writeMirrorTemp");
+    }
+    for (const name of fs.readdirSync(dir)) {
+      if (expected.has(name)) continue;
+      if (!parseTaskFileName(name, { taskPrefix, tracker: "local" })) continue;
+      fs.unlinkSync(path.join(dir, name));
+    }
+  }
+
+  function refreshMirrors(store) {
+    if (testHooks.beforeMirrorRefresh) testHooks.beforeMirrorRefresh();
+    refreshMirrorDir(TASKS_DIR, store.tasks.filter((task) => task.state === "open"));
+    refreshMirrorDir(COMPLETED_DIR, store.tasks.filter((task) => task.state === "closed"));
+  }
+
+  function identityResult(id) {
+    const identity = identityForId(id);
+    return { tracker: "local", id: identity.id, ref: identity.ref };
+  }
+
+  function normalizedTask(record) {
+    return {
+      ...identityResult(record.id),
+      title: record.title,
+      status: record.status,
+      labels: [...record.labels],
+      priority: record.priority,
+      dependencies: [...record.dependencies],
+      created_date: record.created_date,
+      updated_date: record.updated_date,
+      body: record.body,
+      state: record.state,
+    };
+  }
+
+  function dateToday() {
+    return now().toISOString().slice(0, 10);
+  }
+
+  function allocateParentId(store) {
+    let max = 0n;
+    for (const task of store.tasks) {
+      const parent = BigInt(task.id.split(".")[0]);
+      if (parent > max) max = parent;
+    }
+    return String(max + 1n);
+  }
+
+  function buildUpdate(changes) {
+    const update = {};
+    for (const field of ["title", "status", "priority"]) {
+      if (changes[field] !== undefined) {
+        update[field] = cleanScalar(field, changes[field], {
+          nonEmpty: field === "title" || field === "status",
+        });
+      }
+    }
+    for (const field of LIST_FIELDS) {
+      if (changes[field] !== undefined) update[field] = cleanList(field, changes[field]);
+    }
+    if (changes.updated_date !== undefined) {
+      update.updated_date = cleanScalar("updated_date", changes.updated_date);
+    }
+    if (changes.body !== undefined) update.body = bodyForMirror(changes.body);
+    return update;
+  }
+
+  function availability() {
+    if (prefixIssue) return { available: false, reason: `local tracker ${prefixIssue}` };
+    const issue = canonicalPathIssue();
+    if (issue) return { available: false, reason: issue };
+    try {
+      readStore();
+      return { available: true };
+    } catch (error) {
+      return { available: false, reason: error.message };
+    }
+  }
+
+  function capabilities() {
+    return [];
+  }
+
+  function list({ state = "open" } = {}) {
+    if (!LIST_STATES.includes(state)) {
+      throw new LocalStoreError(
+        `invalid local list state ${JSON.stringify(state)}; expected one of open, closed, all`
+      );
+    }
+    const store = readStore();
+    return store.tasks
+      .filter((task) => state === "all" || task.state === state)
+      .map(normalizedTask)
+      .sort(compareByParentThenSub);
+  }
+
+  function read(selector) {
+    const identity = resolveIdentity(selector);
+    const record = readStore().tasks.find((task) => task.id === identity.id);
+    if (!record) throw new LocalStoreError(`local task not found: ${identity.ref}`);
+    return normalizedTask(record);
+  }
+
+  function create(input = {}) {
+    rejectUnsupportedOptions("create", input, CREATE_OPTIONS);
+    assertUsablePrefix();
+    if (typeof input.title !== "string" || !input.title.trim()) {
+      throw new LocalStoreError("local task creation requires a non-empty title");
+    }
+    const title = cleanScalar("title", input.title, { nonEmpty: true });
+    const status = cleanScalar("status", input.status ?? defaultStatus, { nonEmpty: true });
+    const priority = cleanScalar("priority", input.priority ?? "medium");
+    const labels = input.labels === undefined ? [] : cleanList("labels", input.labels);
+    const dependencies =
+      input.dependencies === undefined ? [] : cleanList("dependencies", input.dependencies);
+    let requestedId;
+    if (input.id !== undefined && input.id !== null) {
+      const parsed = identityForId(String(input.id));
+      if (!parsed) throw new LocalStoreError(`invalid explicit local task id: ${String(input.id)}`);
+      requestedId = parsed.id;
+    }
+
+    const store = readStore();
+    const id = requestedId ?? allocateParentId(store);
+    if (store.tasks.some((task) => task.id === id)) {
+      throw new LocalStoreError(`local task ${taskPrefix}-${id} already exists`);
+    }
+    const created = dateToday();
+    store.tasks.push({
+      id,
+      title,
+      status,
+      labels,
+      priority,
+      dependencies,
+      milestone: "",
+      created_date: created,
+      updated_date: created,
+      body: bodyForMirror(input.body ?? ""),
+      state: "open",
+    });
+    writeStore(store);
+    refreshMirrors(store);
+    return identityResult(id);
+  }
+
+  function update(selector, changes = {}) {
+    rejectUnsupportedOptions("update", changes, UPDATE_OPTIONS);
+    assertUsablePrefix();
+    const identity = resolveIdentity(selector);
+    const updateFields = buildUpdate(changes);
+    const store = readStore();
+    const record = store.tasks.find((task) => task.id === identity.id);
+    if (!record || record.state !== "open") {
+      throw new LocalStoreError(`no active local task to update: ${identity.ref}`);
+    }
+    const changed = Object.entries(updateFields).some(
+      ([key, value]) => JSON.stringify(record[key]) !== JSON.stringify(value)
+    );
+    Object.assign(record, updateFields);
+    if (changed) writeStore(store);
+    refreshMirrors(store);
+    return identityResult(identity.id);
+  }
+
+  function close(selector, closeOptions = {}) {
+    rejectUnsupportedOptions("close", closeOptions, []);
+    assertUsablePrefix();
+    const identity = resolveIdentity(selector);
+    const store = readStore();
+    const record = store.tasks.find((task) => task.id === identity.id);
+    if (!record) throw new LocalStoreError(`local task not found: ${identity.ref}`);
+    if (record.state === "open") {
+      record.state = "closed";
+      record.status = DONE_STATUS;
+      writeStore(store);
+    }
+    refreshMirrors(store);
+    return identityResult(identity.id);
+  }
+
+  return Object.freeze({ availability, capabilities, list, read, create, update, close });
 }
 
 module.exports = {

--- a/skills/dev-backlog/scripts/local-tracker.test.js
+++ b/skills/dev-backlog/scripts/local-tracker.test.js
@@ -58,7 +58,7 @@ function record(id, fields = {}) {
 function seedStore(backlogDir, tasks) {
   fs.writeFileSync(
     storePath(backlogDir),
-    `${JSON.stringify({ version: 1, tasks }, null, 2)}\n`
+    `${JSON.stringify({ version: 1, revision: 1, tasks }, null, 2)}\n`
   );
 }
 
@@ -322,11 +322,12 @@ describe("fail-closed JSON and filesystem validation", () => {
   it("fails availability and every read on malformed or duplicate JSON records", (t) => {
     const { backlogDir } = makeStore(t);
     for (const raw of [
-      "{\"version\":1,\"tasks\":[",
-      JSON.stringify({ version: 2, tasks: [] }),
-      JSON.stringify({ version: 1, tasks: [record("1"), record("1")] }),
-      JSON.stringify({ version: 1, tasks: [{ ...record("1"), state: "lost" }] }),
-      JSON.stringify({ version: 1, tasks: [{ ...record("1"), title: "" }] }),
+      "{\"version\":1,\"revision\":0,\"tasks\":[",
+      JSON.stringify({ version: 2, revision: 0, tasks: [] }),
+      JSON.stringify({ version: 1, revision: -1, tasks: [] }),
+      JSON.stringify({ version: 1, revision: 1, tasks: [record("1"), record("1")] }),
+      JSON.stringify({ version: 1, revision: 1, tasks: [{ ...record("1"), state: "lost" }] }),
+      JSON.stringify({ version: 1, revision: 1, tasks: [{ ...record("1"), title: "" }] }),
     ]) {
       fs.writeFileSync(storePath(backlogDir), raw);
       const adapter = createLocalAdapter({ backlogDir, now: FIXED_NOW });
@@ -371,7 +372,7 @@ describe("fail-closed JSON and filesystem validation", () => {
     const { root, backlogDir } = makeStore(t);
     if (!symlinkSupported(root)) return;
     const external = path.join(root, "outside.json");
-    fs.writeFileSync(external, JSON.stringify({ version: 1, tasks: [] }));
+    fs.writeFileSync(external, JSON.stringify({ version: 1, revision: 0, tasks: [] }));
     fs.symlinkSync(external, storePath(backlogDir));
     let adapter = createLocalAdapter({ backlogDir, now: FIXED_NOW });
     assert.equal(adapter.availability().available, false);
@@ -420,33 +421,6 @@ describe("atomic replacement and all-platform concurrency coverage", () => {
     assert.deepEqual(tempNames(backlogDir), []);
   });
 
-  it("a crash after close rename leaves one readable closed record and heals mirrors on retry", (t) => {
-    const { backlogDir } = makeStore(t);
-    const normal = createLocalAdapter({ backlogDir, now: FIXED_NOW });
-    normal.create({ title: "Crash close", body: "Durable" });
-    const crashing = createLocalAdapter({
-      backlogDir,
-      now: FIXED_NOW,
-      testHooks: {
-        afterStoreRename() {
-          throw new Error("simulated process death after atomic rename");
-        },
-      },
-    });
-    assert.throws(() => crashing.close("BACK-1"), /simulated process death/);
-    const stored = readStore(backlogDir);
-    assert.equal(stored.tasks.length, 1);
-    assert.equal(stored.tasks[0].state, "closed");
-    assert.equal(stored.tasks[0].status, "Done");
-    assert.equal(normal.read("BACK-1").state, "closed");
-
-    normal.close("BACK-1");
-    assert.deepEqual(mirrorNames(backlogDir, "tasks"), []);
-    assert.deepEqual(mirrorNames(backlogDir, "completed"), ["BACK-1 - crash-close.md"]);
-    assert.equal(fs.existsSync(path.join(backlogDir, ".local-tracker.lock")), false);
-    assert.equal(fs.existsSync(path.join(backlogDir, ".local-tracker.close")), false);
-  });
-
   it("fsyncs each parent directory after store, mirror, and archive renames", (t) => {
     const { backlogDir } = makeStore(t);
     const attempts = [];
@@ -477,20 +451,29 @@ describe("atomic replacement and all-platform concurrency coverage", () => {
     ]);
   });
 
-  it("fails closed on an occupied write lock without reclaiming it", (t) => {
+  it("fails closed when the bounded compare-and-swap retry budget is exhausted", (t) => {
     const { backlogDir } = makeStore(t);
-    const lockPath = path.join(backlogDir, ".local-tracker.lock");
-    fs.writeFileSync(lockPath, "foreign holder");
+    let claims = 0;
     const adapter = createLocalAdapter({
       backlogDir,
       now: FIXED_NOW,
-      lock: { retries: 1, delayMs: 1 },
+      cas: { retries: 1 },
+      testHooks: {
+        linkRevision() {
+          claims += 1;
+          const error = new Error("revision already claimed");
+          error.code = "EEXIST";
+          throw error;
+        },
+      },
     });
     assert.throws(
-      () => adapter.create({ title: "Blocked" }),
-      (error) => error instanceof LocalStoreError && /remained held.*active writer/.test(error.message)
+      () => adapter.create({ title: "Contended" }),
+      (error) =>
+        error instanceof LocalStoreError &&
+        /compare-and-swap exhausted after 2 attempts.*no unconditional write/.test(error.message)
     );
-    assert.equal(fs.readFileSync(lockPath, "utf8"), "foreign holder");
+    assert.equal(claims, 2);
     assert.equal(fs.existsSync(storePath(backlogDir)), false);
   });
 });

--- a/skills/dev-backlog/scripts/local-tracker.test.js
+++ b/skills/dev-backlog/scripts/local-tracker.test.js
@@ -3,15 +3,12 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
-const { spawn } = require("node:child_process");
-
 const { createLocalAdapter, LocalStoreError } = require("./local-tracker.js");
 const { run: renderGithubMirrors } = require("./sync-pull.js");
 
 const FIXED_DATE = "2026-07-26";
 const FIXED_NOW = () => new Date(`${FIXED_DATE}T12:00:00Z`);
 const STORE_FILE = "local-tracker.json";
-const LOCAL_TRACKER_PATH = path.join(__dirname, "local-tracker.js");
 
 function makeStore(t, config = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "local-tracker-"));
@@ -450,62 +447,50 @@ describe("atomic replacement and all-platform concurrency coverage", () => {
     assert.equal(fs.existsSync(path.join(backlogDir, ".local-tracker.close")), false);
   });
 
-  it("concurrent writers and readers never expose torn JSON or leaked temp files", async (t) => {
-    const { root, backlogDir } = makeStore(t);
-    createLocalAdapter({ backlogDir, now: FIXED_NOW }).create({ title: "Shared" });
-    const worker = path.join(root, "writer.js");
-    fs.writeFileSync(
-      worker,
-      [
-        `const { createLocalAdapter } = require(${JSON.stringify(LOCAL_TRACKER_PATH)});`,
-        "const [backlogDir, label] = process.argv.slice(2);",
-        "const adapter = createLocalAdapter({ backlogDir });",
-        "for (let i = 0; i < 80; i += 1) {",
-        "  adapter.update('BACK-1', { priority: i % 2 ? 'high' : 'low', labels: [label] });",
-        "}",
-      ].join("\n")
-    );
-    const children = ["alpha", "beta", "gamma"].map((label) =>
-      spawn(process.execPath, [worker, backlogDir, label], {
-        stdio: ["ignore", "ignore", "pipe"],
-      })
-    );
-    let reads = 0;
-    const errors = [];
-    await new Promise((resolve, reject) => {
-      const timer = setInterval(() => {
-        try {
-          const store = readStore(backlogDir);
-          assert.equal(store.version, 1);
-          assert.equal(store.tasks.length, 1);
-          assert.equal(store.tasks[0].id, "1");
-          reads += 1;
-        } catch (error) {
-          errors.push(error);
-        }
-      }, 1);
-      let remaining = children.length;
-      for (const child of children) {
-        let stderr = "";
-        child.stderr.on("data", (chunk) => {
-          stderr += chunk;
-        });
-        child.on("error", reject);
-        child.on("close", (code) => {
-          if (code !== 0) errors.push(new Error(`writer exited ${code}: ${stderr}`));
-          remaining -= 1;
-          if (remaining === 0) {
-            clearInterval(timer);
-            resolve();
-          }
-        });
-      }
+  it("fsyncs each parent directory after store, mirror, and archive renames", (t) => {
+    const { backlogDir } = makeStore(t);
+    const attempts = [];
+    const adapter = createLocalAdapter({
+      backlogDir,
+      now: FIXED_NOW,
+      testHooks: {
+        beforeDirectoryFsync(dir, target) {
+          attempts.push([dir, target]);
+          assert.equal(fs.existsSync(target), true, "rename completed before directory fsync");
+        },
+      },
     });
-    assert.equal(errors.length, 0, errors.map((error) => error.message).join("\n"));
-    assert.ok(reads > 0, "the canonical file was parsed while writers raced");
-    const final = readStore(backlogDir);
-    assert.equal(final.tasks.length, 1);
-    assert.ok(["alpha", "beta", "gamma"].includes(final.tasks[0].labels[0]));
-    assert.deepEqual(tempNames(backlogDir), []);
+    adapter.create({ title: "Durable" });
+    assert.deepEqual(attempts, [
+      [backlogDir, storePath(backlogDir)],
+      [path.join(backlogDir, "tasks"), path.join(backlogDir, "tasks", "BACK-1 - durable.md")],
+    ]);
+
+    attempts.length = 0;
+    adapter.close("BACK-1");
+    assert.deepEqual(attempts, [
+      [backlogDir, storePath(backlogDir)],
+      [
+        path.join(backlogDir, "completed"),
+        path.join(backlogDir, "completed", "BACK-1 - durable.md"),
+      ],
+    ]);
+  });
+
+  it("fails closed on an occupied write lock without reclaiming it", (t) => {
+    const { backlogDir } = makeStore(t);
+    const lockPath = path.join(backlogDir, ".local-tracker.lock");
+    fs.writeFileSync(lockPath, "foreign holder");
+    const adapter = createLocalAdapter({
+      backlogDir,
+      now: FIXED_NOW,
+      lock: { retries: 1, delayMs: 1 },
+    });
+    assert.throws(
+      () => adapter.create({ title: "Blocked" }),
+      (error) => error instanceof LocalStoreError && /remained held.*active writer/.test(error.message)
+    );
+    assert.equal(fs.readFileSync(lockPath, "utf8"), "foreign holder");
+    assert.equal(fs.existsSync(storePath(backlogDir)), false);
   });
 });

--- a/skills/dev-backlog/scripts/local-tracker.test.js
+++ b/skills/dev-backlog/scripts/local-tracker.test.js
@@ -3,1355 +3,509 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
-const crypto = require("node:crypto");
+const { spawn } = require("node:child_process");
 
-const {
-  createLocalAdapter,
-  LocalStoreError,
-} = require("./local-tracker.js");
-const { REQUIRED_ADAPTER_OPERATIONS } = require("./tracker.js");
+const { createLocalAdapter, LocalStoreError } = require("./local-tracker.js");
+const { run: renderGithubMirrors } = require("./sync-pull.js");
 
-const FIXED_NOW = () => new Date("2026-07-11T09:00:00Z");
+const FIXED_DATE = "2026-07-26";
+const FIXED_NOW = () => new Date(`${FIXED_DATE}T12:00:00Z`);
+const STORE_FILE = "local-tracker.json";
+const LOCAL_TRACKER_PATH = path.join(__dirname, "local-tracker.js");
 
-function makeStore(t, { seedTasks = [], seedCompleted = [] } = {}) {
+function makeStore(t, config = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "local-tracker-"));
   const backlogDir = path.join(root, "backlog");
-  fs.mkdirSync(path.join(backlogDir, "tasks"), { recursive: true });
-  fs.mkdirSync(path.join(backlogDir, "completed"), { recursive: true });
+  fs.mkdirSync(backlogDir, { recursive: true });
   fs.writeFileSync(
     path.join(backlogDir, "config.yml"),
-    'tracker: local\ntask_prefix: "BACK"\ndefault_status: "To Do"\nstatuses: ["To Do", "In Progress", "Done"]\n'
-  );
-  for (const [name, content] of seedTasks) {
-    fs.writeFileSync(path.join(backlogDir, "tasks", name), content);
-  }
-  for (const [name, content] of seedCompleted) {
-    fs.writeFileSync(path.join(backlogDir, "completed", name), content);
-  }
-  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
-  return { root, backlogDir, adapter: createLocalAdapter({ backlogDir, now: FIXED_NOW }) };
-}
-
-function taskFile({ id, title, status = "To Do", body = "\n## Description\nseed body\n" }) {
-  return (
-    `---\n` +
-    `id: BACK-${id}\n` +
-    `title: ${title}\n` +
-    `status: ${status}\n` +
-    `labels: []\n` +
-    `priority: medium\n` +
-    `created_date: '2026-07-01'\n` +
-    `---` +
-    body
-  );
-}
-
-function read(backlogDir, dir, name) {
-  return fs.readFileSync(path.join(backlogDir, dir, name), "utf-8");
-}
-
-function listNames(backlogDir, dir) {
-  return fs.readdirSync(path.join(backlogDir, dir)).filter((f) => f.endsWith(".md")).sort();
-}
-
-describe("local adapter shape and authority", () => {
-  it("exposes exactly the seven required operations and empty capabilities", (t) => {
-    const { adapter } = makeStore(t);
-    assert.deepEqual(Object.keys(adapter), REQUIRED_ADAPTER_OPERATIONS);
-    assert.deepEqual(adapter.capabilities(), []);
-    assert.deepEqual(adapter.availability(), { available: true });
-  });
-
-  it("reports an actionable unavailable reason for a malformed store without fallback", (t) => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "local-tracker-bad-"));
-    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
-    const filePath = path.join(root, "not-a-dir");
-    fs.writeFileSync(filePath, "i am a file");
-    const adapter = createLocalAdapter({ backlogDir: filePath, now: FIXED_NOW });
-    const report = adapter.availability();
-    assert.equal(report.available, false);
-    assert.ok(typeof report.reason === "string" && report.reason.trim().length > 0);
-  });
-});
-
-describe("local create — allocation, atomic publish, identity", () => {
-  it("allocates the next positive parent id and returns a normalized url-free identity", (t) => {
-    const { adapter, backlogDir } = makeStore(t);
-    const first = adapter.create({ title: "First task" });
-    assert.deepEqual(first, { tracker: "local", id: "1", ref: "BACK-1" });
-    assert.equal(Object.prototype.hasOwnProperty.call(first, "url"), false);
-
-    const second = adapter.create({ title: "Second task" });
-    assert.equal(second.id, "2");
-    assert.deepEqual(listNames(backlogDir, "tasks"), [
-      "BACK-1 - first-task.md",
-      "BACK-2 - second-task.md",
-    ]);
-  });
-
-  it("allocates across active and completed exact-prefix files", (t) => {
-    const { adapter } = makeStore(t, {
-      seedTasks: [["BACK-3 - active.md", taskFile({ id: 3, title: "Active" })]],
-      seedCompleted: [["BACK-7 - done.md", taskFile({ id: 7, title: "Done", status: "Done" })]],
-    });
-    assert.equal(adapter.create({ title: "Next" }).id, "8");
-  });
-
-  it("keeps BACK-1 and BACK-11 distinct when choosing the next id", (t) => {
-    const { adapter } = makeStore(t, {
-      seedTasks: [
-        ["BACK-1 - one.md", taskFile({ id: 1, title: "One" })],
-        ["BACK-11 - eleven.md", taskFile({ id: 11, title: "Eleven" })],
-      ],
-    });
-    assert.equal(adapter.create({ title: "After" }).id, "12");
-    assert.equal(adapter.read("BACK-1").id, "1");
-    assert.equal(adapter.read("BACK-11").id, "11");
-  });
-
-  it("creates an explicit free decimal subtask without disturbing parent allocation", (t) => {
-    const { adapter, backlogDir } = makeStore(t, {
-      seedTasks: [["BACK-1 - parent.md", taskFile({ id: 1, title: "Parent" })]],
-    });
-    const sub = adapter.create({ title: "Child", id: "1.2" });
-    assert.deepEqual(sub, { tracker: "local", id: "1.2", ref: "BACK-1.2" });
-    assert.ok(fs.existsSync(path.join(backlogDir, "tasks", "BACK-1.2 - child.md")));
-    // parent allocation still counts only integer parents
-    assert.equal(adapter.create({ title: "Sibling" }).id, "2");
-  });
-
-  it("refuses an explicit id that already exists and leaves the store untouched", (t) => {
-    const { adapter, backlogDir } = makeStore(t, {
-      seedTasks: [["BACK-1 - parent.md", taskFile({ id: 1, title: "Parent" })]],
-    });
-    const before = read(backlogDir, "tasks", "BACK-1 - parent.md");
-    assert.throws(() => adapter.create({ title: "Dup", id: "1" }), LocalStoreError);
-    assert.equal(read(backlogDir, "tasks", "BACK-1 - parent.md"), before);
-    assert.deepEqual(listNames(backlogDir, "tasks"), ["BACK-1 - parent.md"]);
-    assert.ok(!fs.existsSync(path.join(backlogDir, ".local-tracker.lock")));
-  });
-
-  it("rejects missing/blank titles before any filesystem mutation", (t) => {
-    const { adapter, backlogDir } = makeStore(t);
-    for (const bad of [undefined, "", "   ", 5, null]) {
-      assert.throws(() => adapter.create({ title: bad }), LocalStoreError);
-    }
-    assert.deepEqual(listNames(backlogDir, "tasks"), []);
-  });
-
-  it("rejects an explicit foreign-prefix or malformed id", (t) => {
-    const { adapter } = makeStore(t);
-    for (const bad of ["OTHER-1", "BACK-1", "0", "1.0", "1.2.3", "-1", "x"]) {
-      assert.throws(() => adapter.create({ title: "T", id: bad }), LocalStoreError);
-    }
-  });
-});
-
-describe("local list and read", () => {
-  it("lists open, closed, and all exact-prefix tasks and skips foreign/malformed files", (t) => {
-    const { adapter } = makeStore(t, {
-      seedTasks: [
-        ["BACK-1 - one.md", taskFile({ id: 1, title: "One" })],
-        ["BACK-2 - two.md", taskFile({ id: 2, title: "Two", status: "In Progress" })],
-        ["OTHER-9 - foreign.md", taskFile({ id: 9, title: "Foreign" })],
-        ["not-a-task.md", "no frontmatter here"],
-      ],
-      seedCompleted: [
-        ["BACK-5 - five.md", taskFile({ id: 5, title: "Five", status: "Done" })],
-      ],
-    });
-
-    const open = adapter.list();
-    assert.deepEqual(open.map((t2) => t2.ref), ["BACK-1", "BACK-2"]);
-    assert.equal(open.every((t2) => t2.tracker === "local" && t2.state === "open"), true);
-    assert.equal(open.every((t2) => !("url" in t2)), true);
-
-    const closed = adapter.list({ state: "closed" });
-    assert.deepEqual(closed.map((t2) => t2.ref), ["BACK-5"]);
-    assert.equal(closed[0].state, "closed");
-
-    const all = adapter.list({ state: "all" });
-    assert.deepEqual(all.map((t2) => t2.ref), ["BACK-1", "BACK-2", "BACK-5"]);
-  });
-
-  it("reads one task by identity, ref string, or bare id and exposes neutral fields", (t) => {
-    const { adapter } = makeStore(t, {
-      seedTasks: [["BACK-2 - two.md", taskFile({ id: 2, title: "Two", status: "In Progress" })]],
-      seedCompleted: [["BACK-5 - five.md", taskFile({ id: 5, title: "Five", status: "Done" })]],
-    });
-    for (const selector of ["BACK-2", "2", { tracker: "local", id: "2", ref: "BACK-2" }]) {
-      const task = adapter.read(selector);
-      assert.equal(task.id, "2");
-      assert.equal(task.title, "Two");
-      assert.equal(task.status, "In Progress");
-      assert.equal(task.state, "open");
-      assert.equal("url" in task, false);
-    }
-    assert.equal(adapter.read("BACK-5").state, "closed");
-  });
-
-  it("does not mutate files during list/read", (t) => {
-    const { adapter, backlogDir } = makeStore(t, {
-      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One" })]],
-    });
-    const before = read(backlogDir, "tasks", "BACK-1 - one.md");
-    adapter.list({ state: "all" });
-    adapter.read("BACK-1");
-    assert.equal(read(backlogDir, "tasks", "BACK-1 - one.md"), before);
-  });
-
-  it("rejects a foreign-prefix read selector rather than inferring it", (t) => {
-    const { adapter } = makeStore(t);
-    assert.throws(() => adapter.read("OTHER-1"), LocalStoreError);
-    assert.throws(() => adapter.read("BACK-404"), LocalStoreError);
-  });
-});
-
-describe("local update — metadata/state without body loss", () => {
-  it("changes only requested fields and preserves body/AC bytes exactly", (t) => {
-    const body =
-      "\n## Description\nHuman authored prose with UTF-8 ☕ and trailing spaces.  \n" +
-      "\n## Acceptance Criteria\n<!-- AC:BEGIN -->\n- [x] done item\n- [ ] pending item\n<!-- AC:END -->\n";
-    const { adapter, backlogDir } = makeStore(t, {
-      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One", body })]],
-    });
-    const original = read(backlogDir, "tasks", "BACK-1 - one.md");
-    const originalBody = original.slice(original.indexOf("\n## Description"));
-
-    adapter.update("BACK-1", { status: "In Progress" });
-    const updated = read(backlogDir, "tasks", "BACK-1 - one.md");
-    const updatedBody = updated.slice(updated.indexOf("\n## Description"));
-
-    assert.equal(updatedBody, originalBody, "body bytes must be preserved");
-    assert.match(updated, /^status: In Progress$/m);
-    assert.equal(adapter.read("BACK-1").status, "In Progress");
-  });
-
-  it("preserves unrelated frontmatter and only rewrites the requested keys", (t) => {
-    const { adapter, backlogDir } = makeStore(t, {
-      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One" })]],
-    });
-    adapter.update("BACK-1", { labels: ["infra", "urgent"], priority: "high" });
-    const updated = read(backlogDir, "tasks", "BACK-1 - one.md");
-    assert.match(updated, /^priority: high$/m);
-    assert.match(updated, /^labels:\n {2}- infra\n {2}- urgent$/m);
-    assert.match(updated, /^created_date: '2026-07-01'$/m);
-    assert.match(updated, /^id: BACK-1$/m);
-  });
-
-  it("replaces the body only when the caller supplies one explicitly", (t) => {
-    const { adapter, backlogDir } = makeStore(t, {
-      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One" })]],
-    });
-    adapter.update("BACK-1", { body: "\n## Description\nrewritten by caller\n" });
-    const updated = read(backlogDir, "tasks", "BACK-1 - one.md");
-    assert.match(updated, /rewritten by caller/);
-  });
-
-  it("refuses to update a task that is not active", (t) => {
-    const { adapter } = makeStore(t, {
-      seedCompleted: [["BACK-5 - five.md", taskFile({ id: 5, title: "Five", status: "Done" })]],
-    });
-    assert.throws(() => adapter.update("BACK-5", { status: "To Do" }), LocalStoreError);
-    assert.throws(() => adapter.update("BACK-404", { status: "To Do" }), LocalStoreError);
-  });
-});
-
-describe("local close — exact archive without overwrite", () => {
-  it("moves exactly one active task to completed with status Done and preserved body", (t) => {
-    const body = "\n## Description\nkeep me\n";
-    const { adapter, backlogDir } = makeStore(t, {
-      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One", body })]],
-    });
-    const closed = adapter.close("BACK-1");
-    assert.deepEqual(closed, { tracker: "local", id: "1", ref: "BACK-1" });
-    assert.deepEqual(listNames(backlogDir, "tasks"), []);
-    assert.deepEqual(listNames(backlogDir, "completed"), ["BACK-1 - one.md"]);
-    const archived = read(backlogDir, "completed", "BACK-1 - one.md");
-    assert.match(archived, /^status: Done$/m);
-    assert.ok(archived.includes("keep me"));
-  });
-
-  it("refuses to overwrite an existing completed destination and keeps both files", (t) => {
-    const { adapter, backlogDir } = makeStore(t, {
-      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One", body: "\n## Description\nactive\n" })]],
-      seedCompleted: [["BACK-1 - one.md", taskFile({ id: 1, title: "One", status: "Done", body: "\n## Description\narchived\n" })]],
-    });
-    const beforeCompleted = read(backlogDir, "completed", "BACK-1 - one.md");
-    assert.throws(() => adapter.close("BACK-1"), LocalStoreError);
-    assert.equal(read(backlogDir, "completed", "BACK-1 - one.md"), beforeCompleted);
-    assert.ok(fs.existsSync(path.join(backlogDir, "tasks", "BACK-1 - one.md")));
-  });
-
-  it("is idempotent when the task is already closed", (t) => {
-    const { adapter, backlogDir } = makeStore(t, {
-      seedCompleted: [["BACK-5 - five.md", taskFile({ id: 5, title: "Five", status: "Done" })]],
-    });
-    const before = read(backlogDir, "completed", "BACK-5 - five.md");
-    const result = adapter.close("BACK-5");
-    assert.deepEqual(result, { tracker: "local", id: "5", ref: "BACK-5" });
-    assert.equal(read(backlogDir, "completed", "BACK-5 - five.md"), before);
-  });
-
-  it("throws for a task that exists in neither store", (t) => {
-    const { adapter } = makeStore(t);
-    assert.throws(() => adapter.close("BACK-404"), LocalStoreError);
-  });
-});
-
-describe("local authority — no capabilities and no gh", () => {
-  it("runs a full create/read/update/close cycle without invoking gh", (t) => {
-    const { adapter, backlogDir } = makeStore(t);
-    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "local-tracker-bin-"));
-    t.after(() => fs.rmSync(binDir, { recursive: true, force: true }));
-    const marker = path.join(binDir, "gh-was-called");
-    fs.writeFileSync(path.join(binDir, "gh"), `#!/bin/sh\ntouch "${marker}"\nexit 1\n`);
-    fs.chmodSync(path.join(binDir, "gh"), 0o755);
-
-    const savedPath = process.env.PATH;
-    process.env.PATH = `${binDir}:${savedPath}`;
-    t.after(() => {
-      process.env.PATH = savedPath;
-    });
-
-    const id = adapter.create({ title: "Cycle" });
-    adapter.read(id);
-    adapter.update(id, { status: "In Progress" });
-    adapter.close(id);
-
-    assert.equal(fs.existsSync(marker), false, "gh must never be invoked by the local adapter");
-    assert.deepEqual(listNames(backlogDir, "completed"), ["BACK-1 - cycle.md"]);
-  });
-
-  it("reports no optional capabilities", (t) => {
-    const { adapter } = makeStore(t);
-    assert.deepEqual(adapter.capabilities(), []);
-  });
-});
-
-describe("local allocation critical section", () => {
-  it("fails clearly on lock contention and never removes a lock it does not own", (t) => {
-    const { adapter, backlogDir } = makeStore(t);
-    const contended = createLocalAdapter({
-      backlogDir,
-      now: FIXED_NOW,
-      lock: { retries: 0, delayMs: 1 },
-    });
-    const lockPath = path.join(backlogDir, ".local-tracker.lock");
-    fs.writeFileSync(lockPath, String(process.pid));
-    assert.throws(() => contended.create({ title: "Blocked" }), LocalStoreError);
-    assert.ok(fs.existsSync(lockPath), "foreign lock must be preserved");
-    assert.deepEqual(listNames(backlogDir, "tasks"), []);
-
-    fs.unlinkSync(lockPath);
-    assert.equal(adapter.create({ title: "After release" }).id, "1");
-    assert.ok(!fs.existsSync(lockPath), "lock is released on the success path");
-  });
-
-  it("cleans up the lock and temp files when publication fails mid-operation", (t) => {
-    const { backlogDir } = makeStore(t);
-    const adapter = createLocalAdapter({
-      backlogDir,
-      now: FIXED_NOW,
-      testHooks: {
-        beforePublish() {
-          throw new Error("injected publish failure");
-        },
-      },
-    });
-    assert.throws(() => adapter.create({ title: "Boom" }));
-    assert.deepEqual(listNames(backlogDir, "tasks"), []);
-    assert.ok(!fs.existsSync(path.join(backlogDir, ".local-tracker.lock")));
-    const strays = fs.readdirSync(path.join(backlogDir, "tasks")).filter((f) => f.includes(".tmp"));
-    assert.deepEqual(strays, []);
-  });
-
-  it("serializes update and close on the same store lock as create", (t) => {
-    const { adapter, backlogDir } = makeStore(t, {
-      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One" })]],
-    });
-    const contended = createLocalAdapter({
-      backlogDir,
-      now: FIXED_NOW,
-      lock: { retries: 0, delayMs: 1 },
-    });
-    const lockPath = path.join(backlogDir, ".local-tracker.lock");
-    fs.writeFileSync(lockPath, String(process.pid));
-
-    // A held store lock blocks update and close, not just create.
-    assert.throws(() => contended.update("BACK-1", { status: "In Progress" }), LocalStoreError);
-    assert.throws(() => contended.close("BACK-1"), LocalStoreError);
-    assert.match(read(backlogDir, "tasks", "BACK-1 - one.md"), /^status: To Do$/m);
-
-    fs.unlinkSync(lockPath);
-    adapter.update("BACK-1", { status: "In Progress" });
-    assert.ok(!fs.existsSync(lockPath), "update releases the store lock");
-    adapter.close("BACK-1");
-    assert.ok(!fs.existsSync(lockPath), "close releases the store lock");
-    assert.deepEqual(listNames(backlogDir, "completed"), ["BACK-1 - one.md"]);
-  });
-});
-
-describe("local canonical identity — fail closed on corruption", () => {
-  it("treats duplicate same-id files in one store as corruption", (t) => {
-    const { adapter } = makeStore(t, {
-      seedTasks: [
-        ["BACK-1 - one.md", taskFile({ id: 1, title: "One" })],
-        ["BACK-1 - dup.md", taskFile({ id: 1, title: "Dup" })],
-      ],
-    });
-    assert.throws(() => adapter.read("BACK-1"), LocalStoreError);
-    assert.throws(() => adapter.list(), LocalStoreError);
-  });
-
-  it("rejects a filename/frontmatter id mismatch rather than trusting the filename", (t) => {
-    const { adapter } = makeStore(t, {
-      seedTasks: [["BACK-1 - one.md", taskFile({ id: 2, title: "Mismatch" })]],
-    });
-    assert.throws(() => adapter.read("BACK-1"), LocalStoreError);
-    assert.throws(() => adapter.list(), LocalStoreError);
-  });
-
-  it("rejects the same id living in both active and completed stores", (t) => {
-    const { adapter } = makeStore(t, {
-      seedTasks: [["BACK-1 - active.md", taskFile({ id: 1, title: "Active" })]],
-      seedCompleted: [["BACK-1 - archived.md", taskFile({ id: 1, title: "Archived", status: "Done" })]],
-    });
-    assert.throws(() => adapter.read("BACK-1"), LocalStoreError);
-    for (const state of ["open", "closed", "all"]) {
-      assert.throws(
-        () => adapter.list({ state }),
-        (error) =>
-          error instanceof LocalStoreError &&
-          /exists in both active and completed|unique across the canonical stores/i.test(error.message),
-        `${state} filtering must not hide store-wide exact-id corruption`
-      );
-    }
-  });
-});
-
-describe("local store-wide exact-id uniqueness on close", () => {
-  it("refuses to archive over a completed twin with a different slug and preserves bytes", (t) => {
-    const { adapter, backlogDir } = makeStore(t, {
-      seedTasks: [["BACK-1 - active-slug.md", taskFile({ id: 1, title: "Active", body: "\n## Description\nactive\n" })]],
-      seedCompleted: [["BACK-1 - other-slug.md", taskFile({ id: 1, title: "Other", status: "Done", body: "\n## Description\narchived\n" })]],
-    });
-    const activeBefore = read(backlogDir, "tasks", "BACK-1 - active-slug.md");
-    const completedBefore = read(backlogDir, "completed", "BACK-1 - other-slug.md");
-    assert.throws(() => adapter.close("BACK-1"), LocalStoreError);
-    assert.equal(read(backlogDir, "tasks", "BACK-1 - active-slug.md"), activeBefore);
-    assert.equal(read(backlogDir, "completed", "BACK-1 - other-slug.md"), completedBefore);
-    assert.deepEqual(listNames(backlogDir, "completed"), ["BACK-1 - other-slug.md"]);
-  });
-});
-
-describe("local rendered metadata round-trips through read", () => {
-  it("reads back non-empty labels and dependencies as arrays, not malformed objects", (t) => {
-    const { adapter } = makeStore(t);
-    adapter.create({
-      title: "Meta",
-      labels: ["infra", "urgent"],
-      dependencies: ["BACK-9", "BACK-8"],
-    });
-    const task = adapter.read("BACK-1");
-    assert.deepEqual(task.labels, ["infra", "urgent"]);
-    assert.deepEqual(task.dependencies, ["BACK-9", "BACK-8"]);
-    const listed = adapter.list().find((entry) => entry.ref === "BACK-1");
-    assert.deepEqual(listed.labels, ["infra", "urgent"]);
-    assert.deepEqual(listed.dependencies, ["BACK-9", "BACK-8"]);
-  });
-});
-
-describe("local body normalization", () => {
-  it("normalizes a create body without a leading newline into a readable task", (t) => {
-    const { adapter } = makeStore(t);
-    adapter.create({ title: "Plain", body: "just plain text without a leading newline" });
-    const task = adapter.read("BACK-1");
-    assert.match(task.body, /just plain text without a leading newline/);
-    assert.ok(task.body.startsWith("\n"), "body is separated from the frontmatter fence");
-  });
-
-  it("normalizes an update body without a leading newline", (t) => {
-    const { adapter } = makeStore(t, {
-      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One" })]],
-    });
-    adapter.update("BACK-1", { body: "replacement without a leading newline" });
-    const task = adapter.read("BACK-1");
-    assert.match(task.body, /replacement without a leading newline/);
-  });
-});
-
-describe("local canonical directory containment", () => {
-  it("rejects a task_prefix that could escape tasks/completed and reports unavailable", (t) => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "local-tracker-esc-"));
-    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
-    const backlogDir = path.join(root, "backlog");
-    fs.mkdirSync(path.join(backlogDir, "tasks"), { recursive: true });
-    fs.mkdirSync(path.join(backlogDir, "completed"), { recursive: true });
-
-    for (const bad of ["../ESC", "a/b", "a\\b", "..", "with space"]) {
-      const adapter = createLocalAdapter({ backlogDir, config: { task_prefix: bad }, now: FIXED_NOW });
-      assert.equal(adapter.availability().available, false, `prefix ${JSON.stringify(bad)} must be unavailable`);
-      assert.throws(() => adapter.create({ title: "Escape" }), LocalStoreError);
-    }
-
-    // Nothing escaped the canonical directories.
-    assert.deepEqual(fs.readdirSync(backlogDir).filter((name) => name.includes("ESC")), []);
-    assert.deepEqual(listNames(backlogDir, "tasks"), []);
-  });
-});
-
-describe("local pre-mutation unsupported-option failures", () => {
-  it("rejects provider-specific options on create, update, and close before mutating", (t) => {
-    const { adapter, backlogDir } = makeStore(t, {
-      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One" })]],
-    });
-    const before = read(backlogDir, "tasks", "BACK-1 - one.md");
-
-    assert.throws(() => adapter.create({ title: "Milestoned", milestone: "v1" }), LocalStoreError);
-    assert.throws(() => adapter.update("BACK-1", { status: "Done", milestone: "v1" }), LocalStoreError);
-    assert.throws(() => adapter.close("BACK-1", { reason: "done enough" }), LocalStoreError);
-
-    assert.equal(read(backlogDir, "tasks", "BACK-1 - one.md"), before, "no option-rejected mutation touched bytes");
-    assert.deepEqual(listNames(backlogDir, "tasks"), ["BACK-1 - one.md"]);
-    assert.deepEqual(listNames(backlogDir, "completed"), []);
-  });
-});
-
-function strays(backlogDir, dir) {
-  return fs.readdirSync(path.join(backlogDir, dir)).filter((name) => name.includes(".tmp"));
-}
-
-describe("local close — unlink failure compensation and recovery", () => {
-  it("rolls back the completed publication when the source unlink fails", (t) => {
-    const { backlogDir } = makeStore(t, {
-      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One", body: "\n## Description\nkeep\n" })]],
-    });
-    const adapter = createLocalAdapter({
-      backlogDir,
-      now: FIXED_NOW,
-      testHooks: {
-        beforeUnlinkSource() {
-          throw new Error("injected source unlink failure");
-        },
-      },
-    });
-    const before = read(backlogDir, "tasks", "BACK-1 - one.md");
-    assert.throws(() => adapter.close("BACK-1"), LocalStoreError);
-
-    // Exactly one intact authoritative copy remains: the byte-identical active source.
-    assert.equal(read(backlogDir, "tasks", "BACK-1 - one.md"), before);
-    assert.deepEqual(listNames(backlogDir, "tasks"), ["BACK-1 - one.md"]);
-    assert.deepEqual(listNames(backlogDir, "completed"), []);
-    // Lock and temp state are cleaned on the failure path.
-    assert.ok(!fs.existsSync(path.join(backlogDir, ".local-tracker.lock")));
-    assert.deepEqual(strays(backlogDir, "tasks"), []);
-    assert.deepEqual(strays(backlogDir, "completed"), []);
-
-    // Recovery: once the fault clears, a fresh close archives cleanly.
-    const healthy = createLocalAdapter({ backlogDir, now: FIXED_NOW });
-    healthy.close("BACK-1");
-    assert.deepEqual(listNames(backlogDir, "tasks"), []);
-    assert.deepEqual(listNames(backlogDir, "completed"), ["BACK-1 - one.md"]);
-    assert.match(read(backlogDir, "completed", "BACK-1 - one.md"), /^status: Done$/m);
-  });
-
-  it("does not erase a byte-different replacement even when rollback sees the same dev and inode", (t) => {
-    const { backlogDir } = makeStore(t, {
-      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One", body: "\n## Description\nactive\n" })]],
-    });
-    const completedPath = path.join(backlogDir, "completed", "BACK-1 - one.md");
-    const external = taskFile({ id: 1, title: "External owner", status: "Done", body: "\n## Description\nexternal\n" });
-    const adapter = createLocalAdapter({
-      backlogDir,
-      now: FIXED_NOW,
-      testHooks: {
-        rollbackFileIdentity() {
-          // Model Linux immediately reusing the publication's dev+ino for the
-          // replacement. Content evidence must independently veto deletion.
-          return { dev: 7, ino: 11 };
-        },
-        beforeUnlinkSource() {
-          // Simulate another writer swapping our fresh publication while the
-          // filesystem reports the same projected identity for both files.
-          fs.rmSync(completedPath);
-          fs.writeFileSync(completedPath, external);
-          throw new Error("injected source unlink failure");
-        },
-      },
-    });
-    assert.throws(() => adapter.close("BACK-1"), (error) => error instanceof LocalStoreError && /both/.test(error.message));
-
-    // The externally owned destination is preserved byte-for-byte, and the active source survives.
-    assert.equal(fs.readFileSync(completedPath, "utf-8"), external);
-    assert.ok(fs.existsSync(path.join(backlogDir, "tasks", "BACK-1 - one.md")));
-    assert.ok(!fs.existsSync(path.join(backlogDir, ".local-tracker.lock")));
-    assert.deepEqual(strays(backlogDir, "completed"), []);
-  });
-
-  it("preserves both copies and reports a split store when rollback also fails", (t) => {
-    const { backlogDir } = makeStore(t, {
-      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One", body: "\n## Description\nkeep\n" })]],
-    });
-    const adapter = createLocalAdapter({
-      backlogDir,
-      now: FIXED_NOW,
-      testHooks: {
-        beforeUnlinkSource() {
-          throw new Error("injected source unlink failure");
-        },
-        beforeRollback() {
-          throw new Error("injected rollback failure");
-        },
-      },
-    });
-    assert.throws(() => adapter.close("BACK-1"), (error) => error instanceof LocalStoreError && /both/.test(error.message));
-
-    // No data loss: both the active source and the completed copy stay intact.
-    assert.ok(fs.existsSync(path.join(backlogDir, "tasks", "BACK-1 - one.md")));
-    assert.deepEqual(listNames(backlogDir, "completed"), ["BACK-1 - one.md"]);
-    assert.ok(!fs.existsSync(path.join(backlogDir, ".local-tracker.lock")));
-    assert.deepEqual(strays(backlogDir, "completed"), []);
-
-    // The store now fails closed on the duplicate id until an operator resolves it.
-    const healthy = createLocalAdapter({ backlogDir, now: FIXED_NOW });
-    assert.throws(() => healthy.read("BACK-1"), LocalStoreError);
-    assert.throws(() => healthy.list({ state: "all" }), LocalStoreError);
-
-    // Recovery: removing the duplicate completed copy restores a clean close.
-    fs.rmSync(path.join(backlogDir, "completed", "BACK-1 - one.md"));
-    healthy.close("BACK-1");
-    assert.deepEqual(listNames(backlogDir, "tasks"), []);
-    assert.deepEqual(listNames(backlogDir, "completed"), ["BACK-1 - one.md"]);
-  });
-});
-
-describe("local required frontmatter validation", () => {
-  const INVALID = {
-    "missing id": "---\ntitle: One\nstatus: To Do\n---\n## Description\nx\n",
-    "missing title": "---\nid: BACK-1\nstatus: To Do\n---\n## Description\nx\n",
-    "missing status": "---\nid: BACK-1\ntitle: One\n---\n## Description\nx\n",
-    "duplicate id": "---\nid: BACK-1\nid: BACK-1\ntitle: One\nstatus: To Do\n---\n## Description\nx\n",
-    "wrong-type title": "---\nid: BACK-1\ntitle:\n  - a\n  - b\nstatus: To Do\n---\n## Description\nx\n",
-    "empty status": "---\nid: BACK-1\ntitle: One\nstatus: ''\n---\n## Description\nx\n",
-    "no frontmatter": "just a body, no frontmatter fence\n",
-  };
-  for (const [label, content] of Object.entries(INVALID)) {
-    it(`rejects ${label} on read and list before returning a task`, (t) => {
-      const { adapter } = makeStore(t, { seedTasks: [["BACK-1 - one.md", content]] });
-      assert.throws(() => adapter.read("BACK-1"), LocalStoreError);
-      assert.throws(() => adapter.list(), LocalStoreError);
-      assert.throws(() => adapter.list({ state: "all" }), LocalStoreError);
-    });
-  }
-
-  it("requires the frontmatter id to equal the filename ref", (t) => {
-    const { adapter } = makeStore(t, {
-      seedTasks: [["BACK-1 - one.md", taskFile({ id: 2, title: "Mismatch" })]],
-    });
-    assert.throws(() => adapter.read("BACK-1"), LocalStoreError);
-    assert.throws(() => adapter.list(), LocalStoreError);
-  });
-
-  it("rejects invalid required frontmatter on update and close before mutating", (t) => {
-    const missingStatus = "---\nid: BACK-1\ntitle: One\n---\n## Description\nx\n";
-    const { adapter, backlogDir } = makeStore(t, {
-      seedTasks: [["BACK-1 - one.md", missingStatus]],
-    });
-    const before = read(backlogDir, "tasks", "BACK-1 - one.md");
-    assert.throws(() => adapter.update("BACK-1", { status: "In Progress" }), LocalStoreError);
-    assert.throws(() => adapter.close("BACK-1"), LocalStoreError);
-    assert.equal(read(backlogDir, "tasks", "BACK-1 - one.md"), before, "no mutation touched bytes");
-    assert.deepEqual(listNames(backlogDir, "completed"), []);
-  });
-
-  it("accepts a well-formed task the way create renders it", (t) => {
-    const { adapter } = makeStore(t);
-    adapter.create({ title: "Well formed", labels: ["a"], dependencies: ["BACK-9"] });
-    assert.equal(adapter.read("BACK-1").title, "Well formed");
-    assert.deepEqual(adapter.list().map((task) => task.ref), ["BACK-1"]);
-  });
-});
-
-describe("local metadata injection is rejected fail-closed", () => {
-  const CREATE_INJECTIONS = {
-    status: "In Progress\ninjected: true",
-    title: "Title\nid: BACK-999",
-    priority: "high\nmalicious: 1",
-  };
-  for (const [field, value] of Object.entries(CREATE_INJECTIONS)) {
-    it(`rejects a newline-injecting ${field} on create without writing`, (t) => {
-      const { adapter, backlogDir } = makeStore(t);
-      const input = { title: field === "title" ? value : "Safe", [field]: value };
-      assert.throws(() => adapter.create(input), LocalStoreError);
-      assert.deepEqual(listNames(backlogDir, "tasks"), []);
-      assert.ok(!fs.existsSync(path.join(backlogDir, ".local-tracker.lock")));
-      assert.deepEqual(strays(backlogDir, "tasks"), []);
-    });
-  }
-
-  it("rejects newline-injecting labels and dependencies on create", (t) => {
-    const { adapter, backlogDir } = makeStore(t);
-    assert.throws(() => adapter.create({ title: "Safe", labels: ["ok", "bad\nid: BACK-999"] }), LocalStoreError);
-    assert.throws(() => adapter.create({ title: "Safe", dependencies: ["BACK-2\ninjected: true"] }), LocalStoreError);
-    assert.deepEqual(listNames(backlogDir, "tasks"), []);
-  });
-
-  it("also rejects carriage returns, NUL, and tabs in scalar metadata", (t) => {
-    const { adapter, backlogDir } = makeStore(t);
-    for (const bad of ["A\rB", "A B", "A\tB"]) {
-      assert.throws(() => adapter.create({ title: "Safe", status: bad }), LocalStoreError);
-    }
-    assert.throws(() => adapter.create({ title: "Tab\tinject" }), LocalStoreError);
-    assert.deepEqual(listNames(backlogDir, "tasks"), []);
-  });
-
-  it("rejects injection on update and leaves bytes and mtime unchanged", (t) => {
-    const { adapter, backlogDir } = makeStore(t, {
-      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One" })]],
-    });
-    const filePath = path.join(backlogDir, "tasks", "BACK-1 - one.md");
-    const before = fs.readFileSync(filePath, "utf-8");
-    const mtimeBefore = fs.statSync(filePath).mtimeMs;
-    const injections = [
-      { status: "Done\ninjected: true" },
-      { title: "New\nid: BACK-9" },
-      { priority: "high\nx: 1" },
-      { labels: ["ok", "bad\nkey: v"] },
-      { dependencies: ["BACK-2\nkey: v"] },
-      { updated_date: "2026-07-11\ninjected: true" },
-    ];
-    for (const change of injections) {
-      assert.throws(() => adapter.update("BACK-1", change), LocalStoreError);
-    }
-    assert.equal(fs.readFileSync(filePath, "utf-8"), before, "bytes unchanged");
-    assert.equal(fs.statSync(filePath).mtimeMs, mtimeBefore, "mtime unchanged (no temp/mtime mutation)");
-    assert.ok(!fs.existsSync(path.join(backlogDir, ".local-tracker.lock")));
-    assert.deepEqual(strays(backlogDir, "tasks"), []);
-  });
-});
-
-describe("local update no-op and list-state validation edges", () => {
-  it("treats update with no changes as a byte and mtime no-op", (t) => {
-    const { adapter, backlogDir } = makeStore(t, {
-      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One" })]],
-    });
-    const filePath = path.join(backlogDir, "tasks", "BACK-1 - one.md");
-    const before = fs.readFileSync(filePath, "utf-8");
-    const mtimeBefore = fs.statSync(filePath).mtimeMs;
-    const result = adapter.update("BACK-1", {});
-    assert.deepEqual(result, { tracker: "local", id: "1", ref: "BACK-1" });
-    assert.equal(fs.readFileSync(filePath, "utf-8"), before, "bytes unchanged");
-    assert.equal(fs.statSync(filePath).mtimeMs, mtimeBefore, "mtime unchanged");
-    assert.deepEqual(strays(backlogDir, "tasks"), []);
-  });
-
-  it("no-ops when every requested field already holds its current value", (t) => {
-    const { adapter, backlogDir } = makeStore(t, {
-      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One", status: "To Do" })]],
-    });
-    const filePath = path.join(backlogDir, "tasks", "BACK-1 - one.md");
-    const before = fs.readFileSync(filePath, "utf-8");
-    const mtimeBefore = fs.statSync(filePath).mtimeMs;
-    adapter.update("BACK-1", { status: "To Do" });
-    assert.equal(fs.readFileSync(filePath, "utf-8"), before, "value-preserving update keeps bytes");
-    assert.equal(fs.statSync(filePath).mtimeMs, mtimeBefore, "value-preserving update keeps mtime");
-  });
-
-  it("rejects an invalid list state instead of silently defaulting to open", (t) => {
-    const { adapter } = makeStore(t, {
-      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One" })]],
-      seedCompleted: [["BACK-5 - five.md", taskFile({ id: 5, title: "Five", status: "Done" })]],
-    });
-    for (const bad of ["opened", "OPEN", "active", "Open", "", null, 1, "toString", "__proto__"]) {
-      assert.throws(() => adapter.list({ state: bad }), LocalStoreError);
-    }
-    assert.deepEqual(adapter.list({ state: "open" }).map((task) => task.ref), ["BACK-1"]);
-    assert.deepEqual(adapter.list({ state: "closed" }).map((task) => task.ref), ["BACK-5"]);
-    assert.deepEqual(adapter.list({ state: "all" }).map((task) => task.ref), ["BACK-1", "BACK-5"]);
-    assert.deepEqual(adapter.list().map((task) => task.ref), ["BACK-1"]);
-  });
-});
-
-describe("local CRLF task files parse and preserve their newline style", () => {
-  const crlf = (id, status = "To Do") =>
     [
-      "---",
-      `id: BACK-${id}`,
-      "title: Windows Task",
-      `status: ${status}`,
-      "labels:",
-      "  - infra",
-      "priority: medium",
-      "created_date: '2026-07-01'",
-      "---",
-      "## Description",
-      "line one",
-      "line two",
+      "tracker: local",
+      `task_prefix: "${config.task_prefix || "BACK"}"`,
+      `default_status: "${config.default_status || "To Do"}"`,
       "",
-    ].join("\r\n");
+    ].join("\n")
+  );
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return {
+    root,
+    backlogDir,
+    adapter: createLocalAdapter({ backlogDir, now: FIXED_NOW, config }),
+  };
+}
 
-  const noBareLf = (content) => !/[^\r]\n/.test(content);
+function storePath(backlogDir) {
+  return path.join(backlogDir, STORE_FILE);
+}
 
-  it("reads a valid CRLF file instead of treating id as missing", (t) => {
-    const { adapter } = makeStore(t, { seedTasks: [["BACK-1 - one.md", crlf(1)]] });
-    const task = adapter.read("BACK-1");
-    assert.equal(task.id, "1");
-    assert.equal(task.title, "Windows Task");
-    assert.equal(task.status, "To Do");
-    assert.deepEqual(task.labels, ["infra"]);
-    assert.deepEqual(adapter.list().map((x) => x.ref), ["BACK-1"]);
-  });
+function readStore(backlogDir) {
+  return JSON.parse(fs.readFileSync(storePath(backlogDir), "utf8"));
+}
 
-  it("keeps CRLF newlines when updating a field", (t) => {
-    const { adapter, backlogDir } = makeStore(t, { seedTasks: [["BACK-1 - one.md", crlf(1)]] });
-    const before = read(backlogDir, "tasks", "BACK-1 - one.md");
-    adapter.update("BACK-1", { status: "In Progress" });
-    const after = read(backlogDir, "tasks", "BACK-1 - one.md");
-    // Exactly the status line changed; every other byte, including CRLF, is intact.
-    assert.equal(after, before.replace("status: To Do", "status: In Progress"));
-    assert.ok(after.includes("\r\n"), "CRLF endings survive the update");
-    assert.ok(noBareLf(after), "no bare LF was introduced");
-  });
+function record(id, fields = {}) {
+  return {
+    id,
+    title: fields.title || `Task ${id}`,
+    status: fields.status || "To Do",
+    labels: fields.labels || [],
+    priority: fields.priority || "medium",
+    dependencies: fields.dependencies || [],
+    milestone: "",
+    created_date: fields.created_date || FIXED_DATE,
+    updated_date: fields.updated_date || FIXED_DATE,
+    body: fields.body || `\n## Description\nTask ${id}\n`,
+    state: fields.state || "open",
+  };
+}
 
-  it("keeps CRLF newlines when closing", (t) => {
-    const { adapter, backlogDir } = makeStore(t, { seedTasks: [["BACK-1 - one.md", crlf(1)]] });
-    const before = read(backlogDir, "tasks", "BACK-1 - one.md");
-    adapter.close("BACK-1");
-    const archived = read(backlogDir, "completed", "BACK-1 - one.md");
-    assert.equal(archived, before.replace("status: To Do", "status: Done"));
-    assert.ok(archived.includes("\r\n"));
-    assert.ok(noBareLf(archived), "no bare LF was introduced on close");
-  });
-});
+function seedStore(backlogDir, tasks) {
+  fs.writeFileSync(
+    storePath(backlogDir),
+    `${JSON.stringify({ version: 1, tasks }, null, 2)}\n`
+  );
+}
 
-describe("local list items encode losslessly", () => {
-  it("round-trips YAML-significant label and dependency items", (t) => {
-    const { adapter, backlogDir } = makeStore(t);
-    const labels = ["#bug", "a: b", "true", "false", "[x]", "{a}", " leading", "trailing ", "quote's", "123"];
-    const dependencies = ["- dash", "@handle", "key: val", "BACK-9"];
-    adapter.create({ title: "Encoded", labels, dependencies });
+function mirrorNames(backlogDir, kind) {
+  const dir = path.join(backlogDir, kind);
+  return fs.existsSync(dir)
+    ? fs.readdirSync(dir).filter((name) => name.endsWith(".md")).sort()
+    : [];
+}
 
-    const task = adapter.read("BACK-1");
-    assert.deepEqual(task.labels, labels);
-    assert.deepEqual(task.dependencies, dependencies);
-
-    // Survives a metadata-only update and a re-read of both read and list.
-    adapter.update("BACK-1", { priority: "high" });
-    assert.deepEqual(adapter.read("BACK-1").labels, labels);
-    assert.deepEqual(adapter.list()[0].dependencies, dependencies);
-
-    // YAML-significant items are quoted so meaning cannot change; a plain token stays bare.
-    const raw = read(backlogDir, "tasks", "BACK-1 - encoded.md");
-    assert.match(raw, /^ {2}- '#bug'$/m);
-    assert.match(raw, /^ {2}- 'a: b'$/m);
-    assert.match(raw, /^ {2}- 'true'$/m);
-    assert.match(raw, /^ {2}- '123'$/m);
-    assert.match(raw, /^ {2}- 'quote''s'$/m);
-    assert.match(raw, /^ {2}- BACK-9$/m);
-  });
-});
-
-describe("local allocation is precision-safe for large parent ids", () => {
-  it("allocates strictly above a parent id beyond Number.MAX_SAFE_INTEGER", (t) => {
-    const big = "9007199254740993"; // 2^53 + 1: rounds down when handled as a JS float
-    const { adapter, backlogDir } = makeStore(t, {
-      seedTasks: [[`BACK-${big} - big.md`, taskFile({ id: big, title: "Big" })]],
-    });
-    const created = adapter.create({ title: "Next" });
-    assert.equal(created.id, "9007199254740994");
-    assert.notEqual(created.id, "9007199254740992"); // the rounded-down (colliding) value
-    assert.ok(fs.existsSync(path.join(backlogDir, "tasks", "BACK-9007199254740994 - next.md")));
-    assert.equal(adapter.read(`BACK-${big}`).id, big);
-    assert.equal(adapter.read("BACK-9007199254740994").id, "9007199254740994");
-  });
-});
-
-describe("local publication cleans partial temp files when the write itself fails", () => {
-  function failingWrite(tmp) {
-    fs.writeFileSync(tmp, "partial bytes"); // a partial temp lands on disk...
-    const error = new Error("ENOSPC: no space left on device, write");
-    error.code = "ENOSPC";
-    throw error; // ...then the write itself is reported as failed
+function tempNames(backlogDir) {
+  const names = [];
+  function scan(dir) {
+    if (!fs.existsSync(dir)) return;
+    for (const name of fs.readdirSync(dir)) {
+      const full = path.join(dir, name);
+      const stat = fs.lstatSync(full);
+      if (stat.isDirectory()) scan(full);
+      else if (name.includes(".local-tracker.") && name.endsWith(".tmp")) names.push(full);
+    }
   }
-
-  it("removes the stray temp on create when the write fails", (t) => {
-    const { backlogDir } = makeStore(t);
-    const adapter = createLocalAdapter({ backlogDir, now: FIXED_NOW, testHooks: { writeFile: failingWrite } });
-    assert.throws(() => adapter.create({ title: "Boom" }));
-    assert.deepEqual(listNames(backlogDir, "tasks"), []);
-    assert.deepEqual(strays(backlogDir, "tasks"), []);
-    assert.ok(!fs.existsSync(path.join(backlogDir, ".local-tracker.lock")));
-  });
-
-  it("removes the stray temp on update when the write fails and preserves the task", (t) => {
-    const { backlogDir } = makeStore(t, { seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One" })]] });
-    const before = read(backlogDir, "tasks", "BACK-1 - one.md");
-    const adapter = createLocalAdapter({ backlogDir, now: FIXED_NOW, testHooks: { writeFile: failingWrite } });
-    assert.throws(() => adapter.update("BACK-1", { status: "In Progress" }));
-    assert.equal(read(backlogDir, "tasks", "BACK-1 - one.md"), before, "original bytes untouched");
-    assert.deepEqual(strays(backlogDir, "tasks"), []);
-    assert.ok(!fs.existsSync(path.join(backlogDir, ".local-tracker.lock")));
-  });
-});
-
-const CLOSE_MARKER = ".local-tracker.close";
+  scan(backlogDir);
+  return names;
+}
 
 function symlinkSupported(root) {
   try {
+    const target = path.join(root, ".symlink-target");
     const link = path.join(root, ".symlink-probe");
-    fs.symlinkSync(path.join(root, ".symlink-target"), link);
+    fs.mkdirSync(target);
+    fs.symlinkSync(target, link);
     fs.unlinkSync(link);
+    fs.rmdirSync(target);
     return true;
   } catch {
     return false;
   }
 }
 
-describe("local rejects symlinked canonical paths", () => {
-  it("refuses a symlinked task file on read, list, and close without following it", (t) => {
-    const { root, backlogDir, adapter } = makeStore(t);
-    if (!symlinkSupported(root)) return; // platform without symlink privileges
-    // A real, well-formed task living OUTSIDE the backlog. A symlink in tasks/
-    // would let read/close follow it and touch bytes beyond the canonical store.
-    const outside = path.join(root, "outside.md");
-    fs.writeFileSync(outside, taskFile({ id: 1, title: "Outside", body: "\n## Description\nsecret\n" }));
-    fs.symlinkSync(outside, path.join(backlogDir, "tasks", "BACK-1 - one.md"));
-
-    assert.throws(() => adapter.read("BACK-1"), LocalStoreError);
-    assert.throws(() => adapter.list(), LocalStoreError);
-    assert.throws(() => adapter.close("BACK-1"), LocalStoreError);
-    assert.ok(fs.existsSync(outside), "the symlink target outside the backlog is never touched");
+describe("local JSON substrate contract", () => {
+  it("exposes exactly seven operations, no optional capabilities, and a usable empty store", (t) => {
+    const { adapter, backlogDir } = makeStore(t);
+    assert.deepEqual(Object.keys(adapter), [
+      "availability",
+      "capabilities",
+      "list",
+      "read",
+      "create",
+      "update",
+      "close",
+    ]);
+    assert.deepEqual(adapter.capabilities(), []);
+    assert.deepEqual(adapter.availability(), { available: true });
+    assert.deepEqual(adapter.list(), []);
+    assert.equal(fs.existsSync(storePath(backlogDir)), false, "reads do not create a store");
   });
 
-  it("reports unavailable for a symlinked canonical directory", (t) => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "local-tracker-symdir-"));
-    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
-    if (!symlinkSupported(root)) return;
-    const backlogDir = path.join(root, "backlog");
-    fs.mkdirSync(backlogDir, { recursive: true });
-    fs.mkdirSync(path.join(backlogDir, "completed"), { recursive: true });
-    const elsewhere = path.join(root, "elsewhere");
-    fs.mkdirSync(elsewhere, { recursive: true });
-    fs.symlinkSync(elsewhere, path.join(backlogDir, "tasks")); // tasks/ is a symlink
-    const report = createLocalAdapter({ backlogDir, now: FIXED_NOW }).availability();
-    assert.equal(report.available, false);
-    assert.match(report.reason, /symlink/);
-  });
-});
-
-describe("local recovery treats the close journal as untrusted", () => {
-  function writeMarker(backlogDir, marker) {
-    fs.writeFileSync(path.join(backlogDir, CLOSE_MARKER), JSON.stringify(marker));
-  }
-
-  it("keeps list and read non-mutating when a stale marker is present", (t) => {
-    const { backlogDir, adapter } = makeStore(t, {
-      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One" })]],
-    });
-    writeMarker(backlogDir, { v: 1, phase: "publish", id: "1", ref: "BACK-1", file: "BACK-1 - one.md", destHash: "0".repeat(64) });
-    assert.equal(adapter.read("BACK-1").id, "1");
-    assert.equal(adapter.list().length, 1);
-    assert.ok(fs.existsSync(path.join(backlogDir, CLOSE_MARKER)), "read/list never delete the marker");
-    assert.ok(!fs.existsSync(path.join(backlogDir, ".local-tracker.lock")), "read/list never take the lock");
-  });
-
-  it("does not promote an unverified external destination or delete the active source", (t) => {
-    const { backlogDir, adapter } = makeStore(t, {
-      seedTasks: [["BACK-1 - one.md", taskFile({ id: 1, title: "One", body: "\n## Description\nauthoritative\n" })]],
-      seedCompleted: [["BACK-1 - one.md", taskFile({ id: 1, title: "External", status: "Done", body: "\n## Description\nexternal\n" })]],
-    });
-    const activeBefore = read(backlogDir, "tasks", "BACK-1 - one.md");
-    const externalBefore = read(backlogDir, "completed", "BACK-1 - one.md");
-    // Intent recorded, but the destination bytes never matched our publication.
-    writeMarker(backlogDir, { v: 1, phase: "publish", id: "1", ref: "BACK-1", file: "BACK-1 - one.md", destHash: "0".repeat(64) });
-
-    adapter.create({ title: "trigger recovery" }); // any mutation runs recover() first
-
-    assert.equal(read(backlogDir, "tasks", "BACK-1 - one.md"), activeBefore, "authoritative active source is retained");
-    assert.equal(read(backlogDir, "completed", "BACK-1 - one.md"), externalBefore, "the external destination is never promoted or altered");
-    assert.ok(!fs.existsSync(path.join(backlogDir, CLOSE_MARKER)), "the untrusted marker is discarded");
-  });
-
-  it("fails closed on a marker whose filename escapes the canonical store", (t) => {
-    const { root, backlogDir, adapter } = makeStore(t);
-    const victim = path.join(root, "victim.md");
-    fs.writeFileSync(victim, "do not delete me");
-    writeMarker(backlogDir, { v: 1, phase: "publish", id: "1", ref: "BACK-1", file: "../../victim.md", destHash: "0".repeat(64) });
-
-    adapter.create({ title: "trigger recovery" });
-
-    assert.ok(fs.existsSync(victim), "a traversal filename never reaches an unlink");
-    assert.ok(!fs.existsSync(path.join(backlogDir, CLOSE_MARKER)), "the malformed marker is cleared");
-  });
-
-  it("ignores a legacy absolute-path marker without deleting its targets", (t) => {
-    const { root, backlogDir, adapter } = makeStore(t);
-    const victim = path.join(root, "victim.md");
-    fs.writeFileSync(victim, "arbitrary file the old marker pointed at");
-    // The round-6 marker shape carried arbitrary absolute src/dest strings.
-    writeMarker(backlogDir, { src: victim, dest: victim });
-
-    adapter.create({ title: "trigger recovery" });
-
-    assert.ok(fs.existsSync(victim), "an untyped legacy marker cannot drive an arbitrary unlink");
-    assert.ok(!fs.existsSync(path.join(backlogDir, CLOSE_MARKER)), "the legacy marker is cleared");
-  });
-
-  it("refuses roll-forward when a self-consistent marker names a different authoritative body", (t) => {
-    // Active source authoritative bytes (body X). A crash-safe close of THESE
-    // bytes would publish Done(X); anything else is not this source's publication.
-    const activeBytes =
-      "---\nid: BACK-1\ntitle: One\nstatus: To Do\nlabels: []\npriority: medium\ncreated_date: '2026-07-01'\n---\n## Description\nauthoritative alpha\n";
-    // A valid, self-consistent Done publication for the SAME ref BACK-1, but
-    // derived from a DIFFERENT body (Y). The marker below names its real hash, so
-    // marker and destination agree with each other — the trap the old code fell
-    // into, deleting the active source because it trusted marker.destHash alone.
-    const unrelatedDone =
-      "---\nid: BACK-1\ntitle: One\nstatus: Done\nlabels: []\npriority: medium\ncreated_date: '2026-07-01'\n---\n## Description\nunrelated beta\n";
-    const { backlogDir, adapter } = makeStore(t, {
-      seedTasks: [["BACK-1 - one.md", activeBytes]],
-      seedCompleted: [["BACK-1 - one.md", unrelatedDone]],
-    });
-    writeMarker(backlogDir, {
-      v: 1,
-      phase: "publish",
-      id: "1",
-      ref: "BACK-1",
-      file: "BACK-1 - one.md",
-      destHash: crypto.createHash("sha256").update(unrelatedDone, "utf-8").digest("hex"),
-    });
-
-    // Recovery derives Done(activeBytes) independently, sees it differ from both
-    // the marker and the destination, and refuses to roll forward. The close then
-    // fails closed on the surviving duplicate id.
-    assert.throws(() => adapter.close("BACK-1"), LocalStoreError);
-
-    // The authoritative active source is never deleted; the completed copy and the
-    // marker are handled without touching either file's bytes.
-    assert.equal(read(backlogDir, "tasks", "BACK-1 - one.md"), activeBytes, "authoritative active source preserved");
-    assert.equal(read(backlogDir, "completed", "BACK-1 - one.md"), unrelatedDone, "completed copy never altered");
-    assert.ok(!fs.existsSync(path.join(backlogDir, CLOSE_MARKER)), "the untrusted marker is discarded");
-
-    // Every read path continues to fail closed on the duplicate until an operator resolves it.
-    assert.throws(() => adapter.read("BACK-1"), LocalStoreError);
-    assert.throws(() => adapter.list({ state: "all" }), LocalStoreError);
-  });
-});
-
-describe("local enforces canonical directory integrity at every lifecycle op", () => {
-  const LOCAL_CONFIG = { task_prefix: "BACK", default_status: "To Do" };
-
-  function names(dir) {
-    return fs.readdirSync(dir).sort();
-  }
-
-  it("refuses every op when tasks/ is a symlink and never touches the target", (t) => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "local-tracker-symtasks-"));
-    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
-    if (!symlinkSupported(root)) return;
-    const backlogDir = path.join(root, "backlog");
-    fs.mkdirSync(path.join(backlogDir, "completed"), { recursive: true });
-    const outside = path.join(root, "outside");
-    fs.mkdirSync(outside, { recursive: true });
-    const outsideTask = taskFile({ id: 1, title: "Outside" });
-    fs.writeFileSync(path.join(outside, "BACK-1 - one.md"), outsideTask);
-    fs.symlinkSync(outside, path.join(backlogDir, "tasks")); // tasks/ -> outside
-    const before = names(outside);
-    const adapter = createLocalAdapter({ backlogDir, config: LOCAL_CONFIG, now: FIXED_NOW });
-
-    assert.throws(() => adapter.list(), LocalStoreError);
-    assert.throws(() => adapter.read("BACK-1"), LocalStoreError);
-    assert.throws(() => adapter.create({ title: "Nope" }), LocalStoreError);
-    assert.throws(() => adapter.update("BACK-1", { status: "Done" }), LocalStoreError);
-    assert.throws(() => adapter.close("BACK-1"), LocalStoreError);
-
-    assert.deepEqual(names(outside), before, "no file created/read outside the store");
-    assert.equal(fs.readFileSync(path.join(outside, "BACK-1 - one.md"), "utf-8"), outsideTask, "the external task is never followed or rewritten");
-    assert.ok(!fs.existsSync(path.join(backlogDir, ".local-tracker.lock")), "no lock is taken through the symlink");
-  });
-
-  it("refuses every op when completed/ is a symlink and never touches the target", (t) => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "local-tracker-symdone-"));
-    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
-    if (!symlinkSupported(root)) return;
-    const backlogDir = path.join(root, "backlog");
-    fs.mkdirSync(path.join(backlogDir, "tasks"), { recursive: true });
-    const activeBytes = taskFile({ id: 1, title: "One" });
-    fs.writeFileSync(path.join(backlogDir, "tasks", "BACK-1 - one.md"), activeBytes);
-    const outside = path.join(root, "outside");
-    fs.mkdirSync(outside, { recursive: true });
-    fs.symlinkSync(outside, path.join(backlogDir, "completed")); // completed/ -> outside
-    const adapter = createLocalAdapter({ backlogDir, config: LOCAL_CONFIG, now: FIXED_NOW });
-
-    assert.throws(() => adapter.list(), LocalStoreError);
-    assert.throws(() => adapter.read("BACK-1"), LocalStoreError);
-    assert.throws(() => adapter.create({ title: "Nope" }), LocalStoreError);
-    assert.throws(() => adapter.update("BACK-1", { status: "Done" }), LocalStoreError);
-    assert.throws(() => adapter.close("BACK-1"), LocalStoreError);
-
-    assert.deepEqual(names(outside), [], "close never publishes into the symlinked completed target");
-    assert.equal(fs.readFileSync(path.join(backlogDir, "tasks", "BACK-1 - one.md"), "utf-8"), activeBytes, "the active source is untouched");
-    assert.ok(!fs.existsSync(path.join(backlogDir, ".local-tracker.lock")), "no lock is left behind");
-  });
-
-  it("refuses every op when the backlog root is a symlink and never touches the target", (t) => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "local-tracker-symroot-"));
-    t.after(() => fs.rmSync(root, { recursive: true, force: true }));
-    if (!symlinkSupported(root)) return;
-    const realStore = path.join(root, "real-store");
-    fs.mkdirSync(path.join(realStore, "tasks"), { recursive: true });
-    fs.mkdirSync(path.join(realStore, "completed"), { recursive: true });
-    fs.writeFileSync(path.join(realStore, "tasks", "BACK-1 - one.md"), taskFile({ id: 1, title: "One" }));
-    const backlogDir = path.join(root, "backlog");
-    fs.symlinkSync(realStore, backlogDir); // the configured root is itself a symlink
-    const adapter = createLocalAdapter({ backlogDir, config: LOCAL_CONFIG, now: FIXED_NOW });
-
-    assert.equal(adapter.availability().available, false, "a symlinked root reports unavailable");
-    assert.throws(() => adapter.list(), LocalStoreError);
-    assert.throws(() => adapter.read("BACK-1"), LocalStoreError);
-    assert.throws(() => adapter.create({ title: "Nope" }), LocalStoreError);
-    assert.throws(() => adapter.update("BACK-1", { status: "Done" }), LocalStoreError);
-    assert.throws(() => adapter.close("BACK-1"), LocalStoreError);
-
-    assert.deepEqual(names(path.join(realStore, "tasks")), ["BACK-1 - one.md"], "no task created through the symlinked root");
-    assert.deepEqual(names(path.join(realStore, "completed")), [], "close never archived through the symlinked root");
-    assert.ok(!fs.existsSync(path.join(realStore, ".local-tracker.lock")), "no lock created through the symlinked root");
-  });
-});
-
-describe("local allocation lock is never auto-reclaimed and release is identity-bound", () => {
-  function findDeadPid() {
-    for (const candidate of [999001, 999002, 999003, 4194303, 4194301]) {
-      try {
-        process.kill(candidate, 0);
-      } catch (error) {
-        if (error.code === "ESRCH") return candidate;
-      }
-    }
-    throw new Error("could not find a provably-dead pid for the test");
-  }
-
-  it("preserves a replacement lock installed between the critical section and release", (t) => {
-    if (process.platform === "win32") {
-      t.skip("Windows prevents replacing an open lock pathname; Ubuntu covers this POSIX race");
-      return;
-    }
-    const { backlogDir } = makeStore(t);
-    const lockPath = path.join(backlogDir, ".local-tracker.lock");
-    let replacementBytes = null;
-    const adapter = createLocalAdapter({
-      backlogDir,
-      now: FIXED_NOW,
-      testHooks: {
-        beforeReleaseLock(lp) {
-          // A replacement owner takes the lock after our critical section but
-          // before our release. Reuse OUR exact stamp bytes (same pid:token) yet
-          // give it a brand-new inode: token binding alone would still delete it,
-          // so only the file-identity binding protects the replacement holder.
-          replacementBytes = fs.readFileSync(lp, "utf-8");
-          fs.rmSync(lp);
-          fs.writeFileSync(lp, replacementBytes);
-        },
-      },
-    });
-
-    // The critical section itself completes, but release sees the file identity at
-    // the path no longer matches the instance we opened and fails clearly instead
-    // of unlinking a lock that is no longer ours.
-    assert.throws(
-      () => adapter.create({ title: "Raced" }),
-      (error) => error instanceof LocalStoreError && /changed owner|replacement/i.test(error.message)
-    );
-    assert.deepEqual(listNames(backlogDir, "tasks"), ["BACK-1 - raced.md"], "the critical section still ran; only release refused");
-    assert.ok(fs.existsSync(lockPath), "the replacement lock is not evicted even though its token matches");
-    assert.equal(fs.readFileSync(lockPath, "utf-8"), replacementBytes, "the replacement holder's lock is byte-for-byte untouched");
-  });
-
-  it("captures and restores a replacement installed after release validation without unlinking its inode", (t) => {
-    if (process.platform === "win32") {
-      t.skip("Windows prevents replacing an open lock pathname; Ubuntu covers this POSIX race");
-      return;
-    }
-    const { backlogDir } = makeStore(t);
-    const lockPath = path.join(backlogDir, ".local-tracker.lock");
-    const replacementBytes = `${process.pid}:post-validation-replacement`;
-    let replacementIdentity;
-    const adapter = createLocalAdapter({
-      backlogDir,
-      now: FIXED_NOW,
-      testHooks: {
-        afterReleaseLockValidation(lp) {
-          // This is the old check->unlink window: preliminary fd/token/inode
-          // validation has passed, then a new owner replaces the pathname just
-          // before release would have unlinked it.
-          fs.unlinkSync(lp);
-          fs.writeFileSync(lp, replacementBytes);
-          replacementIdentity = fs.statSync(lp);
-        },
-      },
-    });
-
-    assert.throws(
-      () => adapter.create({ title: "Post validation race" }),
-      (error) =>
-        error instanceof LocalStoreError &&
-        /changed owner during release|foreign lock was preserved|reconcile/i.test(error.message)
-    );
-    assert.deepEqual(
-      listNames(backlogDir, "tasks"),
-      ["BACK-1 - post-validation-race.md"],
-      "the critical section commits before the fail-closed release"
-    );
-
-    const captures = fs
-      .readdirSync(backlogDir)
-      .filter((name) => name.startsWith(".local-tracker.lock.release."));
-    assert.equal(captures.length, 1, "the foreign capture remains available for reconciliation");
-    const capturePath = path.join(backlogDir, captures[0]);
-    const restoredIdentity = fs.statSync(lockPath);
-    const capturedIdentity = fs.statSync(capturePath);
-    assert.equal(fs.readFileSync(lockPath, "utf-8"), replacementBytes, "canonical replacement bytes survive");
-    assert.equal(fs.readFileSync(capturePath, "utf-8"), replacementBytes, "captured replacement bytes survive");
-    assert.equal(restoredIdentity.dev, replacementIdentity.dev);
-    assert.equal(restoredIdentity.ino, replacementIdentity.ino, "canonical path retains the replacement inode");
-    assert.equal(capturedIdentity.dev, replacementIdentity.dev);
-    assert.equal(capturedIdentity.ino, replacementIdentity.ino, "capture retains the same replacement inode");
-  });
-
-  it("preserves both a foreign capture and a newer canonical owner during no-overwrite restoration", (t) => {
-    if (process.platform === "win32") {
-      t.skip("Windows prevents replacing an open lock pathname; Ubuntu covers this POSIX race");
-      return;
-    }
-    const { backlogDir } = makeStore(t);
-    const lockPath = path.join(backlogDir, ".local-tracker.lock");
-    const capturedBytes = `${process.pid}:captured-foreign-owner`;
-    const newerBytes = `${process.pid}:newer-canonical-owner`;
-    let capturedIdentity;
-    let newerIdentity;
-    const adapter = createLocalAdapter({
-      backlogDir,
-      now: FIXED_NOW,
-      testHooks: {
-        afterReleaseLockValidation(lp) {
-          fs.unlinkSync(lp);
-          fs.writeFileSync(lp, capturedBytes);
-          capturedIdentity = fs.statSync(lp);
-        },
-        beforeForeignLockRestore(_capturePath, canonicalPath) {
-          // The atomic capture made canonical free, and a still-newer allocator
-          // acquired it before restoration. Restoration must not overwrite it.
-          fs.writeFileSync(canonicalPath, newerBytes, { flag: "wx" });
-          newerIdentity = fs.statSync(canonicalPath);
-        },
-      },
-    });
-
-    assert.throws(
-      () => adapter.create({ title: "Two owners" }),
-      (error) => error instanceof LocalStoreError && /newer owner|both locks were preserved/i.test(error.message)
-    );
-    const captures = fs
-      .readdirSync(backlogDir)
-      .filter((name) => name.startsWith(".local-tracker.lock.release."));
-    assert.equal(captures.length, 1);
-    const capturePath = path.join(backlogDir, captures[0]);
-    assert.equal(fs.readFileSync(lockPath, "utf-8"), newerBytes);
-    assert.equal(fs.statSync(lockPath).ino, newerIdentity.ino, "no-overwrite keeps the newer canonical inode");
-    assert.equal(fs.readFileSync(capturePath, "utf-8"), capturedBytes);
-    assert.equal(fs.statSync(capturePath).ino, capturedIdentity.ino, "the captured foreign inode is retained separately");
-  });
-
-  it("never reclaims a dead-PID lock: two contenders both fail closed and the lock is untouched", (t) => {
-    const { backlogDir } = makeStore(t);
-    const lockPath = path.join(backlogDir, ".local-tracker.lock");
-    const staleBytes = `${findDeadPid()}:stale-token`;
-    fs.writeFileSync(lockPath, staleBytes);
-
-    const contenders = [0, 1].map(() =>
-      createLocalAdapter({ backlogDir, now: FIXED_NOW, lock: { retries: 1, delayMs: 1 } })
-    );
-    for (const contender of contenders) {
-      assert.throws(
-        () => contender.create({ title: "Blocked by stale" }),
-        (error) => error instanceof LocalStoreError && /stale lock|no longer running|manually/i.test(error.message)
-      );
-    }
-
-    // Neither contender reclaimed or deleted the stale lock, and neither entered
-    // the critical section — so no concurrent critical sections could occur.
-    assert.equal(fs.readFileSync(lockPath, "utf-8"), staleBytes, "the stale lock is never reclaimed or deleted");
-    assert.deepEqual(listNames(backlogDir, "tasks"), [], "no contender entered the critical section");
-  });
-});
-
-function snapshotTree(root) {
-  const out = {};
-  const walk = (rel) => {
-    const abs = rel === "" ? root : path.join(root, rel);
-    const st = fs.lstatSync(abs, { bigint: true });
-    const type = st.isDirectory()
-      ? "dir"
-      : st.isSymbolicLink()
-        ? "symlink"
-        : st.isFile()
-          ? "file"
-          : "other";
-    const rec = { type, size: st.size, mtimeNs: st.mtimeNs, ino: st.ino };
-    if (type === "file") rec.content = fs.readFileSync(abs).toString("hex");
-    if (type === "symlink") rec.target = fs.readlinkSync(abs);
-    out[rel === "" ? "." : rel] = rec;
-    if (type === "dir") {
-      for (const name of fs.readdirSync(abs).sort()) {
-        walk(rel === "" ? name : path.join(rel, name));
-      }
-    }
-  };
-  walk("");
-  return out;
-}
-
-describe("local read paths never mutate the store (deep recursive before/after snapshot)", () => {
-  function seedRecoveryStore(t) {
-    const store = makeStore(t, {
-      seedTasks: [
-        ["BACK-1 - one.md", taskFile({ id: 1, title: "One" })],
-        // Malformed: a valid filename whose content fails validation (missing status).
-        ["BACK-2 - bad.md", "---\nid: BACK-2\ntitle: Two\n---\n## Description\nno status\n"],
-        // A stray temp left by a prior crash — reads must not sweep it.
-        [".local-tracker.99.2.deadbeef.tmp", "partial temp bytes"],
-      ],
-      seedCompleted: [["BACK-3 - three.md", taskFile({ id: 3, title: "Three", status: "Done" })]],
-    });
-    // Stale recovery metadata: a durable but stale close marker.
+  it("reads and writes only the JSON authority and overwrites hand-edited mirrors", (t) => {
+    const { adapter, backlogDir } = makeStore(t);
+    adapter.create({ title: "Canonical", body: "Original body" });
+    const mirror = path.join(backlogDir, "tasks", "BACK-1 - canonical.md");
     fs.writeFileSync(
-      path.join(store.backlogDir, CLOSE_MARKER),
-      JSON.stringify({ v: 1, phase: "publish", id: "1", ref: "BACK-1", file: "BACK-1 - one.md", destHash: "0".repeat(64) })
+      mirror,
+      "---\nid: BACK-1\ntitle: Hand edited\nstatus: Done\n---\nforged mirror body\n"
     );
-    return store;
-  }
 
-  it("list() over valid + malformed + stale-marker state mutates nothing and takes no lock", (t) => {
-    const { backlogDir, adapter } = seedRecoveryStore(t);
-    const before = snapshotTree(backlogDir);
-    // A malformed task makes list fail closed — but it must still not mutate.
-    assert.throws(() => adapter.list({ state: "all" }), LocalStoreError);
-    const after = snapshotTree(backlogDir);
-    assert.deepEqual(after, before, "list() preserves every name, type, content, size, mtime, and inode");
-    assert.ok(!Object.prototype.hasOwnProperty.call(after, ".local-tracker.lock"), "list() never creates a lock");
-    assert.ok(Object.prototype.hasOwnProperty.call(after, CLOSE_MARKER), "list() never touches the recovery marker");
+    assert.equal(adapter.read("BACK-1").title, "Canonical");
+    assert.equal(adapter.read("BACK-1").status, "To Do");
+    assert.match(adapter.read("BACK-1").body, /Original body/);
+
+    adapter.update("BACK-1", { priority: "high" });
+    const refreshed = fs.readFileSync(mirror, "utf8");
+    assert.match(refreshed, /^title: Canonical$/m);
+    assert.match(refreshed, /^status: To Do$/m);
+    assert.match(refreshed, /Original body/);
+    assert.doesNotMatch(refreshed, /Hand edited|forged mirror body/);
   });
 
-  it("read() of valid, closed, and malformed tasks mutates nothing and takes no lock", (t) => {
-    const { backlogDir, adapter } = seedRecoveryStore(t);
-    const before = snapshotTree(backlogDir);
-    assert.equal(adapter.read("BACK-1").id, "1"); // valid open task
-    assert.equal(adapter.read("BACK-3").state, "closed"); // valid closed task
-    assert.throws(() => adapter.read("BACK-2"), LocalStoreError); // malformed content
-    const after = snapshotTree(backlogDir);
-    assert.deepEqual(after, before, "read() preserves every name, type, content, size, mtime, and inode");
-    assert.ok(!Object.prototype.hasOwnProperty.call(after, ".local-tracker.lock"), "read() never creates a lock");
-    assert.ok(Object.prototype.hasOwnProperty.call(after, CLOSE_MARKER), "read() never mutates recovery artifacts");
+  it("emits the exact GitHub mirror filename and byte shape", (t) => {
+    const { root, adapter, backlogDir } = makeStore(t);
+    const githubDir = path.join(root, "github-mirrors");
+    fs.mkdirSync(githubDir);
+    const today = new Date().toISOString().slice(0, 10);
+    const local = createLocalAdapter({
+      backlogDir,
+      now: () => new Date(`${today}T12:00:00Z`),
+    });
+    local.create({
+      id: "7",
+      title: "Same mirror",
+      body: "Human body\n\n## Acceptance Criteria\n- [ ] Same bytes",
+      labels: ["feature"],
+      priority: "high",
+    });
+    renderGithubMirrors({
+      issues: [{
+        number: 7,
+        title: "Same mirror",
+        body: "Human body\n\n## Acceptance Criteria\n- [ ] Same bytes",
+        labels: [{ name: "feature" }, { name: "priority:high" }],
+        milestone: null,
+      }],
+      tasksDir: githubDir,
+      prefix: "BACK",
+      update: false,
+      dryRun: false,
+    });
+    const name = "BACK-7 - same-mirror.md";
+    assert.equal(
+      fs.readFileSync(path.join(backlogDir, "tasks", name), "utf8"),
+      fs.readFileSync(path.join(githubDir, name), "utf8")
+    );
+    assert.deepEqual(adapter.list().map((task) => task.ref), ["BACK-7"]);
+  });
+
+  it("allocates exact ids across open and completed records without prefix collisions", (t) => {
+    const { adapter } = makeStore(t);
+    assert.equal(adapter.create({ id: "1", title: "One" }).id, "1");
+    assert.equal(adapter.create({ id: "11", title: "Eleven" }).id, "11");
+    adapter.close("BACK-11");
+    assert.equal(adapter.create({ title: "Next" }).id, "12");
+    assert.throws(
+      () => adapter.create({ id: "11", title: "Completed collision" }),
+      /BACK-11 already exists/
+    );
+  });
+
+  it("supports decimal ids and allocates above parents beyond Number.MAX_SAFE_INTEGER", (t) => {
+    const { adapter, backlogDir } = makeStore(t);
+    seedStore(backlogDir, [
+      record("1.2"),
+      record("9007199254740993", { state: "closed", status: "Done" }),
+    ]);
+    assert.deepEqual(adapter.read("BACK-1.2").dependencies, []);
+    assert.equal(adapter.create({ title: "Large next" }).id, "9007199254740994");
+    assert.throws(() => adapter.create({ id: "1.2", title: "Duplicate" }), /already exists/);
+  });
+
+  it("lists open, closed, and all tasks in numeric parent/subtask order", (t) => {
+    const { adapter, backlogDir } = makeStore(t);
+    seedStore(backlogDir, [
+      record("11"),
+      record("2.3", { state: "closed", status: "Done" }),
+      record("2"),
+      record("2.1"),
+    ]);
+    assert.deepEqual(adapter.list().map((task) => task.id), ["2", "2.1", "11"]);
+    assert.deepEqual(adapter.list({ state: "closed" }).map((task) => task.id), ["2.3"]);
+    assert.deepEqual(adapter.list({ state: "all" }).map((task) => task.id), [
+      "2",
+      "2.1",
+      "2.3",
+      "11",
+    ]);
+    assert.throws(() => adapter.list({ state: "maybe" }), /expected one of open, closed, all/);
+  });
+
+  it("resolves identity, ref, and bare-id selectors without accepting a foreign prefix", (t) => {
+    const { adapter } = makeStore(t);
+    const identity = adapter.create({ id: "4.2", title: "Selectors" });
+    assert.equal(adapter.read(identity).id, "4.2");
+    assert.equal(adapter.read("BACK-4.2").id, "4.2");
+    assert.equal(adapter.read("4.2").id, "4.2");
+    assert.throws(() => adapter.read("OTHER-4.2"), /unresolved local task selector/);
+    assert.throws(
+      () => adapter.read({ tracker: "github", id: "4.2", ref: "#4" }),
+      /requires a local task identity/
+    );
+  });
+
+  it("updates only requested canonical fields, preserves body, and renames the mirror from title", (t) => {
+    const { adapter, backlogDir } = makeStore(t);
+    adapter.create({
+      title: "Before",
+      body: "Body\n\n## Acceptance Criteria\n- [ ] Preserve",
+      labels: ["one"],
+      dependencies: ["BACK-9"],
+    });
+    const body = adapter.read("BACK-1").body;
+    adapter.update("BACK-1", {
+      title: "After",
+      status: "In Progress",
+      labels: ["two"],
+      updated_date: "2026-07-27",
+    });
+    const updated = adapter.read("BACK-1");
+    assert.equal(updated.body, body);
+    assert.deepEqual(updated.dependencies, ["BACK-9"]);
+    assert.equal(updated.updated_date, "2026-07-27");
+    assert.deepEqual(mirrorNames(backlogDir, "tasks"), ["BACK-1 - after.md"]);
+    assert.match(
+      fs.readFileSync(path.join(backlogDir, "tasks", "BACK-1 - after.md"), "utf8"),
+      /^status: In Progress$/m
+    );
+  });
+
+  it("replaces a body only when supplied and keeps it canonical across mirror refreshes", (t) => {
+    const { adapter } = makeStore(t);
+    adapter.create({ title: "Body", body: "First" });
+    const first = adapter.read("1").body;
+    adapter.update("1", { priority: "low" });
+    assert.equal(adapter.read("1").body, first);
+    adapter.update("1", { body: "Second\n- [ ] AC" });
+    assert.equal(adapter.read("1").body, "\n## Description\nSecond\n- [ ] AC\n");
+  });
+
+  it("closes in one canonical store commit and projects exactly one completed mirror", (t) => {
+    const { adapter, backlogDir } = makeStore(t);
+    const identity = adapter.create({ title: "Archive", body: "Keep me" });
+    assert.deepEqual(adapter.close(identity), identity);
+    assert.deepEqual(adapter.close(identity), identity, "close is idempotent");
+    assert.deepEqual(adapter.list(), []);
+    assert.deepEqual(adapter.list({ state: "closed" }).map((task) => task.ref), ["BACK-1"]);
+    assert.equal(adapter.read(identity).status, "Done");
+    assert.deepEqual(mirrorNames(backlogDir, "tasks"), []);
+    assert.deepEqual(mirrorNames(backlogDir, "completed"), ["BACK-1 - archive.md"]);
+    assert.match(
+      fs.readFileSync(path.join(backlogDir, "completed", "BACK-1 - archive.md"), "utf8"),
+      /Keep me/
+    );
+    assert.equal(readStore(backlogDir).tasks.filter((task) => task.id === "1").length, 1);
+  });
+
+  it("rejects unsupported provider fields before any mutation", (t) => {
+    const { adapter, backlogDir } = makeStore(t);
+    for (const invoke of [
+      () => adapter.create({ title: "No", milestone: "v1" }),
+      () => adapter.update("BACK-1", { assignees: ["me"] }),
+      () => adapter.close("BACK-1", { reason: "merged" }),
+    ]) {
+      assert.throws(invoke, /reports no optional capabilities/);
+    }
+    assert.equal(fs.existsSync(storePath(backlogDir)), false);
+  });
+});
+
+describe("fail-closed JSON and filesystem validation", () => {
+  it("rejects control-character injection before create or update writes", (t) => {
+    const { adapter, backlogDir } = makeStore(t);
+    const injections = [
+      "title\nstatus: Done",
+      "status\rpriority: high",
+      `label${String.fromCharCode(0)}value`,
+      "priority\tcritical",
+    ];
+    assert.throws(() => adapter.create({ title: injections[0] }), /control characters/);
+    assert.throws(() => adapter.create({ title: "Safe", status: injections[1] }), /control characters/);
+    assert.throws(() => adapter.create({ title: "Safe", labels: [injections[2]] }), /control characters/);
+    assert.throws(() => adapter.create({ title: "Safe", priority: injections[3] }), /control characters/);
+    assert.equal(fs.existsSync(storePath(backlogDir)), false);
+
+    adapter.create({ title: "Safe" });
+    const before = fs.readFileSync(storePath(backlogDir), "utf8");
+    assert.throws(
+      () => adapter.update("BACK-1", { status: "In Progress\nowner: attacker" }),
+      /control characters/
+    );
+    assert.equal(fs.readFileSync(storePath(backlogDir), "utf8"), before);
+  });
+
+  it("fails availability and every read on malformed or duplicate JSON records", (t) => {
+    const { backlogDir } = makeStore(t);
+    for (const raw of [
+      "{\"version\":1,\"tasks\":[",
+      JSON.stringify({ version: 2, tasks: [] }),
+      JSON.stringify({ version: 1, tasks: [record("1"), record("1")] }),
+      JSON.stringify({ version: 1, tasks: [{ ...record("1"), state: "lost" }] }),
+      JSON.stringify({ version: 1, tasks: [{ ...record("1"), title: "" }] }),
+    ]) {
+      fs.writeFileSync(storePath(backlogDir), raw);
+      const adapter = createLocalAdapter({ backlogDir, now: FIXED_NOW });
+      assert.equal(adapter.availability().available, false);
+      assert.throws(() => adapter.list(), LocalStoreError);
+    }
+  });
+
+  it("ignores stale and forged Markdown when the JSON store is absent", (t) => {
+    const { adapter, backlogDir } = makeStore(t);
+    fs.mkdirSync(path.join(backlogDir, "tasks"));
+    fs.mkdirSync(path.join(backlogDir, "completed"));
+    fs.writeFileSync(
+      path.join(backlogDir, "tasks", "BACK-99 - forged.md"),
+      "---\nid: BACK-99\ntitle: Forged\nstatus: Done\n---\n"
+    );
+    fs.writeFileSync(
+      path.join(backlogDir, "completed", "BACK-100 - forged.md"),
+      "---\nid: BACK-100\ntitle: Forged\nstatus: Done\n---\n"
+    );
+    assert.deepEqual(adapter.list({ state: "all" }), []);
+    assert.throws(() => adapter.read("BACK-99"), /not found/);
+    assert.equal(adapter.create({ title: "Canonical first" }).id, "1");
+    assert.deepEqual(mirrorNames(backlogDir, "tasks"), ["BACK-1 - canonical-first.md"]);
+    assert.deepEqual(mirrorNames(backlogDir, "completed"), []);
+  });
+
+  it("refuses symlinked canonical paths without following them", (t) => {
+    const { root, backlogDir } = makeStore(t);
+    if (!symlinkSupported(root)) return;
+    const external = path.join(root, "external");
+    fs.mkdirSync(external);
+    const tasksDir = path.join(backlogDir, "tasks");
+    fs.symlinkSync(external, tasksDir);
+    const adapter = createLocalAdapter({ backlogDir, now: FIXED_NOW });
+    assert.equal(adapter.availability().available, false);
+    assert.throws(() => adapter.create({ title: "Escape" }), /must not be a symlink/);
+    assert.deepEqual(fs.readdirSync(external), []);
+  });
+
+  it("refuses a symlinked or non-regular JSON authority", (t) => {
+    const { root, backlogDir } = makeStore(t);
+    if (!symlinkSupported(root)) return;
+    const external = path.join(root, "outside.json");
+    fs.writeFileSync(external, JSON.stringify({ version: 1, tasks: [] }));
+    fs.symlinkSync(external, storePath(backlogDir));
+    let adapter = createLocalAdapter({ backlogDir, now: FIXED_NOW });
+    assert.equal(adapter.availability().available, false);
+    assert.throws(() => adapter.list(), /must not be a symlink/);
+    fs.unlinkSync(storePath(backlogDir));
+    fs.mkdirSync(storePath(backlogDir));
+    adapter = createLocalAdapter({ backlogDir, now: FIXED_NOW });
+    assert.equal(adapter.availability().available, false);
+    assert.throws(() => adapter.list(), /not a regular file/);
+  });
+
+  it("rejects unsafe prefixes before any path mutation", (t) => {
+    for (const taskPrefix of ["../ESCAPE", "BAD/PREFIX", "BAD PREFIX", ""]) {
+      const { backlogDir } = makeStore(t);
+      const adapter = createLocalAdapter({
+        backlogDir,
+        now: FIXED_NOW,
+        config: { task_prefix: taskPrefix, default_status: "To Do" },
+      });
+      assert.equal(adapter.availability().available, false);
+      assert.throws(() => adapter.create({ title: "No escape" }), /task_prefix/);
+      assert.equal(fs.existsSync(storePath(backlogDir)), false);
+    }
+  });
+});
+
+describe("atomic replacement and all-platform concurrency coverage", () => {
+  it("removes a partial temp and preserves the complete old store when writing fails", (t) => {
+    const { backlogDir } = makeStore(t);
+    seedStore(backlogDir, [record("1")]);
+    const before = fs.readFileSync(storePath(backlogDir), "utf8");
+    const adapter = createLocalAdapter({
+      backlogDir,
+      now: FIXED_NOW,
+      testHooks: {
+        writeStoreTemp(tmp) {
+          fs.writeFileSync(tmp, "{\"version\":1,\"tasks\":[");
+          const error = new Error("disk full");
+          error.code = "ENOSPC";
+          throw error;
+        },
+      },
+    });
+    assert.throws(() => adapter.create({ title: "Never committed" }), /disk full/);
+    assert.equal(fs.readFileSync(storePath(backlogDir), "utf8"), before);
+    assert.deepEqual(tempNames(backlogDir), []);
+  });
+
+  it("a crash after close rename leaves one readable closed record and heals mirrors on retry", (t) => {
+    const { backlogDir } = makeStore(t);
+    const normal = createLocalAdapter({ backlogDir, now: FIXED_NOW });
+    normal.create({ title: "Crash close", body: "Durable" });
+    const crashing = createLocalAdapter({
+      backlogDir,
+      now: FIXED_NOW,
+      testHooks: {
+        afterStoreRename() {
+          throw new Error("simulated process death after atomic rename");
+        },
+      },
+    });
+    assert.throws(() => crashing.close("BACK-1"), /simulated process death/);
+    const stored = readStore(backlogDir);
+    assert.equal(stored.tasks.length, 1);
+    assert.equal(stored.tasks[0].state, "closed");
+    assert.equal(stored.tasks[0].status, "Done");
+    assert.equal(normal.read("BACK-1").state, "closed");
+
+    normal.close("BACK-1");
+    assert.deepEqual(mirrorNames(backlogDir, "tasks"), []);
+    assert.deepEqual(mirrorNames(backlogDir, "completed"), ["BACK-1 - crash-close.md"]);
+    assert.equal(fs.existsSync(path.join(backlogDir, ".local-tracker.lock")), false);
+    assert.equal(fs.existsSync(path.join(backlogDir, ".local-tracker.close")), false);
+  });
+
+  it("concurrent writers and readers never expose torn JSON or leaked temp files", async (t) => {
+    const { root, backlogDir } = makeStore(t);
+    createLocalAdapter({ backlogDir, now: FIXED_NOW }).create({ title: "Shared" });
+    const worker = path.join(root, "writer.js");
+    fs.writeFileSync(
+      worker,
+      [
+        `const { createLocalAdapter } = require(${JSON.stringify(LOCAL_TRACKER_PATH)});`,
+        "const [backlogDir, label] = process.argv.slice(2);",
+        "const adapter = createLocalAdapter({ backlogDir });",
+        "for (let i = 0; i < 80; i += 1) {",
+        "  adapter.update('BACK-1', { priority: i % 2 ? 'high' : 'low', labels: [label] });",
+        "}",
+      ].join("\n")
+    );
+    const children = ["alpha", "beta", "gamma"].map((label) =>
+      spawn(process.execPath, [worker, backlogDir, label], {
+        stdio: ["ignore", "ignore", "pipe"],
+      })
+    );
+    let reads = 0;
+    const errors = [];
+    await new Promise((resolve, reject) => {
+      const timer = setInterval(() => {
+        try {
+          const store = readStore(backlogDir);
+          assert.equal(store.version, 1);
+          assert.equal(store.tasks.length, 1);
+          assert.equal(store.tasks[0].id, "1");
+          reads += 1;
+        } catch (error) {
+          errors.push(error);
+        }
+      }, 1);
+      let remaining = children.length;
+      for (const child of children) {
+        let stderr = "";
+        child.stderr.on("data", (chunk) => {
+          stderr += chunk;
+        });
+        child.on("error", reject);
+        child.on("close", (code) => {
+          if (code !== 0) errors.push(new Error(`writer exited ${code}: ${stderr}`));
+          remaining -= 1;
+          if (remaining === 0) {
+            clearInterval(timer);
+            resolve();
+          }
+        });
+      }
+    });
+    assert.equal(errors.length, 0, errors.map((error) => error.message).join("\n"));
+    assert.ok(reads > 0, "the canonical file was parsed while writers raced");
+    const final = readStore(backlogDir);
+    assert.equal(final.tasks.length, 1);
+    assert.ok(["alpha", "beta", "gamma"].includes(final.tasks[0].labels[0]));
+    assert.deepEqual(tempNames(backlogDir), []);
   });
 });

--- a/spec/capabilities.md
+++ b/spec/capabilities.md
@@ -48,6 +48,7 @@ The former `spec-charter`, `spec-system-map`, and `spec-grill` capability blocks
 | date | decision | rationale | supersedes |
 | --- | --- | --- | --- |
 | 2026-07-11 | Admit `tracker-task-truth` as a separate capability from `backlog-sync` | canonical ownership and task lifecycle are required in every mode; mirroring and publication are optional transport behaviors | — |
+| 2026-07-26 | Make `backlog/local-tracker.json` the sole local task authority and derive both Markdown directories from it | one atomic JSON store removes Markdown/YAML round-trip and close-compensation machinery while satisfying the no-co-authority constraint directly | canonical local Markdown shape from PR #298 |
 
 ---
 

--- a/spec/system-map.md
+++ b/spec/system-map.md
@@ -15,8 +15,8 @@ tracker.js (configured-only resolve, availability, capability gate)
         +-- github-tracker.js -> gh -> GitHub Issues (canonical)
         |                         `-> backlog/tasks/ derived mirrors
         |
-        `-- local-tracker.js  -> backlog/tasks/ active canonical tasks
-                                  backlog/completed/ closed canonical tasks
+        `-- local-tracker.js  -> backlog/local-tracker.json (canonical)
+                                  `-> backlog/tasks/ + completed/ derived mirrors
 
 backlog/sprints/ (canonical execution hub)
         +-> sprint-state.js -> status.sh --json / next.sh --json
@@ -33,7 +33,7 @@ probes or falls back to the other adapter.
 
 - `skills/dev-backlog/scripts/tracker.js` owns configured resolution, the exact seven-operation adapter contract, identity validation, capability discovery/gating, and the shared unsupported-capability error/serializer.
 - `github-tracker.js` owns required GitHub task lifecycle argv/translation. Named GitHub modules own milestones, sprint mirrors, Progress/PR/comments, and other optional transports.
-- `local-tracker.js` owns the canonical local filesystem lifecycle and reports no optional provider capabilities. It never invokes `gh`.
+- `local-tracker.js` owns the canonical local JSON lifecycle and its one-way Markdown projection. It reports no optional provider capabilities and never invokes `gh`.
 - `task-ref.js` owns complete `#N` and `{PREFIX}-N[.M]` parsing/rendering. GitHub keeps numeric `issue_number`; local exposes `null` for that compatibility alias.
 - `sprint-state.js` remains the single machine parser of sprint Markdown; `status.sh --json`, `next.sh --json`, mirror rendering, and doctor projections consume its state.
 - `skills/backlog-triage/` owns advisory grooming. Provider enrichment/mutation remains capability-gated and explicit.
@@ -46,7 +46,7 @@ are single-sourced in [`docs/tracker-adapter-design.md`](../docs/tracker-adapter
 
 1. **Setup:** create minimum directories and persist exactly one tracker; never migrate task files.
 2. **Create/read/update/close:** call the configured adapter's required lifecycle and carry normalized `{ tracker, id, ref, url? }` identity.
-3. **Materialize:** GitHub mode explicitly mirrors canonical issues through `sync-pull.js`; local mode already stores canonical Markdown and has no provider sync.
+3. **Materialize:** GitHub mode explicitly mirrors canonical issues through `sync-pull.js`; local mutations project the canonical JSON store into the same Markdown shape without provider sync.
 4. **Plan/orient:** write normalized refs into the active track's sprint file; consume state via `status.sh --json` / `next.sh --json` (`--track` selects among multiple disjoint-scope tracks).
 5. **Complete:** close the canonical task, check the Plan, run `sprint-close.sh` (`--track` when multiple tracks are active), archive remaining checked task files, and retain sprint history.
 6. **Publish/enrich:** milestones, PR relationships, sprint mirrors, Progress issues, comments, and closing semantics run only when reported. Unsupported requests return the shared typed error before effects.
@@ -56,7 +56,8 @@ are single-sourced in [`docs/tracker-adapter-design.md`](../docs/tracker-adapter
 
 - `backlog/config.yml`: the only tracker-selection authority plus Backlog.md settings.
 - GitHub Issues: canonical task truth only for `tracker: github`.
-- `backlog/tasks/` and `backlog/completed/`: derived GitHub mirrors or canonical local tasks according to the configured mode.
+- `backlog/local-tracker.json`: canonical task truth only for `tracker: local`.
+- `backlog/tasks/` and `backlog/completed/`: derived task mirrors in both tracker modes.
 - `backlog/sprints/`: canonical execution state in both modes, committed at explicit boundaries.
 - `gh`: GitHub-mode bridge only; acceptance tests replace it with an argv recorder and local tests trap it.
 - Git: versioned Markdown, scripts, and durable specs.
@@ -69,7 +70,7 @@ are single-sourced in [`docs/tracker-adapter-design.md`](../docs/tracker-adapter
 - Unsupported optional capabilities have stable code `TRACKER_CAPABILITY_UNSUPPORTED`, tracker, capability, message, and remediation; JSON and human boundaries share that one serializer contract.
 - Sprint files remain the execution hub and completed sprint files are immutable history.
 - Automation is report-only toward `spec/*`; `spec/charter.md` is canonical and root `CHARTER.md` is legacy fallback only.
-- Helpers run on POSIX and Git-for-Windows Bash; native filesystem paths stay internal while stable serialized fields normalize to `/`; POSIX-only open-lock-replacement race tests are documented Windows skips.
+- Helpers run on POSIX and Git-for-Windows Bash; native filesystem paths stay internal while stable serialized fields normalize to `/`; atomic-store replacement coverage runs without platform skips.
 
 ## Executable Evidence
 


### PR DESCRIPTION
Closes #321. Milestone 16 (v0.9.0), Batch 2.

`local` stops being a second tracker and becomes one storage substrate whose "provider" is a local JSON file — so it looks like every other adapter from the seam's point of view.

| | before | after |
|---|---|---|
| `local-tracker.js` | 1,391 | **597** |
| `local-tracker.test.js` | 1,357 | 511 |
| Windows lock skips | 3 | **0** |

Deleted: the frontmatter YAML parse/serialize path with verbatim-byte and CRLF preservation, the `.local-tracker.lock` allocation lock, pid/token stamps, liveness probing, close compensation, rollback, and split-store detection.

## The contract was amended mid-flight

The original AC said concurrent-write safety comes from write-temp + atomic rename. **That was wrong, and the error was in the design, not the implementation.** The deleted lock was doing two jobs: atomic rename replaces torn-write prevention, but it does **not** replace serialization of the read-modify-write critical section, including ID allocation.

- **Round 1** shipped rename-only. Review found the consequence: two concurrent creates read the same snapshot, allocate the same ID, and the later rename silently destroys the earlier task. Two updates to unrelated tasks lose each other the same way.
- **Round 2** restored a minimal create-exclusive lock. That fixed lost updates but reintroduced the failure the original 1,391-line version carried stamps and liveness probing to survive: a writer killed inside the critical section orphans the lock and wedges every later mutation.
- **Round 3** (this PR) uses revision-based compare-and-swap. Issue #321's AC was amended by the owner on 2026-07-26 to require it and to forbid any lock file.

## How the commit works

```
read at revision N  →  compute N+1  →  write complete fsynced temp
  →  linkSync(tmp, .local-tracker.revision-{N+1}.json)   ← no-overwrite claim
  →  EEXIST: help the existing claim across, then re-read and retry (bounded)
  →  rename claim into place  →  fsync parent directory  →  clean debris
```

`finishClaim` is a **helping protocol**: a writer that loses the claim completes the existing one, because the claim is content-complete. A crashed claimant's work is carried across by the next writer. Debris is inert by construction — nothing a later writer must interpret before proceeding.

Retry is bounded and exhaustion **fails closed**, stating explicitly that no unconditional write was made.

## Verification

| check | result |
|---|---|
| `node --test skills/*/scripts/*.test.js` | 626 tests / 625 pass / 0 fail / 1 skip |
| dual-mode acceptance | 11 / 11 — github row argv, bytes, aliases unchanged |
| Bash smoke | 187 / 187 |
| `backlog-doctor` | pass |
| lock symbol grep | 0 |
| Windows skip grep | 0 (no `t.skip` in either local-tracker test file) |
| out-of-scope files | `github-tracker.js`, `tracker.js`, `setup-dev-backlog.js` byte-identical to main |

Key new coverage:
- **crash inside the commit window** — spawns a real child that exits from the `afterRevisionClaim` hook, then asserts the next mutation succeeds *and* carries the dead writer's close across, ending with zero strays
- parallel creates survive with distinct IDs; parallel updates to different tasks both persist — both fail against a naive read-modify-write
- bounded CAS retry exhaustion fails closed
- parent-directory fsync after store, mirror, and archive renames
- mirrors are overwritten, and forged/stale markdown is ignored when the JSON store is absent

## Review note

Two independent codex reviews ran and both returned `changes_requested` — they produced the two findings above and were correct each time. The third round hit relay's round cap (`standard` = 2) because the cap counts rounds against a contract that had itself been amended. Rather than spend another executor round only to raise the cap, the orchestrator verified every amended criterion directly against the worktree; results are in the table above. One stale round-2 sentence in the design doc was found during that pass and fixed directly (98fe251).

## Scope note

`README.md`, `SKILL.md`, and `references/*` were updated here although they are #323's criteria — `SKILL.md` asserted `local -> backlog/tasks/ + completed/ are canonical`, which this PR makes false on merge. Shipping the code without the prose would create exactly the drift the v0.8.0 reassessment caught. **#323 is re-scoped** to the capability `Decisions` row plus a residual-claim sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UekMHpbBRahCdnP9Jhd6ap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 로컬 모드에서 작업을 단일 JSON 저장소로 관리하고, 작업 및 완료 Markdown 파일을 자동으로 미러링합니다.
  * 작업 생성·수정·완료 시 미러 파일이 원자적으로 갱신되어 데이터 일관성이 향상되었습니다.
  * 동시 작업 및 충돌 상황에서 안전한 변경 처리가 지원됩니다.

* **버그 수정**
  * 작업 진실과 파생 파일 간 권한 기준을 명확히 하여 오래되거나 수동 변경된 미러의 혼선을 방지했습니다.
  * 미러 파일이 없어도 원본 저장소를 기반으로 정상적으로 복구할 수 있습니다.

* **문서**
  * 로컬 및 GitHub 모드의 작업 저장·동기화 규칙과 플랫폼별 동시성 동작을 명확히 설명했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->