### PR TITLE
docs: record the tracker-selection move as a capability decision (#323)

### DIFF
--- a/spec/capabilities.md
+++ b/spec/capabilities.md
@@ -49,6 +49,7 @@ The former `spec-charter`, `spec-system-map`, and `spec-grill` capability blocks
 | --- | --- | --- | --- |
 | 2026-07-11 | Admit `tracker-task-truth` as a separate capability from `backlog-sync` | canonical ownership and task lifecycle are required in every mode; mirroring and publication are optional transport behaviors | — |
 | 2026-07-26 | Make `backlog/local-tracker.json` the sole local task authority and derive both Markdown directories from it | one atomic JSON store removes Markdown/YAML round-trip and close-compensation machinery while satisfying the no-co-authority constraint directly | canonical local Markdown shape from PR #298 |
+| 2026-07-27 | Move tracker selection to `backlog/.tracker`; `config.yml` becomes a read-only legacy fallback that is never written | the selection tokenizer existed only to write one key into user-owned YAML safely, so not writing removes its reason to exist and preserves user bytes permanently; the legacy read refuses authority-obscuring shapes rather than decoding them | tracker key in `config.yml` from PR #301 |
 
 ---
 


### PR DESCRIPTION
Closes #323.

#323 was re-scoped once #321 and #322 landed: both changes made contract prose false the moment they merged, so the prose corrections and the residual-claim sweep shipped with them rather than trailing behind. What remained was the durable `Decisions` record for the selection move itself.

**Verified already done:**

| #323 criterion | where it landed |
|---|---|
| `SKILL.md` Core Contracts describes the local canonical shape and the new selection file | #322 (PR #328) |
| `references/*` agree; no residual "local markdown is canonical" or "`tracker:` lives in config.yml" claims | #322 — final sweep returns 0 matches |
| 200-line adapter budget recorded in a durable reference | `docs/tracker-adapter-design.md`, linked from `references/{file-format,process,scripts}.md` and the README |
| `README.md` matches | #322 |
| `capabilities-doctor` / `backlog-doctor` green | verified on main |

**This PR:** appends the `tracker-task-truth` Decisions row for the selection move, recording that not writing `config.yml` is what removes the tokenizer's reason to exist, and that the legacy read refuses authority-obscuring shapes rather than decoding them.

The change stays an implementation-choice record, not an invariant amendment, so no human-gated `spec-grill` pass is required — consistent with the escalation rule set in the sprint's Running Context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UekMHpbBRahCdnP9Jhd6ap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * 트래커 선택 기준을 `backlog/.tracker`로 명확히 했습니다.
  * `config.yml`은 읽기 전용 레거시 폴백으로만 사용되며, 더 이상 작성되지 않음을 명시했습니다.
  * 기존 `config.yml` 선택 토크나이저 관련 설명을 최신 동작에 맞게 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->