### PR TITLE
test: canonical-store contract prose must match code (#332)

### DIFF
--- a/skills/dev-backlog/scripts/contract-prose.test.js
+++ b/skills/dev-backlog/scripts/contract-prose.test.js
@@ -1,0 +1,89 @@
+// This is repo-local because the prose ships byte-identically to every consumer;
+// running the same authoring check in backlog-doctor would add no coverage.
+
+const { it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { STORE_FILE } = require("./local-tracker.js");
+const { TRACKER_SELECTION_FILE } = require("./tracker.js");
+const ROOT = path.resolve(__dirname, "../../..");
+const SURFACES = ["skills/dev-backlog/SKILL.md", "README.md", "spec/system-map.md"];
+const escape = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+function contractBlock(file) {
+  const lines = fs.readFileSync(path.join(ROOT, file), "utf8").split(/\r?\n/);
+  let start = -1;
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!/^```/.test(lines[index])) continue;
+    if (start < 0) {
+      start = index + 1;
+      continue;
+    }
+    const block = lines.slice(start, index);
+    if (/\bgithub\b/i.test(block.join("\n")) && /\blocal\b/i.test(block.join("\n"))) {
+      return block.map((text, offset) => ({ text, number: start + offset + 1 }));
+    }
+    start = -1;
+  }
+  assert.fail(`${file}:1: no delimited canonical-store contract block found`);
+}
+
+function diagnostic(file, line, fact) {
+  return `${file}:${line.number}: ${line.text.trim()}\ncontradicts code-derived fact: ${fact}`;
+}
+function requireLine(file, line, pattern, fact) {
+  assert.ok(pattern.test(line.text), diagnostic(file, line, fact));
+}
+function modeSection(file, block, mode) {
+  const start = block.findIndex(({ text }) => new RegExp(`\\b${mode}\\b.*->`, "i").test(text));
+  assert.notEqual(start, -1, diagnostic(file, block[0], `${mode} mode must name canonical truth`));
+  const next = block.findIndex(({ text }, index) => index > start && /\b(?:github|local)\b.*->/i.test(text));
+  return block.slice(start, next < 0 ? block.length : next);
+}
+function assertDerived(file, mode, section, block) {
+  const global = block.find(({ text }) => /derived .*mirrors? in both modes/i.test(text));
+  const claim = section.find(({ text }) => /derived/i.test(text) && /tasks?|mirrors?/i.test(text));
+  const offender = section.find(({ text }) => /tasks?|completed|mirrors?/i.test(text)) || section[0];
+  assert.ok(global || claim, diagnostic(
+    file, offender, `task mirrors are derived in ${mode} mode`
+  ));
+}
+function assertNoCanonicalMirrors(file, block) {
+  const lines = fs.readFileSync(path.join(ROOT, file), "utf8").split(/\r?\n/);
+  const subject = "(?:task files?|(?:backlog/)?tasks/?(?:\\s*\\+\\s*(?:backlog/)?completed/?)?|mirrors?)";
+  const forbidden = new RegExp(
+    `${subject}\\s+(?:(?:are|is)\\s+(?:the\\s+)?canonical|\\(canonical)`, "i"
+  );
+  lines.forEach((text, index) => {
+    if (forbidden.test(text) || /task files?.*\bcanonical records?\b/i.test(text) ||
+        /\bcanonical\s+(?:task files?|tasks|mirrors?)\b/i.test(text)) {
+      assert.fail(diagnostic(file, { text, number: index + 1 },
+        `only GitHub Issues or backlog/${STORE_FILE} can be canonical task truth`));
+    }
+  });
+  const approved = new RegExp(
+    `(?:GitHub Issues|${escape(`backlog/${STORE_FILE}`)})\\s*\\(?canonical\\)?`, "ig");
+  block.forEach((line) => {
+    const rest = line.text.replace(approved, "");
+    if (/\bcanonical\b/i.test(rest) && !/sprints\/.*canonical execution hub/i.test(rest))
+      assert.fail(diagnostic(file, line, "no other store can be canonical task truth"));
+  });
+}
+function assertContract(file) {
+  const block = contractBlock(file);
+  const github = modeSection(file, block, "github");
+  const local = modeSection(file, block, "local");
+  requireLine(file, block[0], new RegExp(escape(`backlog/${TRACKER_SELECTION_FILE}`)),
+    `tracker selection lives in backlog/${TRACKER_SELECTION_FILE}`);
+  requireLine(file, github[0], /GitHub Issues.*canonical/i,
+    "GitHub Issues are canonical in github mode");
+  requireLine(file, local[0], new RegExp(`${escape(`backlog/${STORE_FILE}`)}.*canonical`, "i"),
+    `backlog/${STORE_FILE} is canonical in local mode`);
+  assertDerived(file, "github", github, block);
+  assertDerived(file, "local", local, block);
+  assertNoCanonicalMirrors(file, block);
+}
+
+for (const file of SURFACES) {
+  it(`${file} matches canonical-store code`, () => assertContract(file));
+}

--- a/skills/dev-backlog/scripts/local-tracker.js
+++ b/skills/dev-backlog/scripts/local-tracker.js
@@ -592,6 +592,7 @@ function createLocalAdapter(options = {}) {
 }
 
 module.exports = {
+  STORE_FILE,
   createLocalAdapter,
   LocalStoreError,
 };

--- a/skills/dev-backlog/scripts/tracker.js
+++ b/skills/dev-backlog/scripts/tracker.js
@@ -32,6 +32,7 @@ const CAPABILITY_NAMES = Object.freeze([
 const UNSUPPORTED_CAPABILITY_CODE = "TRACKER_CAPABILITY_UNSUPPORTED";
 
 const DEFAULT_BACKLOG_DIR = "backlog";
+const TRACKER_SELECTION_FILE = ".tracker";
 
 class TrackerConfigurationError extends Error {
   constructor(value) {
@@ -62,7 +63,8 @@ class TrackerUnavailableError extends Error {
   constructor(tracker, reason, options = {}) {
     super(
       `Configured tracker "${tracker}" is unavailable: ${reason}. ` +
-        "Restore that tracker or change backlog/.tracker explicitly; no fallback was attempted.",
+        `Restore that tracker or change backlog/${TRACKER_SELECTION_FILE} explicitly; ` +
+        "no fallback was attempted.",
       options
     );
     this.name = "TrackerUnavailableError";
@@ -75,7 +77,7 @@ class UnsupportedTrackerCapabilityError extends Error {
   constructor(
     tracker,
     capability,
-    configPath = configDisplayPath(DEFAULT_BACKLOG_DIR, ".tracker")
+    configPath = configDisplayPath(DEFAULT_BACKLOG_DIR, TRACKER_SELECTION_FILE)
   ) {
     super(`Tracker "${tracker}" does not support capability "${capability}".`);
     this.name = "UnsupportedTrackerCapabilityError";
@@ -141,7 +143,7 @@ function selectTracker(config = {}) {
 }
 
 function readTrackerSelection(backlogDir = DEFAULT_BACKLOG_DIR, { fs: fsApi = fs } = {}) {
-  const trackerPath = path.join(backlogDir, ".tracker");
+  const trackerPath = path.join(backlogDir, TRACKER_SELECTION_FILE);
   try {
     return fsApi.readFileSync(trackerPath, "utf8").trim();
   } catch (error) {
@@ -241,7 +243,7 @@ function resolveConfiguredTracker(config, {
   );
   return Object.freeze({
     ...resolved,
-    configPath: configDisplayPath(backlogDir || DEFAULT_BACKLOG_DIR, ".tracker"),
+    configPath: configDisplayPath(backlogDir || DEFAULT_BACKLOG_DIR, TRACKER_SELECTION_FILE),
   });
 }
 
@@ -352,6 +354,7 @@ module.exports = {
   REQUIRED_ADAPTER_OPERATIONS,
   CAPABILITY_NAMES,
   UNSUPPORTED_CAPABILITY_CODE,
+  TRACKER_SELECTION_FILE,
   TRACKER_ADAPTERS,
   TrackerConfigurationError,
   TrackerContractError,


### PR DESCRIPTION
Closes #332.

Makes canonical-store contract prose fail a test when it drifts from the code.

## What it does

`skills/dev-backlog/scripts/contract-prose.test.js` (89 lines) derives the canonical paths **from code** — `STORE_FILE` from `local-tracker.js` and `TRACKER_SELECTION_FILE` from `tracker.js`, both newly exported — and asserts `SKILL.md`, `README.md`, and `spec/system-map.md` agree. One `assertContract` helper, three call sites. Renaming either path in code fails the test, so the test is not a second hardcoded copy of the claim.

## It found a live drift on its first run

Round 1 could not go green: `README.md:22` said `local -> tasks/ + completed/ (canonical, no gh)` and `:38` said `canonical tasks in local`. Both had been false since #321 merged in v0.9.0 and both were live on `main`. README was read-only for this task, so the executor correctly left it alone; the fix landed separately on `main` (`9228a65`) and this branch was rebased onto it. That is the fourth canonical-store drift in two releases and the first caught by a test rather than a human read.

## Regression proof

```
===== WITH the pre-#321 wording restored (exit 1) =====
not ok 1 - skills/dev-backlog/SKILL.md matches canonical-store code
    skills/dev-backlog/SKILL.md:39: backlog/config.yml (one tracker: github | local)
    contradicts code-derived fact: tracker selection lives in backlog/.tracker
ok 2 - README.md matches canonical-store code
ok 3 - spec/system-map.md matches canonical-store code
# tests 3
# pass 2
# fail 1

===== WITH the current wording (exit 0) =====
ok 1 - skills/dev-backlog/SKILL.md matches canonical-store code
ok 2 - README.md matches canonical-store code
ok 3 - spec/system-map.md matches canonical-store code
# tests 3
# pass 3
# fail 0

RESULT: drifted=FAILED as required; clean=passes

worktree restored; git status: clean
exit 1
not ok 1 - skills/dev-backlog/SKILL.md matches canonical-store code
    skills/dev-backlog/SKILL.md:41: local  -> backlog/tasks/ + completed/ are canonical; zero provider calls
    contradicts code-derived fact: backlog/local-tracker.json is canonical in local mode
ok 2 - README.md matches canonical-store code
ok 3 - spec/system-map.md matches canonical-store code
# tests 3
# pass 2
# fail 1

restored; status: clean
```

Two variants. The first restores the whole pre-#321 Core Contracts block and fails on the selection-path assertion. The second keeps the correct `backlog/.tracker` line and regresses **only** the local canonical claim — the exact drift this issue exists for — failing with a diagnostic that names the file, the line number, the offending text, and the code-derived fact it contradicts. The worktree is clean after both runs.

## Why repo-local and not a `backlog-doctor` check

`backlog-doctor` runs in the 19 consuming repositories, but this prose ships byte-identically in every install. Checking it 19 times verifies nothing that checking it once here does not, and it would add consumer surface to catch an authoring mistake only makeable in this repo. The reasoning is recorded in the test header so the decision survives the next person who wants to move it.

## Contract amendment

Criterion 7 originally required the failing output "in the PR body", but this run publishes **after** internal review, so the criterion was unsatisfiable at the moment it was checked. That was an orchestrator authoring error, amended in the open on issue #332 rather than left as a silent miss. The proof above is that criterion, met.

## Process note

This run was briefly wedged by an orchestrator mis-recovery to `review_pending` (the post-publication state) when `internal_review_pending` was meant. There is no edge back, and `publish-run` requires `publish_pending`, so the PR was created manually. Upstream context: sungjunlee/dev-relay#755.

Track: `2026-07-prose-guard` (`component: tracker-task-truth`), one half of the repo's first concurrent two-track portfolio.