### PR TITLE
docs: point spec-axis mutations at spec-charter map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Each entry links the GitHub issue (the canonical spec) and the merge PR (the shi
 
 ### Changed
 
+- **Route spec-axis mutations through craftkit 0.4.0 skill names** — `spec-charter` owns `spec/charter.md` and `spec/system-map.md` (`map` mode); `spec-grill` owns `spec/capabilities.md`. Alignment reports use `uncovered objective` for missing coverage.
 - **Current-product docs** — SKILL.md / CLAUDE.md / process.md describe the GitHub + sprint loop instead of the subtraction history; `file-format.md` is sprint-first; `github-sync.md` no longer shows `gh issue create --json` or `backlog/tasks/draft.md`; `_context.md` drops other-repo harness gotchas. Closes [#380](https://github.com/sungjunlee/dev-backlog/issues/380).
 - **README right-sized to a personal-toolkit quick start** — install, the default Issue → PR loop, and when to open a sprint. Drops the subtraction-proof / upgrade-history / multi-track tutorial surface. Closes [#369](https://github.com/sungjunlee/dev-backlog/issues/369).
 - **Spec axis compacted for a second start** — charter rev 16 keeps O10, O1 (shared state, not sprint count), and O4; O3 and O5 retire to `docs/spec-history.md`. Decisions record personal-toolkit posture, the #350 no-go, and a freeze on leftover compatibility runtime. Living capability Decisions drop local-tracker history; `docs/spec-system-design.md` is Removed. Human gate: 2026-08-17 second-start direction. Closes [#379](https://github.com/sungjunlee/dev-backlog/issues/379).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,10 +22,10 @@ skills/
     scripts/               ← Deterministic helpers (node + bash)
 ```
 
-The `spec-charter`, `spec-system-map`, and `spec-grill` authoring skills live
-in [craftkit](https://github.com/sungjunlee/craftkit); this repo consumes
+The `spec-charter` and `spec-grill` authoring skills live in
+[craftkit](https://github.com/sungjunlee/craftkit); this repo consumes
 `spec/charter.md`, `spec/system-map.md`, and `spec/capabilities.md` and does
-not ship those skills.
+not ship those skills. `spec-charter` owns the charter and the system map.
 
 ## Key Design Decisions
 

--- a/skills/backlog-triage/SKILL.md
+++ b/skills/backlog-triage/SKILL.md
@@ -72,7 +72,7 @@ Required sections:
 - `## Obsolete Candidates` — anchored close/revisit proposals with evidence.
 - `## Priority Proposals` — model-judged anchored priority proposals with rationale (delivered via `--model-actions`).
 - `## Milestone Suggestions` — model-judged anchored milestone proposals grouped into candidate sprint clusters (delivered via `--model-actions`).
-- `## Alignment` — objective coverage, orphan work, neglected objectives, contradictions, and proposed charter changes; when no charter exists, record that alignment was skipped.
+- `## Alignment` — objective coverage, orphan work, uncovered objectives, contradictions, and proposed charter changes; when no charter exists, record that alignment was skipped.
 - `## Decision Review` — `Do Now`, `Shape First`, `Defer`, and `Drop / Close`.
 - `## Apply Checklist` — consolidated review surface for every anchored action.
 
@@ -89,7 +89,7 @@ Full section examples and rubric details live in `references/classification.md`,
 | AC checkboxes inside issue bodies (`AC:BEGIN` / `AC:END`) | `dev-backlog` |
 | Open-issue classification, relationships, stale flags | `backlog-triage` |
 | Charter alignment of open issues | `backlog-triage` report; mutations route to `spec-charter` |
-| Capability/system-map concerns | `backlog-triage` report; mutations route to `spec-grill` or `spec-system-map` |
+| Capability/system-map concerns | `backlog-triage` report; mutations route to `spec-grill` or `spec-charter` (`map`) |
 | Priority/milestone proposals and accepted mutations | `backlog-triage` |
 | Post-triage sprint planning | `dev-backlog` |
 

--- a/skills/dev-backlog/SKILL.md
+++ b/skills/dev-backlog/SKILL.md
@@ -31,7 +31,7 @@ If `backlog/` does not exist, run `scripts/setup-dev-backlog.js --tracker
 github --non-interactive`; see `references/file-format.md`. Never infer a
 tracker from availability.
 
-Related skills (none required for either core cycle): when installed, `spec-charter` (`spec/charter.md`), `spec-system-map` (`spec/system-map.md`), and `spec-grill` (`spec/capabilities.md`) ship with craftkit (`npx skills add sungjunlee/craftkit`) and supply the optional spec axis; [`backlog-triage`](../backlog-triage/SKILL.md) provides advisory backlog review before sprint planning. Degradation when they are absent is specified in `references/spec-fallback.md`.
+Related skills (none required for either core cycle): when installed, `spec-charter` (`spec/charter.md` and `spec/system-map.md`) and `spec-grill` (`spec/capabilities.md`) ship with craftkit (`npx skills add sungjunlee/craftkit`) and supply the optional spec axis; [`backlog-triage`](../backlog-triage/SKILL.md) provides advisory backlog review before sprint planning. Degradation when they are absent is specified in `references/spec-fallback.md`.
 
 The state ownership, compatibility, and optional-integration boundary
 are single-sourced in [`references/authority-contract.md`](references/authority-contract.md).

--- a/spec/README.md
+++ b/spec/README.md
@@ -9,9 +9,10 @@ and git.
 | [`system-map.md`](system-map.md) | Current system shape and invariants. |
 | [`capabilities.md`](capabilities.md) | Per-capability Goal, scope, behaviors, constraints. |
 
-Authoring skills (`spec-charter`, `spec-system-map`, `spec-grill`) live in
-[craftkit](https://github.com/sungjunlee/craftkit). This repo consumes the
-files; it does not ship the skills.
+Authoring skills (`spec-charter`, `spec-grill`) live in
+[craftkit](https://github.com/sungjunlee/craftkit). `spec-charter` owns
+`spec/charter.md` and `spec/system-map.md`. This repo consumes the files; it
+does not ship the skills.
 
 ## Mutation
 


### PR DESCRIPTION
## Summary
- CraftKit 0.4.0 absorbed `spec-system-map` into `spec-charter` `map` mode.
- Live skill spines, `spec/README.md`, and CLAUDE.md now name the two remaining authoring skills and route system-map mutations to `spec-charter`.
- Alignment report wording matches craftkit's `uncovered objective` finding. Historical sprints and CHANGELOG entries are unchanged.

## Test plan
- [x] Grep live `skills/` and `spec/README.md` for `spec-system-map` — only historical records should remain
- [x] Confirm `AGENTS.md` still follows `CLAUDE.md`


Made with [Cursor](https://cursor.com)