### PR TITLE
docs: define GitHub-native authority contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,22 @@
 [![CI](https://github.com/sungjunlee/dev-backlog/actions/workflows/test.yml/badge.svg)](https://github.com/sungjunlee/dev-backlog/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
-Choose one canonical task tracker per repository: GitHub Issues or an offline
-local Markdown store. Sprint files remain the execution hub that both you and
-your AI agent read during a coding session.
+GitHub Issues own task definition and lifecycle. Simple Issue → PR work stays
+sprint-free; a local sprint file is added only when complex execution needs
+shared batching, context, progress, or handoff across issues, actors, or
+sessions.
 
 dev-backlog adds a local sprint file that carries the plan, decisions, and progress across tasks and sessions. Claude Code, Codex, and humans all read the same file.
 
-No new server. No hidden state. Existing GitHub repositories keep their current
-behavior without migration.
+No new server. No hidden state. No automatic memory writes. Existing GitHub
+repositories keep their current behavior without migration.
 
 README.md is the product overview and human quick start. The agent execution contract, sprint-file rules, and full script reference live in [skills/dev-backlog/SKILL.md](skills/dev-backlog/SKILL.md).
+
+The implementation still exposes local-tracker and task-mirror compatibility
+while the 2026-08 migration is staged. Those paths are frozen, are not the
+target product boundary, and never become co-authoritative. See the
+[authority and routing contract](skills/dev-backlog/references/authority-contract.md).
 
 ```text
 backlog/.tracker: github | local
@@ -34,9 +40,9 @@ backlog/sprints/     execution hub: plan, context, progress
 
 | Capability | What changes |
 |------------|--------------|
-| One canonical tracker | Explicit `github` or fully offline `local`; runtime never switches it |
-| One active sprint file per track | The human and the agent read the same execution plan; disjoint tracks may run concurrently |
-| Derived task files | `backlog/tasks/` mirrors the canonical store in both modes and is never read back as truth |
+| One task authority | Live GitHub Issues own specification, native planning metadata, and lifecycle |
+| Complexity-triggered sprint | Simple work stays Issue → PR; admitted complex tracks share one execution plan and may run concurrently when disjoint |
+| Non-authoritative compatibility | Transition task files are derived/read-only fallback material and are never read back as truth |
 | Explicit sync | Pull and refresh when you choose, not behind your back |
 | `[ ]` / `[~]` / `[x]` plan states | Delegated work stays visible in the sprint file, not buried in PR tabs |
 | `context-hook.sh` | Claude Code can get a one-line sprint summary before edits |
@@ -71,6 +77,13 @@ git clone https://github.com/sungjunlee/dev-backlog.git
 Run these commands from the project you want to manage, not from the `dev-backlog` repo itself.
 The examples below assume you have this repo available at `/path/to/dev-backlog`. If you installed the skill with `npx skills add`, use the installed skill path instead.
 
+For one self-contained Issue, work directly from the live Issue and its PR.
+Open a sprint only for ordered multi-Issue work, delegated/parallel handoff,
+cross-Issue or cross-session context, or concurrent-track coordination.
+Duration, estimate, milestone membership, and Relay presence alone do not
+require one. The commands below show that admitted complex-work path and its
+transition-compatible setup.
+
 ```bash
 # 1. Choose the canonical tracker and bootstrap backlog/
 node /path/to/dev-backlog/skills/dev-backlog/scripts/setup-dev-backlog.js \
@@ -94,13 +107,15 @@ bash /path/to/dev-backlog/skills/dev-backlog/scripts/status.sh
 bash /path/to/dev-backlog/skills/dev-backlog/scripts/sprint-close.sh backlog
 ```
 
-For a fully offline repository, choose `--tracker local` instead. Create and
-update tasks in the canonical store through the configured tracker lifecycle, use normalized
+Transition compatibility only: an existing fully offline repository may still
+choose `--tracker local`. Create and update tasks in the compatibility store
+through the configured tracker lifecycle, use normalized
 refs such as `BACK-1` in the Plan, and run the same `status`, `next`, and
 `sprint-close` commands. Local mode deliberately does not invent milestones,
 PR relationships, comments, or closing-keyword links.
 Those requests fail before side effects with actionable remediation; JSON-capable
-commands return the same structured error contract.
+commands return the same structured error contract. Do not adopt local mode for
+new repositories or add features to it during the GitHub-native migration.
 
 For task `list`, `read`, `create`, `update`, and `close`, the stable invocation
 boundary is the configured adapter exported by `scripts/tracker.js`. Operators
@@ -203,14 +218,15 @@ Users can log in and access protected API endpoints.
 
 ## Daily Workflow
 
-1. Read the configured tracker; in GitHub mode, explicitly pull issues into `backlog/tasks/`.
-2. Create or read tasks in the canonical store and generate the active sprint file.
-3. Read the sprint before you code.
+1. Read the live GitHub Issue.
+2. If execution complexity meets a sprint-admission trigger, create the active sprint file; otherwise continue directly to its PR.
+3. For admitted work, read the sprint before you code.
 4. Work batch by batch, not issue by issue across ten tabs.
 5. Update `Running Context` and `Progress` as you learn things.
 6. Close the sprint explicitly when the work is really done.
 
-The configured tracker handles task truth. The sprint file handles execution.
+GitHub handles task truth. An admitted sprint file handles only complex
+execution continuity.
 
 ## Multi-Track Sprints
 
@@ -246,6 +262,8 @@ The core loop above needs none of these. Add one only when you want its capabili
 | Spec axis (charter / system map / capabilities) | Objective/capability alignment for sprints and triage, plus the reassess signal | craftkit skills installed; degrades gracefully when absent |
 | dev-relay | delegated-work tracking: `[~]` in-flight state and PR handoff in the sprint file | the dev-relay skill |
 | backlog-triage | open-issue grooming into an advisory report (classification, stale flags, Alignment, Decision Review) | nothing — ships in this bundle |
+| GitHub Projects | optional planning visualization over Issues | a separately configured Project; project-only fields remain non-authoritative |
+| Matt Pocock skills | optional shaping or execution techniques | separately installed skills; no persisted dev-backlog state |
 
 ### Spec axis (charter, system map, capabilities)
 
@@ -367,16 +385,17 @@ This keeps Codex focused on one execution file, not ten browser tabs and stale i
 
 | Decision | Why |
 |----------|-----|
-| Exactly one tracker owns task truth | GitHub collaboration and offline local work share one core lifecycle without becoming co-authoritative |
-| Sprint files are the execution hub | One file carries plan, context, and progress across sessions |
-| Task files are always mirrors | GitHub Issues or `local-tracker.json` owns task truth; both modes emit the same active/completed Markdown shape |
+| GitHub Issues own task truth | Task specification, native planning fields, and lifecycle have one standalone authority |
+| Sprint files are complexity-triggered | One file carries plan, context, and progress only when continuity extends beyond one Issue/PR |
+| Task files are transition projections | Legacy mirrors are fallback material pending staged retirement, never authority or a new feature surface |
 | `_context.md` holds cross-sprint knowledge | Sprint files stay local to the sprint, project memory stays shared |
 | Sync is always explicit | No background process mutates your local state behind your back |
-| Task-file format is Backlog.md-compatible | `tasks/` follows the [Backlog.md](https://github.com/MrLesk/Backlog.md) task format; `sprints/` and `gh` sync are dev-backlog additions |
+| Backlog.md is optional compatibility | Existing task Markdown follows the [Backlog.md](https://github.com/MrLesk/Backlog.md) shape, but its runtime and conventions are not dependencies |
 
 ## Docs
 
 - [Agent execution contract](skills/dev-backlog/SKILL.md)
+- [Authority and routing contract](skills/dev-backlog/references/authority-contract.md)
 - [Process guide](skills/dev-backlog/references/process.md)
 - [File format and config](skills/dev-backlog/references/file-format.md)
 - [GitHub sync patterns](skills/dev-backlog/references/github-sync.md)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ backlog/sprints/     execution hub: plan, context, progress
 |------------|--------------|
 | One task authority | Live GitHub Issues own specification, native planning metadata, and lifecycle |
 | Complexity-triggered sprint | Simple work stays Issue → PR; admitted complex tracks share one execution plan and may run concurrently when disjoint |
-| Non-authoritative compatibility | Transition task files are derived/read-only fallback material and are never read back as truth |
+| Non-authoritative compatibility | Transition task files are derived diagnostic/export material and are never read back as runtime truth |
 | Explicit sync | Pull and refresh when you choose, not behind your back |
 | `[ ]` / `[~]` / `[x]` plan states | Delegated work stays visible in the sprint file, not buried in PR tabs |
 | `context-hook.sh` | Claude Code can get a one-line sprint summary before edits |
@@ -108,11 +108,13 @@ bash /path/to/dev-backlog/skills/dev-backlog/scripts/sprint-close.sh backlog
 ```
 
 Transition compatibility only: an existing fully offline repository may still
-choose `--tracker local`. Create and update tasks in the compatibility store
-through the configured tracker lifecycle, use normalized
-refs such as `BACK-1` in the Plan, and run the same `status`, `next`, and
-`sprint-close` commands. Local mode deliberately does not invent milestones,
-PR relationships, comments, or closing-keyword links.
+choose `--tracker local`. In that explicitly selected legacy mode,
+`backlog/local-tracker.json` remains its sole task authority; `backlog/tasks/`
+and `backlog/completed/` are derived read-only projections. Mutate the JSON
+authority only through the configured tracker lifecycle, use normalized refs
+such as `BACK-1` in the Plan, and run the same `status`, `next`, and
+`sprint-close` commands. This is separate from the GitHub-native core. Local
+mode deliberately does not invent milestones, PR relationships, comments, or closing-keyword links.
 Those requests fail before side effects with actionable remediation; JSON-capable
 commands return the same structured error contract. Do not adopt local mode for
 new repositories or add features to it during the GitHub-native migration.
@@ -221,9 +223,9 @@ Users can log in and access protected API endpoints.
 1. Read the live GitHub Issue.
 2. If execution complexity meets a sprint-admission trigger, create the active sprint file; otherwise continue directly to its PR.
 3. For admitted work, read the sprint before you code.
-4. Work batch by batch, not issue by issue across ten tabs.
-5. Update `Running Context` and `Progress` as you learn things.
-6. Close the sprint explicitly when the work is really done.
+4. For admitted work, execute its ordered batches; otherwise implement the Issue directly.
+5. Update `Running Context` and `Progress` only for admitted work.
+6. Close the sprint explicitly only when a sprint was admitted.
 
 GitHub handles task truth. An admitted sprint file handles only complex
 execution continuity.
@@ -387,7 +389,7 @@ This keeps Codex focused on one execution file, not ten browser tabs and stale i
 |----------|-----|
 | GitHub Issues own task truth | Task specification, native planning fields, and lifecycle have one standalone authority |
 | Sprint files are complexity-triggered | One file carries plan, context, and progress only when continuity extends beyond one Issue/PR |
-| Task files are transition projections | Legacy mirrors are fallback material pending staged retirement, never authority or a new feature surface |
+| Task files are transition projections | Legacy mirrors are diagnostic/export material pending staged retirement, never runtime fallback, authority, or a new feature surface |
 | `_context.md` holds cross-sprint knowledge | Sprint files stay local to the sprint, project memory stays shared |
 | Sync is always explicit | No background process mutates your local state behind your back |
 | Backlog.md is optional compatibility | Existing task Markdown follows the [Backlog.md](https://github.com/MrLesk/Backlog.md) shape, but its runtime and conventions are not dependencies |

--- a/backlog/sprints/2026-07-github-native-core-simplification.md
+++ b/backlog/sprints/2026-07-github-native-core-simplification.md
@@ -15,7 +15,7 @@ Make GitHub Issues the standalone task authority, preserve sprint continuity for
 ## Plan
 
 ### Batch 1 — Authority gate
-- [ ] #345 Define the GitHub-native authority contract and reduced product boundary (3d)
+- [~] #345 Define the GitHub-native authority contract and reduced product boundary (3d) — branch codex/github-native-core-simplification
 
 ### Batch 2 — Resolver and independent evidence tracks
 - [ ] #346 Resolve effective task specs without GitHub task mirrors (8d)
@@ -40,3 +40,4 @@ Make GitHub Issues the standalone task authority, preserve sprint continuity for
 
 ## Progress
 - 2026-07-31: Opened the milestone execution track from GitHub issues #345–#350. Doctor reported no pre-existing active sprint and no blocking repository health failures.
+- 2026-07-31: Started #345 on `codex/github-native-core-simplification`; authority-contract document and spec amendments are under implementation review.

--- a/backlog/sprints/2026-07-github-native-core-simplification.md
+++ b/backlog/sprints/2026-07-github-native-core-simplification.md
@@ -3,7 +3,7 @@ milestone: 2026-08 GitHub-native core simplification
 status: active
 started: 2026-07-31
 due: TBD
-objectives: [O3]
+objectives: [O10]
 component: "tracker-task-truth"
 ---
 
@@ -36,7 +36,7 @@ Make GitHub Issues the standalone task authority, preserve sprint continuity for
 - #349 remains an optional planning-projection experiment and must not enter the core Issue → PR or sprint path.
 - Start #350 evidence collection after #345 so its 4–6 week clock overlaps implementation. Any productization decision waits for #347 pilot evidence.
 - Stop #347 and repair #346 if mirrorless execution cannot recover acceptance criteria, task intent, lifecycle, or in-flight handoff state.
-- Existing mirrors remain read-only fallback during the pilot. Do not introduce new dual writes or committed automatic memory artifacts.
+- Existing mirrors remain diagnostic and rollback material during the pilot, never runtime task-spec or lifecycle fallback. If the live Issue cannot resolve, stop and repair #346. Do not introduce new dual writes or committed automatic memory artifacts.
 
 ## Progress
 - 2026-07-31: Opened the milestone execution track from GitHub issues #345–#350. Doctor reported no pre-existing active sprint and no blocking repository health failures.

--- a/backlog/sprints/2026-07-github-native-core-simplification.md
+++ b/backlog/sprints/2026-07-github-native-core-simplification.md
@@ -15,7 +15,7 @@ Make GitHub Issues the standalone task authority, preserve sprint continuity for
 ## Plan
 
 ### Batch 1 — Authority gate
-- [~] #345 Define the GitHub-native authority contract and reduced product boundary (3d) — branch codex/github-native-core-simplification
+- [~] #345 Define the GitHub-native authority contract and reduced product boundary (3d) [branch:codex/github-native-core-simplification]
 
 ### Batch 2 — Resolver and independent evidence tracks
 - [ ] #346 Resolve effective task specs without GitHub task mirrors (8d)

--- a/backlog/sprints/2026-07-github-native-core-simplification.md
+++ b/backlog/sprints/2026-07-github-native-core-simplification.md
@@ -1,0 +1,42 @@
+---
+milestone: 2026-08 GitHub-native core simplification
+status: active
+started: 2026-07-31
+due: TBD
+objectives: [O3]
+component: "tracker-task-truth"
+---
+
+# GitHub-native Core Simplification
+
+## Goal
+Make GitHub Issues the standalone task authority, preserve sprint continuity for complex work, and remove unproven mirror, tracker, planning, and memory complexity behind measured gates.
+
+## Plan
+
+### Batch 1 — Authority gate
+- [ ] #345 Define the GitHub-native authority contract and reduced product boundary (3d)
+
+### Batch 2 — Resolver and independent evidence tracks
+- [ ] #346 Resolve effective task specs without GitHub task mirrors (8d)
+- [ ] #349 Validate GitHub Projects as an optional planning projection (3d)
+
+### Batch 3 — Mirrorless execution pilot
+- [ ] #347 Pilot mirrorless GitHub execution and retire task mirrors (two sprints across 2–3 consuming repositories)
+
+### Batch 4 — Subtract unused compatibility machinery
+- [ ] #348 Subtract zero-adopter tracker and compatibility machinery (5d)
+
+### Batch 5 — Evidence-gated memory decision
+- [ ] #350 Benchmark historical retrieval before admitting project memory (4–6 week shadow period)
+
+## Running Context
+- GitHub Issues are canonical task definitions and lifecycle state for this milestone; sprint files carry only complex execution continuity.
+- #345 is the contract gate for every other epic. #346 gates #347, and #347 gates #348.
+- #349 remains an optional planning-projection experiment and must not enter the core Issue → PR or sprint path.
+- Start #350 evidence collection after #345 so its 4–6 week clock overlaps implementation. Any productization decision waits for #347 pilot evidence.
+- Stop #347 and repair #346 if mirrorless execution cannot recover acceptance criteria, task intent, lifecycle, or in-flight handoff state.
+- Existing mirrors remain read-only fallback during the pilot. Do not introduce new dual writes or committed automatic memory artifacts.
+
+## Progress
+- 2026-07-31: Opened the milestone execution track from GitHub issues #345–#350. Doctor reported no pre-existing active sprint and no blocking repository health failures.

--- a/skills/dev-backlog/SKILL.md
+++ b/skills/dev-backlog/SKILL.md
@@ -21,7 +21,7 @@ README covers install and human quick start. This file is the agent execution co
 | --- | --- | --- |
 | "where are we?", "orient", "status" | `orient` | Any admitted sprint state is identified; otherwise the next live Issue is named without manufacturing a sprint. |
 | "create issue", "new issue", "이슈 만들어" | `create` | A GitHub Issue is created and added to an active sprint Plan only when that work was admitted. |
-| "plan sprint", "make sprint", or complex work with no active sprint | `plan` | One active sprint file exists with Goal, ordered Plan, `objectives:`, and `component:`. |
+| "plan sprint", "make sprint", or complex work with no active sprint | `plan` | One active sprint file exists with Goal and ordered Plan; `objectives:`/`component:` are present only when their backing spec files exist. |
 | "work #N", "continue", "do next batch" | `work` | Live Issue AC is verified and lifecycle is updated; an admitted sprint is also updated when present. |
 | "next", "다음 작업" | `next` | The next actionable batch or sprint-planning need is named. |
 | "sync", "pull issues", "refresh backlog" | `sync` | GitHub mirrors are explicitly refreshed; the local canonical store needs no provider sync. |
@@ -121,14 +121,14 @@ their existing behavior until their staged retirement.
 1. Confirm that the work meets a Sprint Admission trigger. Otherwise keep the Issue → PR path sprint-free.
 2. Resolve Objectives from `spec/charter.md`; fall back to legacy root `CHARTER.md`; omit the `objectives:` field entirely when both are absent (see `references/spec-fallback.md`).
 3. List/inspect open tasks. Use milestone selection only when the configured adapter reports `milestones`; local planning writes normalized refs directly and does not fabricate one.
-4. Create the active sprint file with Goal, ordered Plan batches, estimates, dependencies, `objectives:`, and `component:` via `sprint-init.js --component "slug"` (or mutually exclusive `--scope` globs when no component axis fits). Plan batches are execution waves: intra-batch items MUST be mutually parallel-safe (disjoint files, no ordering between them), dependent items MUST go in a later batch, and batch order is execution order.
+4. Create the active sprint file with Goal, ordered Plan batches, estimates, and dependencies. Include `objectives:` and `component:` only when their backing spec files exist; use `sprint-init.js --component "slug"` when a capability axis exists, or mutually exclusive `--scope` globs when no component axis fits. Plan batches are execution waves: intra-batch items MUST be mutually parallel-safe (disjoint files, no ordering between them), dependent items MUST go in a later batch, and batch order is execution order.
 5. A second active track is refused only when its scope overlaps an existing active track; declare a disjoint `component:`/`scope:` to run tracks concurrently. Once more than one track is active, any track without a declared axis warns and allows (disjointness cannot be proven against an undeclared scope).
 
 Done when the sprint file is the track's execution hub and each planned issue has a clear batch position.
 
 ### Work
 
-1. Read the live GitHub Issue specification and AC. During migration, identify any mirror use explicitly as read-only recovery.
+1. Read the live GitHub Issue specification and AC. If that read fails, stop clearly; a legacy mirror may be inspected only as diagnostic/rollback evidence and cannot authorize execution or lifecycle changes.
 2. If the work has an admitted sprint, read its current batch and Running Context.
 3. Mark meaningful GitHub status before work when useful.
 4. Implement directly or optionally delegate through dev-relay.

--- a/skills/dev-backlog/SKILL.md
+++ b/skills/dev-backlog/SKILL.md
@@ -9,9 +9,9 @@ metadata:
 
 # Dev Backlog
 
-Real job: keep exactly one configured tracker as canonical task truth while
-using `backlog/sprints/` as the local execution hub for planning, context,
-progress, and handoff.
+Real job: keep GitHub Issues as task-definition and lifecycle truth while using
+`backlog/sprints/` only when complex execution needs a shared continuity,
+progress, or handoff record.
 
 README covers install and human quick start. This file is the agent execution contract: mode routing, file roles, must-do steps, and completion criteria.
 
@@ -19,10 +19,10 @@ README covers install and human quick start. This file is the agent execution co
 
 | User intent | Mode | Completion boundary |
 | --- | --- | --- |
-| "where are we?", "orient", "status" | `orient` | Active sprint, latest progress, and next unchecked batch are identified. |
-| "create issue", "new issue", "이슈 만들어" | `create` | A task is created in the configured canonical tracker and added to the current sprint Plan when in scope. |
-| "plan sprint", "make sprint", "start work" with no active sprint | `plan` | One active sprint file exists with Goal, ordered Plan, `objectives:`, and `component:`. |
-| "work #N", "work BACK-N", "continue", "do next batch" | `work` | Task AC is verified and configured-tracker plus sprint state are updated. |
+| "where are we?", "orient", "status" | `orient` | Any admitted sprint state is identified; otherwise the next live Issue is named without manufacturing a sprint. |
+| "create issue", "new issue", "이슈 만들어" | `create` | A GitHub Issue is created and added to an active sprint Plan only when that work was admitted. |
+| "plan sprint", "make sprint", or complex work with no active sprint | `plan` | One active sprint file exists with Goal, ordered Plan, `objectives:`, and `component:`. |
+| "work #N", "continue", "do next batch" | `work` | Live Issue AC is verified and lifecycle is updated; an admitted sprint is also updated when present. |
 | "next", "다음 작업" | `next` | The next actionable batch or sprint-planning need is named. |
 | "sync", "pull issues", "refresh backlog" | `sync` | GitHub mirrors are explicitly refreshed; the local canonical store needs no provider sync. |
 | "complete", "close sprint" | `complete` | Sprint/task state is finalized and rediscovery-prone context is promoted. |
@@ -33,7 +33,15 @@ tracker from availability.
 
 Related skills (none required for either core cycle): when installed, `spec-charter` (`spec/charter.md`), `spec-system-map` (`spec/system-map.md`), and `spec-grill` (`spec/capabilities.md`) ship with craftkit (`npx skills add sungjunlee/craftkit`) and supply the optional spec axis; [`backlog-triage`](../backlog-triage/SKILL.md) provides advisory backlog review before sprint planning. Degradation when they are absent is specified in `references/spec-fallback.md`.
 
+The target state ownership, migration freeze, and optional-integration boundary
+are single-sourced in [`references/authority-contract.md`](references/authority-contract.md).
+Compatibility code for local trackers and task mirrors may remain during the
+staged migration, but it is not permission to expand the target product.
+
 ## Core Contracts
+
+The runtime still exposes this transition implementation contract while the
+live resolver and compatibility subtraction are staged:
 
 ```
 backlog/.tracker (one line: github | local)
@@ -52,6 +60,16 @@ backlog/sprints/ <- shared execution hub in both modes
 - Optional provider capabilities are not part of the core lifecycle. Unsupported requests fail before effects through the shared typed error contract in `tracker.js`; public JSON surfaces emit one structured error and human surfaces include the same remediation.
 - Completed sprints stay as the permanent execution record.
 - Backlog-side file boundaries live in `references/backlog-boundaries.md`. Spec-axis boundaries and how `objectives:`/`component:` degrade when spec files are absent live in `references/spec-fallback.md` (in-bundle, always resolvable); their durable authoring home is craftkit's `spec-charter` skill, consulted when installed. Sprint `objectives:` reference charter Objective IDs, and `component:` is one primary capability handle from `spec/capabilities.md`.
+
+## Sprint Admission
+
+The default path is sprint-free Issue → implementation → PR → Issue closure.
+Create a sprint only when execution complexity requires continuity beyond one
+Issue and its PR: ordered multi-Issue batches, delegated or parallel handoff,
+cross-Issue/session context, or concurrent track coordination. Duration,
+estimate, milestone membership, and Relay presence alone do not trigger a
+sprint. Once admitted, the sprint owns execution continuity only; the Issue
+continues to own task specification and lifecycle.
 
 ## Sprint File Contract
 
@@ -83,38 +101,42 @@ Full sprint and task-file examples live in `references/file-format.md`.
 ### Orient
 
 1. Read `_context.md` if present.
-2. Find the active sprint(s); if none exists, list open tasks through the configured adapter and route to `plan`.
+2. Find the active sprint(s). If none exists, list live open Issues; route to `plan` only when the selected work meets a Sprint Admission trigger.
 3. One active track: read its Goal, Plan, Running Context, and latest Progress. Multiple disjoint tracks: `next.sh`/`status.sh` render a portfolio (one stanza per track); use `--track <slug>` to work one track.
-4. Identify the next unchecked Plan item (per track) or route to `complete` when all items are done.
+4. Identify the next unchecked Plan item per admitted track, or name the next live Issue for sprint-free work.
 
-Done when you can name the current sprint state and the next actionable batch — per track when a portfolio is active.
+Done when you can name the next live Issue and, when a sprint exists, its
+current state and next actionable batch.
 
 ### Create
 
 Follow `references/process.md` → `## Create — New Issues`.
 
-Done when the new task exists in the configured canonical store and is added to
-the active sprint Plan when in scope. GitHub mode may explicitly refresh its
-local mirror; local mode writes canonical JSON and refreshes its derived mirror.
+Done when the new task exists in GitHub and, only when the work was admitted to
+a sprint, is added to the active Plan. Transition compatibility modes keep
+their existing behavior until their staged retirement.
 
 ### Plan
 
-1. Resolve Objectives from `spec/charter.md`; fall back to legacy root `CHARTER.md`; omit the `objectives:` field entirely when both are absent (see `references/spec-fallback.md`).
-2. List/inspect open tasks. Use milestone selection only when the configured adapter reports `milestones`; local planning writes normalized refs directly and does not fabricate one.
-3. Create the active sprint file with Goal, ordered Plan batches, estimates, dependencies, `objectives:`, and `component:` via `sprint-init.js --component "slug"` (or mutually exclusive `--scope` globs when no component axis fits). Plan batches are execution waves: intra-batch items MUST be mutually parallel-safe (disjoint files, no ordering between them), dependent items MUST go in a later batch, and batch order is execution order.
-4. A second active track is refused only when its scope overlaps an existing active track; declare a disjoint `component:`/`scope:` to run tracks concurrently. Once more than one track is active, any track without a declared axis warns and allows (disjointness cannot be proven against an undeclared scope).
+1. Confirm that the work meets a Sprint Admission trigger. Otherwise keep the Issue → PR path sprint-free.
+2. Resolve Objectives from `spec/charter.md`; fall back to legacy root `CHARTER.md`; omit the `objectives:` field entirely when both are absent (see `references/spec-fallback.md`).
+3. List/inspect open tasks. Use milestone selection only when the configured adapter reports `milestones`; local planning writes normalized refs directly and does not fabricate one.
+4. Create the active sprint file with Goal, ordered Plan batches, estimates, dependencies, `objectives:`, and `component:` via `sprint-init.js --component "slug"` (or mutually exclusive `--scope` globs when no component axis fits). Plan batches are execution waves: intra-batch items MUST be mutually parallel-safe (disjoint files, no ordering between them), dependent items MUST go in a later batch, and batch order is execution order.
+5. A second active track is refused only when its scope overlaps an existing active track; declare a disjoint `component:`/`scope:` to run tracks concurrently. Once more than one track is active, any track without a declared axis warns and allows (disjointness cannot be proven against an undeclared scope).
 
 Done when the sprint file is the track's execution hub and each planned issue has a clear batch position.
 
 ### Work
 
-1. Read the current batch and each task file's Description and AC.
-2. Mark meaningful GitHub/local status before work when useful.
-3. Implement or delegate through dev-relay.
-4. Verify every AC item before checking it off.
-5. Update Plan checkbox, Running Context, Progress, and neutral task state. Use comments/PR relationships only after their capability gates succeed.
+1. Read the live GitHub Issue specification and AC. During migration, identify any mirror use explicitly as read-only recovery.
+2. If the work has an admitted sprint, read its current batch and Running Context.
+3. Mark meaningful GitHub status before work when useful.
+4. Implement directly or optionally delegate through dev-relay.
+5. Verify every AC item before checking it off.
+6. Update GitHub lifecycle and, only for admitted work, Plan checkbox, Running Context, and Progress. Use comments/PR relationships only after their capability gates succeed.
 
-Done when verified work is reflected in task AC, sprint progress, and the configured canonical task state.
+Done when verified work is reflected in GitHub Issue AC/lifecycle and, when
+admitted, sprint progress.
 
 ### Complete
 
@@ -144,7 +166,9 @@ Done when the user can tell which direction changed and what was updated.
 
 ### Next
 
-Read the active sprint and return the first unchecked actionable batch. If no active sprint exists or the sprint is done, say whether to plan the next sprint or inspect unplanned configured-tracker work.
+Read any active sprint and return its first unchecked actionable batch. If no
+active sprint exists or it is done, inspect live Issues and recommend a sprint
+only when the selected work meets a Sprint Admission trigger.
 
 ## Script Resolution
 
@@ -179,6 +203,7 @@ Core scripts (full flag inventory in `references/scripts.md`):
 - `references/checkbox-repair.md` — runbook for repairing an unmoored `[~]` after a doctor warn.
 - `references/backlog-boundaries.md` — backlog-side file boundaries and ownership.
 - `references/spec-fallback.md` — spec-axis degradation contract (in-bundle): `objectives:`/`component:` semantics and triage behavior when spec files are thin or absent.
+- `references/authority-contract.md` — sole-owner state routing, sprint admission, product exclusions, and optional ecosystem boundaries.
 
 ## Eval Prompts (fresh-session recovery)
 
@@ -186,7 +211,8 @@ Core scripts (full flag inventory in `references/scripts.md`):
 - "Plan a sprint whose scope overlaps a track that is already `status: active`." Expected: refuse, naming the conflicting track — declare a disjoint `component:`/`scope:` or complete the conflicting track first. Disjoint scopes are NOT refused; they open a second track.
 - "Orient in a repo with two disjoint active tracks (`auth` scoped to `src/auth/**`, `billing` to `src/billing/**`), each with its own Plan." Expected: a portfolio view naming both tracks and each next batch; `next --track auth` returns auth's next batch deterministically; `backlog-doctor` passes because scopes are disjoint.
 - "Cold adopter: a repo with open GitHub issues but no `backlog/`, no `spec/`, no root `CHARTER.md`, and no craftkit `spec-*` skills installed. Reach a first active sprint." Expected: bootstrap `backlog/`, route to `plan`, and create the sprint with `objectives:`/`component:` omitted (no spec axis to reference); never follow or require a `../spec-charter/...` path.
-- "Work issue #42 whose task file has three AC checkboxes." Expected: verify each AC before checking it off, then update Plan, Progress, and GitHub state.
+- "Cold adopter: a repo with one self-contained GitHub issue but no `backlog/`, no spec axis, and no Relay." Expected: use the Issue → PR path without requiring a sprint, mirror, Projects board, generated memory, or optional skill.
+- "Work issue #42 whose live Issue has three AC checkboxes." Expected: verify each AC before checking it off, update GitHub state, and update Plan/Progress only if the work has an admitted sprint.
 - "Fresh session with only repo files available, no conversation history, and no GitHub access." Expected: use `status.sh --json` and `next.sh --json` to name the active sprint, next actionable batch, and every in-flight `[~]` item with its owner/pointer (PR, branch, or run-id); if `--json` is unavailable, read the sprint file directly.
 - "Close a sprint with Running Context that applies to future work." Expected: promote durable context to `_context.md`, set sprint completed, and move completed task files.
 - "Sync local backlog after GitHub issues changed." Expected: run explicit pull/update logic and report what changed; no background mutation.

--- a/skills/dev-backlog/references/authority-contract.md
+++ b/skills/dev-backlog/references/authority-contract.md
@@ -1,0 +1,95 @@
+# GitHub-native authority and routing contract
+
+This is the target product contract for the 2026-08 GitHub-native core
+simplification milestone. During the staged migration, code may still expose
+local-tracker and task-mirror compatibility paths, but those paths must not
+gain features or become a second authority.
+
+The contract is based on the 2026-07-27 adoption review: all 17 observed
+consumer repositories used the default GitHub path, and 0 of 17 selected a
+non-default tracker. A follow-up check on 2026-07-28 found that all 18 then
+known consumer repositories had a GitHub remote. The evidence supports a
+GitHub-native core; it does not support another generic tracker or mirror
+abstraction.
+
+## Authority and routing table
+
+Each state class has one authority system. A projection may make that state
+easier to view or retrieve, but it never accepts an independent write.
+
+| State class | Sole authority | Write and read route | Non-authoritative surfaces |
+| --- | --- | --- | --- |
+| Task specification | GitHub Issue body and acceptance criteria | Create or amend the Issue, then read the live Issue | Legacy `backlog/tasks/` files, sprint Plan text, GitHub Projects |
+| Task lifecycle | GitHub Issue state and native metadata | Update the Issue state, labels, milestone, assignees, and native relationships | Sprint checkboxes, local task files, project-board fields |
+| Planning fields | GitHub Issue native metadata | Use labels, milestone, assignees, and Issue relationships; read them live | GitHub Projects views/fields, triage reports, sprint ordering |
+| Complex execution state | One active sprint file for the admitted track | Update its Plan, Running Context, and Progress at explicit boundaries | Relay run artifacts, PR tabs, chat history, status projections |
+| Durable decisions | The bounded `spec/*` contract axis | Amend through the human-gated spec process; route project, system, and capability decisions to the matching spec file | Issues, sprint Running Context, `_context.md`, generated memory |
+| Historical evidence | GitHub repository history | Read closed Issues/PRs, commits, and committed completed sprint files at their original locations | Copied summaries, search indexes, compiled memory |
+| Derived retrieval output | Its named upstream authority | Recompute from live authorities and identify the source record in every result | Search caches, embeddings, generated summaries, benchmark output |
+
+`Derived retrieval output` is a view, not a new state owner: the sole owner of
+each returned fact remains the upstream authority named by that result.
+Retrieval output must be disposable and must not be written back automatically
+to Issues, sprints, `_context.md`, or `spec/*`.
+
+## Sprint admission
+
+The default path is a sprint-free **Issue → implementation → PR → Issue
+closure**. Time is not an admission criterion: one difficult Issue may take
+days and still need no sprint if its Issue and PR preserve enough continuity.
+
+Create a sprint only when execution complexity requires a shared continuity
+record beyond one Issue and its PR. A sprint is admitted when at least one of
+these conditions is true:
+
+- multiple Issues have ordered dependencies or must be executed in explicit
+  batches;
+- work is delegated or parallelized and in-flight ownership/handoff must
+  survive outside one PR;
+- decisions or discovered constraints must carry across Issues, actors, or
+  sessions before they are ready for durable specs;
+- concurrent tracks need an explicit non-overlap scope and independent
+  completion boundary.
+
+A sprint is not justified solely by elapsed time, estimate size, milestone
+membership, or the presence of Relay. When admitted, it owns only execution
+continuity; it does not restate or supersede Issue acceptance criteria or
+lifecycle.
+
+## Explicit exclusions and freezes
+
+The core product excludes:
+
+- dual-write or bidirectional task state;
+- automatic writes from search, retrieval, summaries, or memory compilers;
+- required Relay, Matt Pocock skill, GitHub Projects, or Backlog.md runtime
+  dependencies;
+- a second task-spec or lifecycle authority outside GitHub Issues.
+
+Until this milestone completes, do not add tracker adapters, local-tracker
+features, bidirectional compatibility machinery, task-mirror features, or a
+committed memory/compiler layer. Removal work must follow the staged resolver
+and mirrorless pilot rather than deleting recovery paths prematurely.
+
+## Optional boundaries
+
+| Surface | Allowed role | Boundary |
+| --- | --- | --- |
+| Relay | Optional implementation/review delegation | May update an admitted sprint through its integration contract; never required for task resolution or sprint execution |
+| Matt Pocock skills | Optional shaping and execution techniques | May help an actor plan or implement; no persisted dev-backlog state or hard dependency |
+| GitHub Projects | Optional planning projection | May visualize Issue metadata; project-only fields cannot become task or lifecycle authority and the core flow must work without Projects |
+| Backlog.md | Optional format compatibility | Existing compatible Markdown may remain import/export material; its conventions and runtime are not product dependencies |
+| Spec axis | Optional durable project contract | Human-gated when present; absence must not block task work or the complete sprint cycle |
+| Retrieval/memory experiments | Optional, report-only evidence tools | Must remain reproducible projections until the separate benchmark meets its quantitative go/no-go gate |
+
+## Cold-adopter invariant
+
+A repository with GitHub Issues but no `backlog/`, no `spec/`, and no Relay
+installation must be able to:
+
+1. complete a simple Issue → PR path without creating a sprint; and
+2. when complexity triggers a sprint, create, resume, and close it using only
+   this bundle, with `objectives:` and `component:` omitted.
+
+No path may require a cross-repository spec reference, Relay artifact, Projects
+board, task mirror, generated memory, or Backlog.md installation.

--- a/skills/dev-backlog/references/backlog-boundaries.md
+++ b/skills/dev-backlog/references/backlog-boundaries.md
@@ -7,15 +7,19 @@ Use this as the shared boundary reference for `dev-backlog` and `backlog-triage`
 | File | Role | Owned by |
 | --- | --- | --- |
 | `backlog/sprints/_context.md` | Operational facts, conventions, and gotchas that would otherwise be rediscovered. | `dev-backlog` |
-| `backlog/sprints/*.md` | Sprint execution plan, Running Context, and Progress for current work. | `dev-backlog` |
-| `backlog/tasks/*.md` | Thin GitHub Issue mirrors and AC checkboxes. | `dev-backlog` |
+| `backlog/sprints/*.md` | Complex execution Plan, Running Context, and Progress for an admitted track. | `dev-backlog` |
+| `backlog/tasks/*.md` | Non-authoritative GitHub Issue projections retained during migration. | `dev-backlog` |
 | `backlog/triage/*.md` | Derived advisory reports. | `backlog-triage` |
 | `backlog/triage/*-apply.log` | JSONL audit logs for accepted issue mutations. | `backlog-triage` |
 
 ## Rules
 
 - GitHub Issues remain the source of truth for task definitions and acceptance criteria.
-- Sprint files remain the execution hub for batching, context, progress, and handoff.
+- Sprint files own batching, context, progress, and handoff only after work meets a complexity admission trigger; simple Issue → PR work is sprint-free.
+- Task projections are never read as authority or dual-written; new mirror features are frozen pending staged retirement.
 - Triage reports are derived, advisory artifacts; they may propose spec changes, but they do not mutate specs.
 
 The spec-side boundaries (`spec/charter.md`, `spec/system-map.md`, `spec/capabilities.md`, and the legacy root `CHARTER.md` fallback) and how they degrade when thin or absent are covered by [`spec-fallback.md`](spec-fallback.md) — it ships in this bundle and is always resolvable. Their durable authoring home is craftkit's `spec-charter` skill (`npx skills add sungjunlee/craftkit`); when installed, its `references/spec-axis.md` deepens the boundaries — an enhancement, never required.
+
+The sole-owner routing table and optional ecosystem boundaries are in
+[`authority-contract.md`](authority-contract.md).

--- a/skills/dev-backlog/references/spec-fallback.md
+++ b/skills/dev-backlog/references/spec-fallback.md
@@ -31,3 +31,11 @@ This is a **reference, not a spec**. It does not author spec-axis semantics — 
 ## When craftkit is installed (enhancement, never required)
 
 Authoring semantics and the durable spec-axis boundaries live in craftkit's `spec-charter` skill. When craftkit is installed alongside this skill, its `references/spec-axis.md` (file boundaries) and `references/alignment.md` (work→objective mapping and drift severity) **deepen** the rules above. They are never required: everything a cold adopter needs to reach a first closed sprint is on this page.
+
+## Cold-adopter execution invariant
+
+Spec absence never creates work. A self-contained GitHub Issue follows the
+sprint-free Issue → PR path. If execution complexity requires a sprint, a cold
+adopter can still create, resume, and close it with `objectives:` and
+`component:` omitted. Neither path may require craftkit, Relay, GitHub
+Projects, task mirrors, generated memory, or Backlog.md.

--- a/skills/dev-backlog/scripts/authority-contract.test.js
+++ b/skills/dev-backlog/scripts/authority-contract.test.js
@@ -1,0 +1,75 @@
+const { it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const ROOT = path.resolve(__dirname, "../../..");
+const CONTRACT_PATH = path.join(
+  ROOT,
+  "skills/dev-backlog/references/authority-contract.md"
+);
+const EXPECTED_STATE_CLASSES = [
+  "Task specification",
+  "Task lifecycle",
+  "Planning fields",
+  "Complex execution state",
+  "Durable decisions",
+  "Historical evidence",
+  "Derived retrieval output",
+];
+const EXPECTED_SOLE_AUTHORITIES = [
+  "GitHub Issue body and acceptance criteria",
+  "GitHub Issue state and native metadata",
+  "GitHub Issue native metadata",
+  "One active sprint file for the admitted track",
+  "The bounded `spec/*` contract axis",
+  "GitHub repository history",
+  "Its named upstream authority",
+];
+
+function contract() {
+  return fs.readFileSync(CONTRACT_PATH, "utf8");
+}
+
+function authorityRows(markdown) {
+  const section = markdown
+    .split("## Authority and routing table")[1]
+    ?.split("\n## ")[0];
+  assert.ok(section, "authority and routing table section must exist");
+
+  return section
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("| ") && !line.startsWith("| ---"))
+    .slice(1)
+    .map((line) => line.split("|").slice(1, -1).map((cell) => cell.trim()));
+}
+
+it("routes every required state class to one non-empty sole-authority cell", () => {
+  const rows = authorityRows(contract());
+  assert.deepEqual(rows.map((row) => row[0]), EXPECTED_STATE_CLASSES);
+  assert.deepEqual(rows.map((row) => row[1]), EXPECTED_SOLE_AUTHORITIES);
+
+  for (const row of rows) {
+    assert.equal(row.length, 4, `${row[0]} must keep the four-column routing shape`);
+    assert.ok(row[1], `${row[0]} must name its sole authority`);
+  }
+});
+
+it("freezes the reduced boundary and complexity-triggered sprint rule", () => {
+  const markdown = contract();
+  assert.match(markdown, /0 of 17 selected a\s+non-default tracker/);
+  assert.match(markdown, /Time is not an admission criterion/);
+  assert.match(markdown, /dual-write or bidirectional task state/);
+  assert.match(markdown, /automatic writes from search, retrieval, summaries, or memory compilers/);
+
+  for (const optional of ["Relay", "Matt Pocock skills", "GitHub Projects", "Backlog.md"]) {
+    assert.match(markdown, new RegExp(`\\| ${optional.replace(".", "\\.")} \\|`));
+  }
+});
+
+it("keeps both no-spec/no-Relay cold-adopter paths explicit", () => {
+  const markdown = contract();
+  assert.match(markdown, /no `backlog\/`, no `spec\/`, and no Relay/);
+  assert.match(markdown, /complete a simple Issue → PR path without creating a sprint/);
+  assert.match(markdown, /create, resume, and close it using only\s+this bundle/);
+});

--- a/skills/dev-backlog/scripts/authority-contract.test.js
+++ b/skills/dev-backlog/scripts/authority-contract.test.js
@@ -73,3 +73,24 @@ it("keeps both no-spec/no-Relay cold-adopter paths explicit", () => {
   assert.match(markdown, /complete a simple Issue → PR path without creating a sprint/);
   assert.match(markdown, /create, resume, and close it using only\s+this bundle/);
 });
+
+it("keeps sprint admission and migration boundaries aligned across public docs", () => {
+  const read = (relativePath) =>
+    fs.readFileSync(path.join(ROOT, relativePath), "utf8");
+  const readme = read("README.md");
+  const skill = read("skills/dev-backlog/SKILL.md");
+  const capabilities = read("spec/capabilities.md");
+  const charter = read("spec/charter.md");
+  const sprint = read(
+    "backlog/sprints/2026-07-github-native-core-simplification.md"
+  );
+
+  assert.match(readme, /Close the sprint explicitly only when a sprint was admitted/);
+  assert.match(readme, /`backlog\/local-tracker\.json` remains its sole task authority/);
+  assert.match(skill, /`objectives:`\/`component:` are present only when their backing spec files exist/);
+  assert.match(skill, /legacy mirror may be inspected only as diagnostic\/rollback evidence/);
+  assert.match(capabilities, /If that read fails, execution stops/);
+  assert.match(charter, /one admitted sprint per track/);
+  assert.match(sprint, /objectives: \[O10\]/);
+  assert.doesNotMatch(sprint, /read-only fallback/);
+});

--- a/spec/README.md
+++ b/spec/README.md
@@ -12,6 +12,13 @@ Use `spec-charter` for `charter.md`, `spec-system-map` for `system-map.md`, and 
 
 ## Boundary
 
-`spec/*` files hold durable project, system, and capability contracts. Task acceptance criteria stay in GitHub Issues and `backlog/tasks/` mirrors; sprint execution context stays in `backlog/sprints/`; relay Done Criteria, rubrics, and review notes stay in dev-relay run artifacts.
+`spec/*` files hold durable project, system, and capability contracts. Task
+acceptance criteria stay in GitHub Issues; legacy `backlog/tasks/` files are
+non-authoritative migration fallbacks. Complex execution context stays in
+`backlog/sprints/`; Relay Done Criteria, rubrics, and review notes stay in
+dev-relay run artifacts.
 
 Spec skills may read task AC and sprint evidence to understand current reality, but they must not copy issue-specific AC, frozen Done Criteria, or review notes into durable specs.
+
+The complete state routing and optional-integration boundary is
+[`../skills/dev-backlog/references/authority-contract.md`](../skills/dev-backlog/references/authority-contract.md).

--- a/spec/capabilities.md
+++ b/spec/capabilities.md
@@ -33,7 +33,7 @@ does not widen these capability contracts.
 - GitHub Projects fields as task specification or lifecycle state
 
 ### Expected Behaviors
-- Task work resolves the effective specification from the live GitHub Issue; a legacy mirror may be an explicitly identified read-only recovery source during migration, never the default authority.
+- Task work resolves the effective specification from the live GitHub Issue. If that read fails, execution stops; a legacy mirror may be inspected only as diagnostic/rollback evidence and must be human-verified against GitHub before work resumes.
 - Create, plan, work, and complete operations use the Issue's stable `#N` identity and update lifecycle state only through GitHub.
 - Optional features report their availability explicitly; absence of Relay, Projects, Backlog.md, or the spec axis does not block the core Issue → PR path.
 
@@ -141,7 +141,7 @@ does not widen these capability contracts.
 | 2026-07-04 | Capability widens from read-only pull to bidirectional mirroring; the read-only bright line narrows to "human-authored content is untouchable" | sprint-mirror (PR #233, SSOT decision charter rev.4) writes only marker-identified machine-managed bodies; push-direction mirroring belongs with mirroring, not with monthly journaling | — |
 | 2026-07-12 | `sprint-mirror` becomes per-track: `--track` selects among multiple active tracks instead of failing on any second active (epic #289; human-gated pass #294) | the per-slug marker already made mirrors track-idempotent; only selection needed to change, and refusing to guess is preserved | 2026-07-04 single-active mirror selection |
 | 2026-07-28 | `sprint-mirror` is removed; this capability no longer publishes sprint state to the provider | measured 2026-07-28: four mirror issues ever created (#230, #234, #237, #239, all 2026-07-03/04) and none since, in any of the 18 consuming repos; the sprint file is committed at explicit boundaries and already readable directly (#340) | 2026-07-04 bidirectional widening; 2026-07-12 per-track mirror selection |
-| 2026-07-31 | Freeze task projections as migration-only, read-only fallback pending the live resolver and mirrorless pilot | a projection cannot remain harmless if new behavior depends on writing or reading it as truth; retirement must remain staged and recoverable | task mirrors as a continuing product capability |
+| 2026-07-31 | Freeze task projections as migration-only diagnostic/export material pending the live resolver and mirrorless pilot | a projection cannot remain harmless if runtime behavior depends on writing or reading it as truth; rollback remains possible by restoring the legacy path, not by silently consulting stale files | task mirrors as a continuing product capability |
 
 ---
 

--- a/spec/capabilities.md
+++ b/spec/capabilities.md
@@ -8,31 +8,39 @@ Capability headings are strict routing handles. Use one lowercase slug after `##
 
 The former `spec-charter`, `spec-system-map`, and `spec-grill` capability blocks were removed on 2026-07-05: those skills moved to craftkit in 0.7.0 (charter Decision 2026-07-04), so their contracts live with the skill definitions there. This file keeps only capabilities this repo owns.
 
+The 2026-08 target authority boundary is
+[`../skills/dev-backlog/references/authority-contract.md`](../skills/dev-backlog/references/authority-contract.md).
+The human-confirmed 2026-07-31 amendment makes GitHub Issues the sole task and
+lifecycle authority. Compatibility code retained during the staged migration
+does not widen these capability contracts.
+
 ---
 
 ## Capability: tracker-task-truth
 
-**Goal:** A repository explicitly selects one canonical task tracker and completes the same core sprint cycle without hidden synchronization or provider-specific assumptions leaking into sprint execution.
+**Goal:** A repository uses live GitHub Issues as the standalone task-definition and lifecycle authority without mirrors, projections, or execution tools becoming co-authoritative.
 
 **In-scope:**
-- Persisted tracker selection and availability probing
-- Normalized list/read/create/update/close task lifecycle
-- Stable task identity, display references, links, and capability reporting
-- `github` and `local` adapters
+- Live GitHub Issue list/read/create/update/close lifecycle
+- Stable `#N` identity, Issue URLs, labels, milestone, assignees, and native relationships
+- Fail-loud GitHub availability and authentication errors
+- Read-only compatibility during the staged retirement of local-tracker and task-mirror paths
 
 **Out-of-scope:**
 - Synchronizing multiple canonical trackers
-- GitLab, Gitea, Forgejo, Jira, Linear, or Notion adapters before the seam is proven
-- Provider-specific milestones, PR links, mirror issues, progress issues, and close-keyword semantics
+- New or expanded local, GitLab, Gitea, Forgejo, Jira, Linear, or Notion adapters
+- Task-mirror features, generic tracker parity, or runtime tracker switching
+- GitHub Projects fields as task specification or lifecycle state
 
 ### Expected Behaviors
-- Setup persists exactly one tracker selection, and every later command uses that selection or fails with an actionable availability error.
-- `github` and `local` expose the same normalized task lifecycle and stable task references needed by create, plan, work, and complete operations.
-- Capability discovery reports optional features explicitly so callers either invoke supported behavior or return a clear unsupported-capability result.
+- Task work resolves the effective specification from the live GitHub Issue; a legacy mirror may be an explicitly identified read-only recovery source during migration, never the default authority.
+- Create, plan, work, and complete operations use the Issue's stable `#N` identity and update lifecycle state only through GitHub.
+- Optional features report their availability explicitly; absence of Relay, Projects, Backlog.md, or the spec axis does not block the core Issue → PR path.
 
 ### Hard Constraints
-- Runtime never silently changes the configured tracker or treats two task stores as co-authoritative.
-- The normalized interface never fabricates provider semantics; unsupported milestones, PR relationships, publications, and closing links fail clearly.
+- Never dual-write task specification or lifecycle state.
+- Never treat task files, sprint text, Projects fields, retrieval output, or generated memory as fallback authority after a GitHub failure.
+- Do not add tracker adapters or compatibility features during the GitHub-native simplification milestone.
 
 ### Learnings
 <!-- LEARN:BEGIN -->
@@ -50,6 +58,7 @@ The former `spec-charter`, `spec-system-map`, and `spec-grill` capability blocks
 | 2026-07-11 | Admit `tracker-task-truth` as a separate capability from `backlog-sync` | canonical ownership and task lifecycle are required in every mode; mirroring and publication are optional transport behaviors | — |
 | 2026-07-26 | Make `backlog/local-tracker.json` the sole local task authority and derive both Markdown directories from it | one atomic JSON store removes Markdown/YAML round-trip and close-compensation machinery while satisfying the no-co-authority constraint directly | canonical local Markdown shape from PR #298 |
 | 2026-07-27 | Move tracker selection to `backlog/.tracker`; `config.yml` becomes a read-only legacy fallback that is never written | the selection tokenizer existed only to write one key into user-owned YAML safely, so not writing removes its reason to exist and preserves user bytes permanently; the legacy read refuses authority-obscuring shapes rather than decoding them | tracker key in `config.yml` from PR #301 |
+| 2026-07-31 | Narrow the target capability to live GitHub Issue authority and freeze adapter/mirror expansion | 0 of 17 observed consumers selected a non-default tracker, and all 18 known consumers had a GitHub remote; compatibility remains only long enough to stage resolver and mirrorless pilots safely | 2026-07-11 generic configured-tracker target |
 
 ---
 
@@ -63,11 +72,13 @@ The former `spec-charter`, `spec-system-map`, and `spec-grill` capability blocks
 - `sprint-init.js`, `sprint-close.sh`, `find_active_sprint`/`resolve_track`, `next.sh`, `status.sh`
 
 **Out-of-scope:**
-- Tasks outside the active sprint (those live in `backlog/tasks/`)
+- Tasks outside the active sprint (their specification and lifecycle remain in GitHub Issues)
 - Sprint *content* authoring — humans write the Plan; this capability runs it
 - Backlog grooming or stale-issue detection (`triage-grooming` capability)
+- Simple work whose complete continuity fits in one GitHub Issue and its PR
 
 ### Expected Behaviors
+- The default Issue → implementation → PR → closure path creates no sprint. A sprint is admitted only for ordered multi-Issue batches, delegated/parallel handoff, cross-Issue or cross-session context, or concurrent track coordination; duration, estimate, milestone membership, and Relay presence alone never trigger one.
 - No two sprint files with `status: active` declare overlapping scope — overlap fails loud through the one shared `scopesOverlap` predicate (`component:` equality or `scope:` path-prefix collision; surfaced by `sprint-init` refusal, `sprint-state` `OVERLAPPING_TRACKS`, and the doctor's `Active tracks overlap on scope` verdict). Disjoint-scope tracks coexist as a portfolio; a single active track behaves exactly as before; once more than one track is active, any track without a declared axis cannot be proven disjoint and surfaces an informational doctor warning.
 - Every `[~]` line carries a PR or branch ref in-line, or an explicit "no work yet" annotation — never an unmoored `[~]`.
 - Closing a sprint via `sprint-close.sh` is atomic: the sprint flips `status: completed` AND its done-checkbox issues move into `backlog/completed/` in one invocation, not in two steps.
@@ -75,6 +86,7 @@ The former `spec-charter`, `spec-system-map`, and `spec-grill` capability blocks
 ### Hard Constraints
 - Never mutate a sprint's `status: completed` back to `active`; completed sprints are immutable history.
 - Never silently delete sprint Plan items — strike them with a Progress entry or convert to `[~]` with a parking note instead.
+- Never copy Issue acceptance criteria into a sprint or let sprint checkbox state own Issue lifecycle.
 
 ### Learnings
 <!-- LEARN:BEGIN -->
@@ -88,12 +100,13 @@ The former `spec-charter`, `spec-system-map`, and `spec-grill` capability blocks
 | --- | --- | --- | --- |
 | 2026-07-12 | Replace the single-active-sprint invariant with track-partitioned scope disjointness (epic #289, PRD `docs/prd-2026-07-multi-track-sprints.md`; human-gated pass #294) | disjoint-scope tracks remove the false serialization of unrelated work while overlap stays fail-loud through one shared predicate; single-track behavior is byte-identical (G4) | pre-#289 "exactly one active sprint" behavior |
 | 2026-07-28 | The cannot-prove-disjoint warning fires when 2+ tracks are active and **any** of them is scopeless, not only when two or more are (#337) | the pair rule under-warned: one scopeless track next to a declared one is exactly the unprovable state the warning exists for, and B is also the shorter rule to state — "when more than one track is active, every track must declare an axis". Verified against all 18 consuming repos: zero `active_sprint` verdict changes, so single-track repos stay silent | 2026-07-12 pair-rule warning |
+| 2026-07-31 | Admit sprints by execution complexity, not duration; keep simple Issue → PR work sprint-free | the validated sprint kernel solves continuity and handoff, but requiring it for single-threaded work adds state without resolving a continuity problem | implicit sprint-for-all-work routing |
 
 ---
 
 ## Capability: backlog-sync
 
-**Goal:** Canonical tracker tasks are materialized locally and supported execution state is explicitly published without either direction ever diverging human-authored content.
+**Goal:** Legacy task projections remain safe and read-only while live GitHub task resolution replaces them; no projection gains independent write authority.
 
 **In-scope:**
 - `sync-pull.js` (with and without `--update`), task-file frontmatter, and adapter-provided task identity
@@ -105,6 +118,7 @@ The former `spec-charter`, `spec-system-map`, and `spec-grill` capability blocks
 - Writing to human-authored provider content (task bodies without a dev-backlog machine marker, comments, labels, state)
 - Publishing sprint or progress state to the provider — removed 2026-07-28; the sprint file is the shared read surface
 - Cross-repo mirroring
+- New mirror features or bidirectional compatibility work
 
 ### Expected Behaviors
 - `sync-pull` on a fresh checkout produces `backlog/tasks/*.md` with no token prompt beyond `gh auth` already being valid.
@@ -114,6 +128,7 @@ The former `spec-charter`, `spec-system-map`, and `spec-grill` capability blocks
 ### Hard Constraints
 - Never write to human-authored provider content: task bodies without a dev-backlog machine marker, comments, labels, and issue state are untouchable.
 - Never overwrite a non-machine-managed task body during `--update`; only frontmatter is replaced.
+- Never read a task projection as authority, dual-write task state, or make a mirror required for the core Issue → PR or complex-sprint path.
 
 ### Learnings
 <!-- LEARN:BEGIN -->
@@ -126,6 +141,7 @@ The former `spec-charter`, `spec-system-map`, and `spec-grill` capability blocks
 | 2026-07-04 | Capability widens from read-only pull to bidirectional mirroring; the read-only bright line narrows to "human-authored content is untouchable" | sprint-mirror (PR #233, SSOT decision charter rev.4) writes only marker-identified machine-managed bodies; push-direction mirroring belongs with mirroring, not with monthly journaling | — |
 | 2026-07-12 | `sprint-mirror` becomes per-track: `--track` selects among multiple active tracks instead of failing on any second active (epic #289; human-gated pass #294) | the per-slug marker already made mirrors track-idempotent; only selection needed to change, and refusing to guess is preserved | 2026-07-04 single-active mirror selection |
 | 2026-07-28 | `sprint-mirror` is removed; this capability no longer publishes sprint state to the provider | measured 2026-07-28: four mirror issues ever created (#230, #234, #237, #239, all 2026-07-03/04) and none since, in any of the 18 consuming repos; the sprint file is committed at explicit boundaries and already readable directly (#340) | 2026-07-04 bidirectional widening; 2026-07-12 per-track mirror selection |
+| 2026-07-31 | Freeze task projections as migration-only, read-only fallback pending the live resolver and mirrorless pilot | a projection cannot remain harmless if new behavior depends on writing or reading it as truth; retirement must remain staged and recoverable | task mirrors as a continuing product capability |
 
 ---
 
@@ -163,4 +179,3 @@ The former `spec-charter`, `spec-system-map`, and `spec-grill` capability blocks
 | --- | --- | --- | --- |
 | 2026-05-22 | Alignment Check is prompt-driven inside `backlog-triage`, not a new `triage-*.js` | Issue → Objective mapping is semantic, unlike the deterministic relate/stale scripts | — |
 | 2026-05-31 | Decision Review is prompt-driven and report-only inside `backlog-triage` | Final backlog recommendations need semantic spec evidence; `triage-apply.js` should remain limited to explicit issue mutations | — |
-

--- a/spec/charter.md
+++ b/spec/charter.md
@@ -1,6 +1,6 @@
 ---
-last_amended: 2026-07-28
-revision: 11
+last_amended: 2026-07-31
+revision: 12
 ---
 
 # dev-backlog Charter
@@ -13,35 +13,38 @@ in-flight delegation status leak out of the selected task tracker; continuity
 across sessions is rebuilt from scratch each time.
 
 ## Approach           <!-- Tier 1 · Direction (human-gated) -->
-Select exactly one configured tracker adapter as the canonical task spec for a
-repository; add a thin, explicit, markdown-only execution hub (the active
-sprint file) that humans and agents both read and update. GitHub remains the
-compatibility baseline, while local task files are the first alternative
-canonical store. Companion skill `backlog-triage` grooms supported tracker
-state — it never creates a parallel task truth. The spec axis
+Use GitHub Issues as the sole task-definition and lifecycle authority. Simple
+Issue → PR work needs no sprint. When dependency, delegation, cross-session
+context, or parallel-track complexity requires execution continuity, add one
+thin, explicit, markdown-only sprint file that humans and agents both read and
+update. Companion skill `backlog-triage` grooms GitHub state — it never creates
+a parallel task truth. The spec axis
 (`spec/charter.md`, `spec/system-map.md`, `spec/capabilities.md`) is authored by
 craftkit's `spec-charter`/`spec-system-map`/`spec-grill` skills and consumed
 here as read-only yardsticks.
 No server, no daemon, no hidden state, no silent sync.
 
 ## Non-Goals          <!-- Tier 1 · Direction (human-gated) -->
-- A universal or multi-master issue tracker — one configured adapter owns task truth; dev-backlog does not synchronize canonical stores.
+- A universal, pluggable, or multi-master issue tracker — GitHub Issues own task truth; dev-backlog does not synchronize canonical stores.
 - A database, server, or background daemon — Markdown + bash + node built-ins only; no mystery state.
 - A lifecycle-owning workflow engine (Fractal / gsd-2 style) — those conflict with the tracker-anchored model; their patterns are absorbed, never integrated.
 - Silent background sync — every pull and push is an explicit user action.
 - A knowledge base / wiki replacement — `spec/charter.md` is a yardstick, `_context.md` is rediscovery-prone HOW-knowledge, neither is a long-form doc store.
-- Broad SaaS connector proliferation (Jira, Linear, Notion) — out of scope; only explicitly supported forge/local adapters belong to the product boundary.
+- Broad SaaS connector proliferation (Jira, Linear, Notion) or new tracker adapters — out of scope.
 - Backlog.md convention-following — the task-file format stays Backlog.md-compatible, but new features are not constrained by Backlog.md conventions.
+- Dual-write state or automatic memory writes — mirrors, Projects, indexes, and summaries are projections and never become independent write targets.
+- Hard Relay, Matt Pocock skill, GitHub Projects, or Backlog.md dependencies — each may be used optionally without entering the core path.
 
 ## Objectives         <!-- Tier 2 · Predicates (add/remove human-gated; status: active → implemented → validated, proof-gated) -->
-- O1 [validated] Claude Code, Codex, and humans read the same active sprint file as the single execution state · src: user (adoption 2026-07-27: 146 sprints across 17 repos other than this one)
+- O1 [validated] For complex work admitted to a sprint, Claude Code, Codex, and humans read the same active sprint file as the single execution-continuity state · src: user (adoption 2026-07-27: 146 sprints across 17 repos other than this one)
 - O3 [active]    A user can answer "is this project still on track?" in under 5 minutes against a stable per-project reference axis (`spec/charter.md`) · src: user
 - O4 [validated] Open-issue drift (orphan work, neglected objectives, contradictions) is detectable without manual triage · src: user (proof: backlog-doctor PR #226 + sprint-close signal PR #229; live automatic catches 2026-07-03/04 — deferred-O5 objective reference at sprint open, unmoored `[~]` signals at close; adoption 2026-07-27: `backlog/triage/` reports in 7 repos other than this one)
 - O5 [validated] Closing a sprint runs `backlog-doctor`; when doctor emits warnings or 3+ sprints have closed since the last dated reassess report (`backlog/triage/YYYY-MM-DD-reassess.md`), the close summary recommends `spec-charter reassess`. Report-only: unattended sessions may run reassess but never amend · src: user (proof: first full cycle 2026-07-04 — close signal → `backlog/triage/2026-07-04-reassess.md` → human-gated amend revision 5; adoption 2026-07-27: dated reassess reports in 3 repos other than this one — survival-alpha, beopsuny-skill, aibris)
 - O6 [deferred]  `/goal` completion-condition auto-emission from `spec/charter.md` + active sprint — deferred to a follow-up spec
 - O7 [validated] A repo with no craftkit and no `spec/` files can complete a full sprint cycle from this bundle alone, with no dangling cross-repo spec pointers · src: user (proof: adoption-hardening milestone #12 closed 14/14 on 2026-07-07; PRD §8 candidate measured by V1 cold-adopter gates; adoption 2026-07-27: 10 repos run sprints with no `spec/` axis at all, up to 15 sprints each)
-- O8 [implemented] The same core sprint cycle is proven on both `github` and `local`, while GitHub's existing task, milestone, and closing-link behavior remains backward compatible · src: user (proof: GitHub seam PR #286 + local lifecycle PR #298 + table-driven dual-mode acceptance and compatibility proof PR #303; adoption: **not expected** — `local` exists to prove the seam admits a non-GitHub adapter, that proof is delivered, and user adoption of `local` is not a goal of this objective. The generalization direction is carried by the seam and its ≤200-line translator budget, not by `local` gaining users)
-- O9 [implemented] Exactly one configured tracker adapter owns canonical task truth per repository; runtime never silently changes the selected tracker · src: user (proof: configured-only resolver PR #282 + canonical local store PR #298 + persisted immutable setup PR #301 + no-switch/error proof PR #303; adoption 2026-07-27: none — 0 of 17 other repos set a non-default tracker)
+- O8 [implemented] Historical proof: the same core sprint cycle was demonstrated on `github` and `local` without silent switching. Retained so completed sprint references remain resolvable; superseded as product direction by O10 on 2026-07-31 · src: user (proof: PRs #286/#298/#303; adoption premise absent: all 18 known consumers had a GitHub remote)
+- O9 [implemented] Historical proof: exactly one configured adapter owned task truth during the tracker-seam phase. Retained so completed sprint references remain resolvable; superseded as product direction by O10 on 2026-07-31 · src: user (proof: PRs #282/#298/#301/#303; adoption 2026-07-27: 0 of 17 other repos selected a non-default tracker)
+- O10 [active] GitHub Issues are the standalone task-definition and lifecycle authority; simple Issue → PR work is sprint-free, while complex work preserves continuity in one admitted sprint without task mirrors, dual writes, or required ecosystem integrations · src: user (adoption evidence 2026-07-27: 0 of 17 other consumer repos selected a non-default tracker; 2026-07-28: all 18 known consumer repos had a GitHub remote)
 
 ## Decisions          <!-- Tier 3 · History (immutable, append-only) -->
 | date       | decision                                                                              | rationale                                                                                        | supersedes |
@@ -60,3 +63,5 @@ No server, no daemon, no hidden state, no silent sync.
 | 2026-07-11 | Exactly one configured tracker adapter owns task truth per repository; initial adapters are `github` and `local`, with GitHub as the compatibility baseline | Migration must stage task-ID and `gh` coupling behind a compatibility-preserving seam; capability-gated extensions prevent a lowest-common-denominator interface, while single ownership prevents multi-master sync | — |
 | 2026-07-27 | Objective status splits `implemented` (producer-side proof) from `validated` (cited use outside this repo); O8 and O9 move to `implemented` | measured 2026-07-27 across 17 other repos consuming dev-backlog: `local` has 0 adopters and 0 set a non-default tracker, yet both objectives read `validated` on merged-PR proof while v0.9.0 was deleting 2,556 lines from one of those axes for being built at the wrong size. Vocabulary defined by craftkit `spec-charter` (craftkit#165) | — |
 | 2026-07-28 | O8 stays `[implemented]` by design: `local` proved the seam admits a non-GitHub adapter, and user adoption of `local` is not a goal of O8 | measured 2026-07-28: all 18 repos consuming dev-backlog have a GitHub remote, so `local`'s premise has zero instances and O8 cannot reach `[validated]` by waiting. Restating the objective's purpose is honest; manufacturing an adopter or deleting a working adapter is not. O8's predicate also drops `mirror` and `progress` because #340 deleted that behavior — that is removing a reference to deleted code, **not** weakening a predicate so its proof looks sufficient | — |
+| 2026-07-31 | GitHub Issues become the sole task-definition/lifecycle authority; sprints are admitted by execution complexity, while tracker generalization and task mirrors leave the target product boundary | measured adoption found 0 of 17 consumers selecting a non-default tracker and all 18 known consumers on GitHub; preserving unused generality would prolong dual-state and compatibility cost without user evidence. O8/O9 cease to direct product work but remain implemented historical IDs so completed sprint references still resolve | 2026-07-11 configured-tracker direction; 2026-07-28 O8 retention |
+| 2026-07-31 | Relay, Matt Pocock skills, GitHub Projects, Backlog.md compatibility, and retrieval/memory experiments remain optional projections or techniques | the standalone Issue → PR and complex-sprint paths must survive without ecosystem dependencies; projections cannot acquire write authority, and memory requires a separate measured gate | — |

--- a/spec/charter.md
+++ b/spec/charter.md
@@ -16,8 +16,8 @@ across sessions is rebuilt from scratch each time.
 Use GitHub Issues as the sole task-definition and lifecycle authority. Simple
 Issue → PR work needs no sprint. When dependency, delegation, cross-session
 context, or parallel-track complexity requires execution continuity, add one
-thin, explicit, markdown-only sprint file that humans and agents both read and
-update. Companion skill `backlog-triage` grooms GitHub state — it never creates
+thin, explicit, markdown-only sprint file per admitted track that humans and
+agents both read and update. Companion skill `backlog-triage` grooms GitHub state — it never creates
 a parallel task truth. The spec axis
 (`spec/charter.md`, `spec/system-map.md`, `spec/capabilities.md`) is authored by
 craftkit's `spec-charter`/`spec-system-map`/`spec-grill` skills and consumed
@@ -44,7 +44,7 @@ No server, no daemon, no hidden state, no silent sync.
 - O7 [validated] A repo with no craftkit and no `spec/` files can complete a full sprint cycle from this bundle alone, with no dangling cross-repo spec pointers · src: user (proof: adoption-hardening milestone #12 closed 14/14 on 2026-07-07; PRD §8 candidate measured by V1 cold-adopter gates; adoption 2026-07-27: 10 repos run sprints with no `spec/` axis at all, up to 15 sprints each)
 - O8 [implemented] Historical proof: the same core sprint cycle was demonstrated on `github` and `local` without silent switching. Retained so completed sprint references remain resolvable; superseded as product direction by O10 on 2026-07-31 · src: user (proof: PRs #286/#298/#303; adoption premise absent: all 18 known consumers had a GitHub remote)
 - O9 [implemented] Historical proof: exactly one configured adapter owned task truth during the tracker-seam phase. Retained so completed sprint references remain resolvable; superseded as product direction by O10 on 2026-07-31 · src: user (proof: PRs #282/#298/#301/#303; adoption 2026-07-27: 0 of 17 other repos selected a non-default tracker)
-- O10 [active] GitHub Issues are the standalone task-definition and lifecycle authority; simple Issue → PR work is sprint-free, while complex work preserves continuity in one admitted sprint without task mirrors, dual writes, or required ecosystem integrations · src: user (adoption evidence 2026-07-27: 0 of 17 other consumer repos selected a non-default tracker; 2026-07-28: all 18 known consumer repos had a GitHub remote)
+- O10 [active] GitHub Issues are the standalone task-definition and lifecycle authority; simple Issue → PR work is sprint-free, while complex work preserves continuity in one admitted sprint per track without task mirrors, dual writes, or required ecosystem integrations · src: user (adoption evidence 2026-07-27: 0 of 17 other consumer repos selected a non-default tracker; 2026-07-28: all 18 known consumer repos had a GitHub remote)
 
 ## Decisions          <!-- Tier 3 · History (immutable, append-only) -->
 | date       | decision                                                                              | rationale                                                                                        | supersedes |

--- a/spec/system-map.md
+++ b/spec/system-map.md
@@ -2,9 +2,27 @@
 
 ## System Shape
 
-dev-backlog is a skill suite plus deterministic Node/Bash helpers. One
-configuration value selects canonical task truth; sprint Markdown remains the
-shared execution hub in both modes.
+dev-backlog is a skill suite plus deterministic Node/Bash helpers. The target
+core reads task definition and lifecycle from GitHub Issues. Sprint Markdown is
+created only for complex execution continuity; optional projections never
+accept independent writes.
+
+```text
+GitHub Issue (task spec + lifecycle + native planning fields)
+        |
+        +-- simple work ----------------------> implementation -> PR -> close
+        |
+        `-- complexity admission -> one active sprint file per track
+                                      +-> Plan / Running Context / Progress
+                                      `-> explicit status/doctor projections
+
+spec/* (human-gated durable decisions)
+GitHub repository history (historical evidence)
+retrieval / Projects / Relay / Backlog.md (optional, non-authoritative)
+```
+
+The following is the transition implementation shape, retained while the live
+resolver, mirrorless pilot, and compatibility subtraction land:
 
 ```text
 backlog/.tracker
@@ -29,9 +47,16 @@ backlog/sprints/ (canonical execution hub)
 GitHub, without runtime mutation. Setup migrates the resolved legacy choice
 without editing `config.yml`. Availability failure is never a selection
 mechanism, and runtime never probes or falls back to the other adapter.
+These compatibility paths are frozen; they do not alter the target authority
+contract.
 
 ## Runtime Boundaries
 
+- GitHub Issues own task specification, native planning metadata, and
+  lifecycle. The full sole-owner table lives in
+  [`../skills/dev-backlog/references/authority-contract.md`](../skills/dev-backlog/references/authority-contract.md).
+- Sprint files own only admitted complex execution state. Simple Issue → PR
+  work has no separate sprint state.
 - `skills/dev-backlog/scripts/tracker.js` owns configured resolution, the exact seven-operation adapter contract, identity validation, capability discovery/gating, and the shared unsupported-capability error/serializer.
 - `github-tracker.js` owns required GitHub task lifecycle argv/translation. Named GitHub modules own milestones, PR relationships, comments, and other optional transports.
 - `local-tracker.js` owns the canonical local JSON lifecycle and its one-way Markdown projection. It reports no optional provider capabilities and never invokes `gh`.
@@ -45,33 +70,36 @@ are single-sourced in [`docs/tracker-adapter-design.md`](../docs/tracker-adapter
 
 ## Core Flows
 
-1. **Setup:** create minimum directories and persist exactly one tracker; never migrate task files.
-2. **Create/read/update/close:** call the configured adapter's required lifecycle and carry normalized `{ tracker, id, ref, url? }` identity.
-3. **Materialize:** GitHub mode explicitly mirrors canonical issues through `sync-pull.js`; local mutations project the canonical JSON store into the same Markdown shape without provider sync.
-4. **Plan/orient:** write normalized refs into the active track's sprint file; consume state via `status.sh --json` / `next.sh --json` (`--track` selects among multiple disjoint-scope tracks).
-5. **Complete:** close the canonical task, check the Plan, run `sprint-close.sh` (`--track` when multiple tracks are active), archive remaining checked task files, and retain sprint history.
-6. **Publish/enrich:** milestones, PR relationships, comments, and closing semantics run only when reported. Unsupported requests return the shared typed error before effects.
-7. **Groom/spec:** triage stays advisory by default; doctor/reassess may recommend spec work but do not mutate durable specs automatically.
+1. **Resolve:** read the live GitHub Issue as task specification and lifecycle authority.
+2. **Admit:** keep self-contained Issue → PR work sprint-free; create a sprint only for ordered multi-Issue batches, delegated/parallel handoff, cross-Issue/session context, or concurrent-track coordination.
+3. **Execute:** when admitted, update one track's Plan, Running Context, and Progress at explicit boundaries; task acceptance and lifecycle remain on the Issue.
+4. **Complete:** merge the PR, close/update the Issue, and close any admitted sprint while retaining its committed history.
+5. **Project/retrieve:** Projects, Relay artifacts, mirrors, indexes, and summaries remain optional views that identify their upstream authority and never receive automatic state writes.
+6. **Groom/spec:** triage stays advisory by default; doctor/reassess may recommend human-gated spec work but do not mutate durable specs automatically.
 
 ## Storage And External Systems
 
-- `backlog/.tracker`: the tracker-selection authority.
-- `backlog/config.yml`: Backlog.md settings plus read-only legacy selection fallback.
-- GitHub Issues: canonical task truth only when `.tracker` selects `github`.
-- `backlog/local-tracker.json`: canonical task truth only when `.tracker` selects `local`.
-- `backlog/tasks/` and `backlog/completed/`: derived task mirrors in both tracker modes.
-- `backlog/sprints/`: canonical execution state in both modes, committed at explicit boundaries.
+- GitHub Issues: sole task-definition, native planning metadata, and lifecycle authority.
+- `backlog/sprints/`: admitted complex execution state, committed at explicit boundaries.
+- `spec/*`: human-gated durable project, system, and capability decisions.
+- GitHub repository history: original historical evidence.
+- `backlog/.tracker`, `backlog/config.yml`, and `backlog/local-tracker.json`: frozen transition compatibility.
+- `backlog/tasks/` and `backlog/completed/`: non-authoritative transition projections.
 - `gh`: GitHub-mode bridge only; acceptance tests replace it with an argv recorder and local tests trap it.
 - Git: versioned Markdown, scripts, and durable specs.
 
 ## Project-Wide Invariants
 
-- Exactly one configured adapter owns canonical task truth; no runtime fallback, co-authority, or background sync.
+- GitHub Issues own task truth; no runtime fallback, co-authority, dual write, or background sync.
 - Existing tracker-less repositories remain GitHub-backed with zero migration and unchanged `#N`, numeric aliases, task-mirror bytes, argv, milestones, comments, and closing behavior.
-- Local mode implements only the core task lifecycle. It never fabricates provider semantics or URLs.
+- Local compatibility is frozen pending staged retirement. It never fabricates provider semantics or URLs.
 - Unsupported optional capabilities have stable code `TRACKER_CAPABILITY_UNSUPPORTED`, tracker, capability, message, and remediation; JSON and human boundaries share that one serializer contract.
-- Sprint files remain the execution hub and completed sprint files are immutable history.
+- A sprint is triggered by execution complexity, never duration alone; the
+  no-spec/no-Relay cold-adopter paths work both sprint-free and, when admitted,
+  through a complete sprint cycle.
+- Completed sprint files are immutable history.
 - Automation is report-only toward `spec/*`; `spec/charter.md` is canonical and root `CHARTER.md` is legacy fallback only.
+- Retrieval and memory output is disposable, source-attributed, and never written automatically to an authority.
 - Helpers run on POSIX and Git-for-Windows Bash; native filesystem paths stay internal while stable serialized fields normalize to `/`; atomic-store replacement coverage runs without platform skips.
 
 ## Executable Evidence
@@ -80,22 +108,23 @@ are single-sourced in [`docs/tracker-adapter-design.md`](../docs/tracker-adapter
 cycles with real temporary files and subprocesses, no network, exact GitHub
 compatibility evidence, local zero-provider evidence, body-preserving updates,
 Done archive/final reads, and every optional-capability failure shape. This
-implementation proof merged as PR #303 (2026-07-12); O8 and O9 are validated
-(`charter.md:43-44`).
+implementation proof merged as PR #303 (2026-07-12). It is transition evidence,
+not a current objective or a reason to expand generic tracker compatibility.
 
 ## Accepted Capability Contracts
 
 - `sprint-execution` — plan state, context, progress, and active/completed sprint invariants.
-- `tracker-task-truth` — configured ownership, normalized lifecycle/identity, capability discovery, and deterministic degradation.
-- `backlog-sync` — explicit materialization/publication without overwriting human-authored content.
+- `tracker-task-truth` — live GitHub Issue ownership and lifecycle, with frozen transition compatibility.
+- `backlog-sync` — safe, non-authoritative transition projection pending retirement.
 - `triage-grooming` — advisory classification, relationships, stale signals, Alignment, and Decision Review.
 
-## Open Boundary Questions
+## Optional Boundaries
 
-GitLab, Gitea, and Forgejo remain future candidates after the merged
-`github`/`local` proof. They must fit the same authority and capability rules;
-the current interface does not promise generic provider parity or a published
-tracker-neutral shape.
+Relay, Matt Pocock skills, GitHub Projects, Backlog.md, and retrieval/memory
+experiments may assist execution or present projections. None is required by
+the Issue → PR or complex-sprint path, none owns product state, and no new
+tracker adapter or committed memory/compiler work is admitted during this
+milestone.
 
 ## Where To Go Next
 

--- a/spec/system-map.md
+++ b/spec/system-map.md
@@ -93,6 +93,7 @@ are single-sourced in [`docs/tracker-adapter-design.md`](../docs/tracker-adapter
 - GitHub Issues own task truth; no runtime fallback, co-authority, dual write, or background sync.
 - Existing tracker-less repositories remain GitHub-backed with zero migration and unchanged `#N`, numeric aliases, task-mirror bytes, argv, milestones, comments, and closing behavior.
 - Local compatibility is frozen pending staged retirement. It never fabricates provider semantics or URLs.
+- Task projections are diagnostic/export material only. A failed live Issue read stops execution; stale projection bytes cannot authorize task work or lifecycle changes.
 - Unsupported optional capabilities have stable code `TRACKER_CAPABILITY_UNSUPPORTED`, tracker, capability, message, and remediation; JSON and human boundaries share that one serializer contract.
 - A sprint is triggered by execution complexity, never duration alone; the
   no-spec/no-Relay cold-adopter paths work both sprint-free and, when admitted,


### PR DESCRIPTION
## Summary

- define one GitHub-native authority/routing table for seven state classes
- make simple Issue → PR work sprint-free and admit sprints by execution complexity
- freeze dual writes, automatic memory writes, new tracker adapters, and mirror expansion
- keep Relay, Matt Pocock skills, GitHub Projects, and Backlog.md optional
- preserve no-spec/no-Relay cold-adopter behavior and historical O8/O9 references

## Verification

- `node --test skills/dev-backlog/scripts/*.test.js`
- `bash skills/dev-backlog/scripts/smoke-test.sh`
- `node skills/dev-backlog/scripts/backlog-doctor.js --json backlog`
- `git diff --check`

Fixes #345


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서**
  - 작업 정의와 상태 관리의 기준을 GitHub Issues로 통일했습니다.
  - 단순 작업은 Issue → PR 흐름으로 처리하고, 복잡한 작업에만 스프린트를 사용하도록 안내를 정비했습니다.
  - 기존 로컬 작업 목록과 미러는 마이그레이션 기간의 읽기 전용 호환 경로로 제한했습니다.
  - 스펙, 시스템 구조, 권한 및 통합 경계를 최신 운영 방식에 맞게 갱신했습니다.
  - 도구나 별도 저장소 없이도 작업을 시작하고 완료할 수 있는 안내를 추가했습니다.

- **테스트**
  - 작업 권한 라우팅과 스프린트 사용 규칙을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->