### PR TITLE
fix(sprint-init): generated sprints pass backlog-doctor's shape check (#339)

### DIFF
--- a/skills/dev-backlog/references/file-format.md
+++ b/skills/dev-backlog/references/file-format.md
@@ -112,6 +112,10 @@ Sprint files (`backlog/sprints/*.md`) carry `objectives:` and `component:` along
 
 `sprint-init.js` emits each field only when its backing spec file is present, so a cold adopter with no `spec/` gets a clean sprint with neither key. An older sprint that still carries an empty `objectives: []` / `component: ""` stays valid — this is omission-on-generate, not a migration. `backlog-doctor.js` warns (soft, non-blocking) only when the **active** sprint omits a field while its spec file exists. Full semantics live in [`spec-fallback.md`](spec-fallback.md); the authoritative contract table is in [SKILL.md](../SKILL.md).
 
+## Sprint Plan
+
+Order planned tasks into parallel-safe batches. Group small tasks (~30min or less) for one session only when they can run in the same wave. An empty `## Plan` is valid until issues are selected; do not add prose or placeholder checkboxes because every nonblank, non-heading Plan line must parse as a task item.
+
 ## Tracker Selection
 
 `backlog/.tracker` contains exactly one newline-terminated selection:

--- a/skills/dev-backlog/scripts/sprint-init.js
+++ b/skills/dev-backlog/scripts/sprint-init.js
@@ -82,7 +82,7 @@ function parseArgs(args) {
 }
 
 function buildIssueLines(issues) {
-  if (!issues.length) return ["- [ ] (add issues here)"];
+  if (!issues.length) return [];
 
   return issues.map((issue) => {
     const labels = (issue.labels || []).map((l) => l.name);
@@ -141,8 +141,6 @@ ${scopeLine}${specBlock}---
 [One sentence: what's true when this sprint is done]
 
 ## Plan
-[Order into parallel-safe batches. Group small tasks (~30min or less) for one session only when they can run in the same wave.]
-
 ${issueLines.join("\n")}
 
 ## Running Context

--- a/skills/dev-backlog/scripts/sprint-init.test.js
+++ b/skills/dev-backlog/scripts/sprint-init.test.js
@@ -4,6 +4,7 @@ const fs = require("fs");
 const os = require("os");
 const path = require("path");
 const { spawnSync } = require("child_process");
+const { checkSprintShape } = require("./backlog-doctor.js");
 const {
   parseArgs,
   buildIssueLines,
@@ -95,8 +96,8 @@ describe("buildIssueLines", () => {
     ]);
   });
 
-  it("returns placeholder when there are no issues", () => {
-    assert.deepEqual(buildIssueLines([]), ["- [ ] (add issues here)"]);
+  it("returns no Plan lines when there are no issues", () => {
+    assert.deepEqual(buildIssueLines([]), []);
   });
 });
 
@@ -220,6 +221,35 @@ describe("createSprintFile", () => {
     const written = fs.readFileSync(result.sprintFile, "utf-8");
     assert.equal(written, result.content);
     assert.match(written, /due: 2026-04-12\nobjectives: \[\]\ncomponent: ""\n---/);
+  });
+
+  it("generates sprint files that pass the doctor shape check with and without issues (#339)", () => {
+    const cases = [
+      { topic: "empty", issues: [] },
+      { topic: "milestone", issues: [{ number: 42, title: "OAuth2 flow", labels: [] }] },
+    ];
+
+    for (const { topic, issues } of cases) {
+      const repoRoot = path.join(tmpDir, topic);
+      const backlogPath = path.join(repoRoot, "backlog");
+      const result = createSprintFile({
+        topic,
+        milestone: topic,
+        dryRun: false,
+        repoRoot,
+        sprintsDir: path.join(backlogPath, "sprints"),
+        getDue: () => "TBD",
+        getIssues: () => issues,
+      });
+      const shape = checkSprintShape({
+        repoRoot,
+        backlogPath,
+        activePath: result.sprintFile,
+        activeStatus: "pass",
+      });
+
+      assert.equal(shape.status, "pass", shape.detail.summary);
+    }
   });
 
   it("omits spec fields in the written file when no spec files exist (B3)", () => {
@@ -483,7 +513,7 @@ describe("createSprintFile", () => {
     assert.equal(result.placeholderIssue, true);
     assert.equal(result.issueCount, 0);
     assert.equal(fs.existsSync(result.sprintFile), false);
-    assert.match(result.content, /\(add issues here\)/);
+    assert.doesNotMatch(result.content, /Order into parallel-safe batches|add issues here/);
   });
 
   it("reports existing file during dry-run without overwriting it", () => {


### PR DESCRIPTION
Closes #339.

`sprint-init.js` was writing two Plan lines that `backlog-doctor`'s `sprint_shape` check immediately rejected — the bracketed guidance text and the `- [ ] (add issues here)` placeholder. Every cold adopter hit this on their first `sprint-init` → `backlog-doctor` sequence, and O7 is the cold-adopter objective.

## Found by using the tool, not reading it

Running `sprint-init` then `backlog-doctor` in **investanza** — an unfamiliar repo being triaged — produced a shape failure on a file the tool had just written. This repo never saw it because every sprint here is hand-edited seconds after creation, so the authoring repo was the one place the bug was invisible. Both sprints opened for this milestone reproduced it again at creation, and the doctor returned to 13/13 the moment real Plan content replaced the placeholder.

## Approach

The generator was fixed; **the checker was not loosened**. `sprint_shape` exists to catch Plan lines that were meant to be task items but are malformed, and are therefore silently skipped by `next.sh`/`status.sh` — that job stays sharp. The guidance text moved to `references/file-format.md`, where the rest of the Plan contract already lives, and now also states the rule it was previously violating: every nonblank, non-heading Plan line must parse as a task item.

An empty `## Plan` is valid until issues are selected.

## The regression test is a real check, not a string match

`sprint-init.test.js` imports `checkSprintShape` from `backlog-doctor.js` and runs it against generated output, for both the empty and milestone-populated cases. A string assertion would have passed while the two files drifted apart again.

3 files, 38 insertions, 6 deletions.

Track: `2026-07-rule-simplification` (`component: sprint-execution`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * 스프린트 계획 작성 방식과 병렬 작업 배치 규칙을 문서화했습니다.
  * 빈 계획 섹션과 작업 항목 파싱 규칙을 명확히 안내합니다.

* **개선 사항**
  * 작업이 없는 스프린트 생성 시 불필요한 자리표시자가 표시되지 않습니다.
  * 생성된 스프린트 파일이 더 간결하고 바로 작성 가능한 형태로 제공됩니다.

* **테스트**
  * 작업 유무와 관계없이 생성된 스프린트 파일의 형식 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->