### PR TITLE
test: add fail-loud GitHub resilience matrix and operator runbook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ here.
 | File | What it records | Referenced by |
 | --- | --- | --- |
 | [`conformance/`](conformance/) | Dated cross-model conformance runs for prompt-judged surfaces (#367); retention rule in its README. | `conformance/README.md`, #367 |
+| [`github-resilience.md`](github-resilience.md) | `gh` call inventory, fail-loud failure matrix, and operator runbook (#366). | #366 |
 
 ## Removed
 

--- a/docs/github-resilience.md
+++ b/docs/github-resilience.md
@@ -1,0 +1,51 @@
+# GitHub resilience
+
+Living operator contract for fail-loud `gh` paths. This is not a retry
+policy: GitHub remains the only authority, and a failed call must not
+write partial tracker or triage state.
+
+## Call inventory
+
+Counts below are the `gh` argv sequences already locked by the fake-`gh`
+acceptance harness, plus the collect/apply transports in
+`skills/backlog-triage/scripts/`.
+
+| Class | Typical `gh` calls | Source |
+| --- | --- | --- |
+| work (create / read / update / close / list) | 7 in a full cycle: `issue create`, `issue list` (open), `issue view`, `issue edit`, `issue list` (open, after update), `issue close`, `issue list` (closed) + a final `issue view` | `runGithubCycle` in `tracker-cycle.acceptance.test.js` |
+| orient (`status --json` / `next --json`) | 0 extra `gh` calls when the active sprint file already names `#N`; live reads happen in the work class | `status.sh` / `next.sh` read sprint files |
+| sprint init | 2: `api repos/{owner}/{repo}/milestones` (due_on) + `issue list --milestone` | `sprint-init.js` + `github-milestones.js` |
+| sprint close (`--close-milestone`) | 2: `api` milestone number + `api -X PATCH` close | `sprint-close.sh` |
+| triage collect | 1 GraphQL `api graphql` for open issues (plus `--paginate` when the limit exceeds one page). Optional: 1 `api repos/.../issues/N/comments --paginate` per issue when `--with-comments`. Optional: 1 GraphQL search for closed issues | `triage-collect.js` |
+| triage apply | 1 `issue view --json labels` when priority labels must be read, then 1 mutation per action (`issue edit` / `issue comment` / `issue close`). No automatic retry | `triage-apply.js` |
+
+A happy-path GitHub tracker cycle therefore makes **12** `gh` calls
+(7 work + 2 sprint init + 2 sprint close + 1 extra work list/view pair
+already counted in the cycle assertion).
+
+## Failure-mode matrix
+
+The fake-`gh` fixture (`fake-gh.js`) accepts `FAKE_GH_FAIL`:
+
+| Mode | `gh` behavior | Required outcome |
+| --- | --- | --- |
+| `rate-limit` | exit 1, stderr `API rate limit exceeded` | Fail loud. No issue/milestone write. Exactly one attempt. |
+| `auth-expired` | exit 1, stderr `HTTP 401` + `authentication required` | Fail loud. No write. Exactly one attempt. |
+| `partial-outage` | reads (`issue list` / `issue view` / GET `api`) succeed; mutations (`issue create\|edit\|close\|comment`, `api -X`) exit 1 with `GitHub unavailable` | Mutations fail loud and write nothing. Reads stay effect-free. |
+
+No path gets automatic retry or backoff. The default remains: no silent
+retry, no fallback authority.
+
+## Operator runbook
+
+What you see is the `gh` stderr plus a non-zero process exit. Scripts do
+not rewrite GitHub after that failure.
+
+| Class | What to do | When to stop |
+| --- | --- | --- |
+| Rate limited | Wait until the reset window printed by `gh` / `X-RateLimit-Reset`. Re-run the **same** command once. Do not loop. | Still 403 after one manual retry, or the reset is hours away. Pause the session. |
+| Auth expired | `gh auth status`, then `gh auth login` or `gh auth refresh`. Re-run the same command once. | `gh auth status` still fails. Stop and fix credentials offline. |
+| Partial outage | Reads may still work. Do not apply triage or close issues until mutations succeed. Retry the failed mutation once after GitHub status recovers. | Mutations still fail after one retry. Leave the sprint/issue untouched. |
+
+Do not switch tracker, invent a local fallback, or re-enter a prompt that
+would create a second GitHub write for the same action.

--- a/skills/dev-backlog/scripts/fake-gh-fixture.js
+++ b/skills/dev-backlog/scripts/fake-gh-fixture.js
@@ -1,0 +1,46 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const FAKE_GH_SOURCE = path.join(__dirname, "fake-gh.js");
+
+function writeGhFixture(root) {
+  const binDir = path.join(root, "bin");
+  const statePath = path.join(root, "gh-state.json");
+  const logPath = path.join(root, "gh-argv.jsonl");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(statePath, JSON.stringify({
+    nextIssue: 42,
+    issues: [],
+    milestoneClosed: false,
+  }));
+  const ghPath = path.join(binDir, "gh");
+  fs.copyFileSync(FAKE_GH_SOURCE, ghPath);
+  fs.chmodSync(ghPath, 0o755);
+  if (process.platform === "win32") {
+    fs.writeFileSync(`${ghPath}.cmd`, `@echo off\r\n"${process.execPath}" "${ghPath}" %*\r\n`);
+  }
+  const preloadPath = path.join(root, "mock-gh-preload.cjs");
+  fs.writeFileSync(preloadPath, `
+const childProcess = require("node:child_process");
+const original = childProcess.execFileSync;
+childProcess.execFileSync = function (command, args, options) {
+  if (command === "gh") return original(process.execPath, [${JSON.stringify(ghPath)}, ...args], options);
+  return original(command, args, options);
+};
+`);
+  return {
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`,
+      NODE_OPTIONS: `--require=${preloadPath}`,
+      FAKE_GH_STATE: statePath,
+      FAKE_GH_LOG: logPath,
+    },
+    calls: () => fs.existsSync(logPath)
+      ? fs.readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean).map(JSON.parse)
+      : [],
+    state: () => JSON.parse(fs.readFileSync(statePath, "utf8")),
+  };
+}
+
+module.exports = { writeGhFixture };

--- a/skills/dev-backlog/scripts/fake-gh.js
+++ b/skills/dev-backlog/scripts/fake-gh.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+const fs = require("node:fs");
+
+const args = process.argv.slice(2);
+const statePath = process.env.FAKE_GH_STATE;
+const logPath = process.env.FAKE_GH_LOG;
+const failMode = process.env.FAKE_GH_FAIL || "";
+const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+fs.appendFileSync(logPath, JSON.stringify(args) + "\n");
+
+const save = () => fs.writeFileSync(statePath, JSON.stringify(state));
+const valueAfter = (flag) => args[args.indexOf(flag) + 1];
+const out = (value) => process.stdout.write(typeof value === "string" ? value : JSON.stringify(value));
+const exact = (expected) => JSON.stringify(args) === JSON.stringify(expected);
+const exactBodyCall = (head) =>
+  args.length === head.length + 2 &&
+  exact([...head, "--body", args[args.length - 1]]) &&
+  typeof args[args.length - 1] === "string";
+
+function isMutation(argv) {
+  if (argv[0] === "issue" && ["create", "edit", "close", "comment"].includes(argv[1])) {
+    return true;
+  }
+  return argv[0] === "api" && argv.includes("-X");
+}
+
+if (failMode === "rate-limit") {
+  process.stderr.write("API rate limit exceeded\n");
+  process.exit(1);
+}
+if (failMode === "auth-expired") {
+  process.stderr.write("HTTP 401: authentication required. Run gh auth login.\n");
+  process.exit(1);
+}
+if (failMode === "partial-outage" && isMutation(args)) {
+  process.stderr.write("GitHub unavailable\n");
+  process.exit(1);
+}
+
+if (exactBodyCall(["issue", "create", "--title", args[3]]) && args[3]) {
+  const title = valueAfter("--title");
+  const body = valueAfter("--body") || "";
+  const number = state.nextIssue++;
+  state.issues.push({
+    number, title, body, state: "open", url: "https://github.test/acme/widgets/issues/" + number,
+    labels: [{ name: "priority:high" }], milestone: { title: "Cycle Milestone" }, assignees: [],
+  });
+  save(); out("https://github.test/acme/widgets/issues/" + number + "\n");
+  process.exit(0);
+}
+
+if (args[0] === "issue" && args[1] === "list") {
+  if (exact(["issue", "list", "--milestone", "Cycle Milestone", "--state", "open", "--json", "number,title,labels"])) {
+    out(state.issues.filter((issue) => issue.state === "open").map(({ number, title, labels }) => ({ number, title, labels })));
+  } else if (exact(["issue", "list", "--state", "open", "--limit", "1", "--json", "number,title,body,labels,milestone,assignees"]) ||
+      exact(["issue", "list", "--state", "closed", "--limit", "20", "--json", "number,title,body,labels,milestone,assignees,createdAt,updatedAt"])) {
+    out(state.issues.filter((issue) => {
+      const requested = valueAfter("--state") || "open";
+      return requested === "all" || issue.state === requested;
+    }));
+  } else {
+    process.stderr.write("unhandled fake gh argv: " + JSON.stringify(args) + "\n"); process.exit(93);
+  }
+  process.exit(0);
+}
+
+if (exact(["issue", "view", "42", "--json", "number,title,body,labels,milestone,assignees,createdAt,updatedAt"]) ||
+    exact(["issue", "view", "42", "--json", "number,title,body,state,labels,milestone,assignees,createdAt,updatedAt,url"]) ||
+    exact(["issue", "view", "42", "--json", "number,title,body,state,labels,milestone,assignees,createdAt,updatedAt,url,comments"])) {
+  const issue = state.issues.find((candidate) => String(candidate.number) === args[2]);
+  if (!issue) process.exit(4);
+  out(issue); process.exit(0);
+}
+
+if (exact(["issue", "edit", "42", "--title", "Cycle task renamed"])) {
+  const number = Number(args[2]);
+  const issue = state.issues.find((candidate) => candidate.number === number);
+  if (issue) issue.title = valueAfter("--title");
+  save(); process.exit(0);
+}
+
+if (exact(["issue", "close", "42"])) {
+  const issue = state.issues.find((candidate) => String(candidate.number) === args[2]);
+  if (issue) issue.state = "closed";
+  save(); process.exit(0);
+}
+
+if (exact(["api", "repos/{owner}/{repo}/milestones", "--jq", ".[] | select(.title==env.MS) | .due_on"]) ||
+    exact(["api", "repos/{owner}/{repo}/milestones", "--jq", ".[] | select(.title==env.MS) | .number"])) {
+  const query = valueAfter("--jq");
+  out(query.includes("due_on") ? "2026-06-30T00:00:00Z\n" : "7\n");
+  process.exit(0);
+}
+if (exact(["api", "-X", "PATCH", "repos/{owner}/{repo}/milestones/7", "-f", "state=closed"])) {
+  state.milestoneClosed = true; save(); process.exit(0);
+}
+process.stderr.write("unhandled fake gh argv: " + JSON.stringify(args) + "\n");
+process.exit(93);

--- a/skills/dev-backlog/scripts/github-resilience.acceptance.test.js
+++ b/skills/dev-backlog/scripts/github-resilience.acceptance.test.js
@@ -1,0 +1,144 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const { writeGhFixture } = require("./fake-gh-fixture.js");
+
+const SCRIPTS_DIR = __dirname;
+const TRACKER_PATH = path.join(SCRIPTS_DIR, "tracker.js");
+const LIB_PATH = path.join(SCRIPTS_DIR, "lib.js");
+
+const FAIL_MODES = {
+  "rate-limit": /API rate limit exceeded/,
+  "auth-expired": /HTTP 401[\s\S]*authentication required/,
+};
+
+function makeRoot(t, prefix) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+
+function writeWorker(root) {
+  const worker = path.join(root, "tracker-worker.cjs");
+  fs.writeFileSync(worker, `
+const tracker = require(${JSON.stringify(TRACKER_PATH)});
+const [backlogDir, action, payload = "{}"] = process.argv.slice(2);
+const resolved = tracker.resolveConfiguredTracker(
+  require(${JSON.stringify(LIB_PATH)}).readConfig(backlogDir),
+  { backlogDir }
+);
+const input = JSON.parse(payload);
+let result;
+if (action === "list") result = resolved.adapter.list(input);
+else if (action === "read") result = resolved.adapter.read(input.selector);
+else if (action === "create") result = resolved.adapter.create(input);
+else if (action === "update") result = resolved.adapter.update(input.selector, input.changes);
+else if (action === "close") result = resolved.adapter.close(input.selector, input.options);
+else throw new Error("unknown worker action: " + action);
+process.stdout.write(JSON.stringify(result));
+`);
+  return worker;
+}
+
+function prepare(t) {
+  const root = makeRoot(t, "github-resilience-");
+  const backlogDir = path.join(root, "backlog");
+  fs.mkdirSync(path.join(backlogDir, "sprints"), { recursive: true });
+  fs.writeFileSync(path.join(backlogDir, ".tracker"), "github\n");
+  const gh = writeGhFixture(root);
+  return {
+    root,
+    backlogDir,
+    worker: writeWorker(root),
+    env: gh.env,
+    providerCalls: gh.calls,
+    providerState: gh.state,
+  };
+}
+
+function runWorker(fixture, action, payload = {}) {
+  return spawnSync(
+    process.execPath,
+    [fixture.worker, fixture.backlogDir, action, JSON.stringify(payload)],
+    { cwd: fixture.root, env: fixture.env, encoding: "utf8" },
+  );
+}
+
+function seedIssue(fixture) {
+  const created = runWorker(fixture, "create", { title: "Cycle task", body: "body" });
+  assert.equal(created.status, 0, created.stderr);
+  return created;
+}
+
+describe("GitHub resilience acceptance", () => {
+  for (const [mode, stderrPattern] of Object.entries(FAIL_MODES)) {
+    it(`${mode}: create fails loud once and writes no issue`, (t) => {
+      const fixture = prepare(t);
+      fixture.env.FAKE_GH_FAIL = mode;
+      const result = runWorker(fixture, "create", { title: "Cycle task", body: "body" });
+      assert.notEqual(result.status, 0);
+      assert.match(`${result.stderr}\n${result.stdout}`, stderrPattern);
+      assert.deepEqual(fixture.providerState().issues, []);
+      assert.equal(fixture.providerCalls().length, 1);
+    });
+
+    it(`${mode}: update and close fail loud once and leave seeded issue unchanged`, (t) => {
+      const fixture = prepare(t);
+      seedIssue(fixture);
+      const before = fixture.providerState();
+      fixture.env.FAKE_GH_FAIL = mode;
+
+      const updated = runWorker(fixture, "update", {
+        selector: "#42",
+        changes: { title: "Cycle task renamed" },
+      });
+      assert.notEqual(updated.status, 0);
+      assert.match(`${updated.stderr}\n${updated.stdout}`, stderrPattern);
+
+      const closed = runWorker(fixture, "close", { selector: "#42" });
+      assert.notEqual(closed.status, 0);
+      assert.match(`${closed.stderr}\n${closed.stdout}`, stderrPattern);
+
+      assert.deepEqual(fixture.providerState().issues, before.issues);
+      const mutating = fixture.providerCalls().slice(1);
+      assert.equal(mutating.length, 2);
+      assert.deepEqual(mutating[0].slice(0, 2), ["issue", "edit"]);
+      assert.deepEqual(mutating[1].slice(0, 2), ["issue", "close"]);
+    });
+  }
+
+  it("partial-outage: reads succeed, mutations fail once without writing", (t) => {
+    const fixture = prepare(t);
+    seedIssue(fixture);
+    fixture.env.FAKE_GH_FAIL = "partial-outage";
+
+    const listed = runWorker(fixture, "list", {
+      state: "open",
+      limit: 1,
+      fields: "number,title,body,labels,milestone,assignees",
+    });
+    assert.equal(listed.status, 0, listed.stderr);
+    assert.equal(JSON.parse(listed.stdout)[0].ref, "#42");
+
+    const viewed = runWorker(fixture, "read", { selector: "#42" });
+    assert.equal(viewed.status, 0, viewed.stderr);
+    assert.equal(JSON.parse(viewed.stdout).title, "Cycle task");
+
+    const before = fixture.providerState();
+    const created = runWorker(fixture, "create", { title: "Another", body: "nope" });
+    assert.notEqual(created.status, 0);
+    assert.match(`${created.stderr}\n${created.stdout}`, /GitHub unavailable/);
+    assert.deepEqual(fixture.providerState().issues, before.issues);
+
+    const mutationCalls = fixture.providerCalls().filter((args) => args[1] === "create");
+    assert.equal(mutationCalls.length, 2);
+    assert.equal(
+      fixture.providerCalls().filter((args) => args[1] === "create").length,
+      2,
+      "seed create + one failed create, no retry",
+    );
+  });
+});

--- a/skills/dev-backlog/scripts/tracker-cycle.acceptance.test.js
+++ b/skills/dev-backlog/scripts/tracker-cycle.acceptance.test.js
@@ -5,6 +5,7 @@ const os = require("node:os");
 const path = require("node:path");
 const { spawnSync } = require("node:child_process");
 const { resolveBashExecutable, toBashArgs } = require("./bash-runtime.js");
+const { writeGhFixture } = require("./fake-gh-fixture.js");
 
 const SCRIPTS_DIR = __dirname;
 const TRACKER_PATH = path.join(SCRIPTS_DIR, "tracker.js");
@@ -67,120 +68,6 @@ function runWorker(fixture, action, payload = {}) {
   );
 }
 
-function writeGhFixture(root) {
-  const binDir = path.join(root, "bin");
-  const statePath = path.join(root, "gh-state.json");
-  const logPath = path.join(root, "gh-argv.jsonl");
-  fs.mkdirSync(binDir, { recursive: true });
-  fs.writeFileSync(statePath, JSON.stringify({
-    nextIssue: 42,
-    issues: [],
-    milestoneClosed: false,
-  }));
-  const ghPath = path.join(binDir, "gh");
-  fs.writeFileSync(ghPath, `#!/usr/bin/env node
-const fs = require("node:fs");
-const args = process.argv.slice(2);
-const statePath = process.env.FAKE_GH_STATE;
-const logPath = process.env.FAKE_GH_LOG;
-const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
-fs.appendFileSync(logPath, JSON.stringify(args) + "\\n");
-const save = () => fs.writeFileSync(statePath, JSON.stringify(state));
-const valueAfter = (flag) => args[args.indexOf(flag) + 1];
-const out = (value) => process.stdout.write(typeof value === "string" ? value : JSON.stringify(value));
-const exact = (expected) => JSON.stringify(args) === JSON.stringify(expected);
-const exactBodyCall = (head) =>
-  args.length === head.length + 2 &&
-  exact([...head, "--body", args[args.length - 1]]) &&
-  typeof args[args.length - 1] === "string";
-
-if (exactBodyCall(["issue", "create", "--title", args[3]]) && args[3]) {
-  const title = valueAfter("--title");
-  const body = valueAfter("--body") || "";
-  const number = state.nextIssue++;
-  state.issues.push({
-    number, title, body, state: "open", url: "https://github.test/acme/widgets/issues/" + number,
-    labels: [{ name: "priority:high" }], milestone: { title: "Cycle Milestone" }, assignees: [],
-  });
-  save(); out("https://github.test/acme/widgets/issues/" + number + "\\n");
-  process.exit(0);
-}
-
-if (args[0] === "issue" && args[1] === "list") {
-  if (exact(["issue", "list", "--milestone", "Cycle Milestone", "--state", "open", "--json", "number,title,labels"])) {
-    out(state.issues.filter((issue) => issue.state === "open").map(({ number, title, labels }) => ({ number, title, labels })));
-  } else if (exact(["issue", "list", "--state", "open", "--limit", "1", "--json", "number,title,body,labels,milestone,assignees"]) ||
-      exact(["issue", "list", "--state", "closed", "--limit", "20", "--json", "number,title,body,labels,milestone,assignees,createdAt,updatedAt"])) {
-    out(state.issues.filter((issue) => {
-      const requested = valueAfter("--state") || "open";
-      return requested === "all" || issue.state === requested;
-    }));
-  } else {
-    process.stderr.write("unhandled fake gh argv: " + JSON.stringify(args) + "\\n"); process.exit(93);
-  }
-  process.exit(0);
-}
-
-if (exact(["issue", "view", "42", "--json", "number,title,body,labels,milestone,assignees,createdAt,updatedAt"]) ||
-    exact(["issue", "view", "42", "--json", "number,title,body,state,labels,milestone,assignees,createdAt,updatedAt,url"]) ||
-    exact(["issue", "view", "42", "--json", "number,title,body,state,labels,milestone,assignees,createdAt,updatedAt,url,comments"])) {
-  const issue = state.issues.find((candidate) => String(candidate.number) === args[2]);
-  if (!issue) process.exit(4);
-  out(issue); process.exit(0);
-}
-
-if (exact(["issue", "edit", "42", "--title", "Cycle task renamed"])) {
-  const number = Number(args[2]);
-  const issue = state.issues.find((candidate) => candidate.number === number);
-  if (issue) issue.title = valueAfter("--title");
-  save(); process.exit(0);
-}
-
-if (exact(["issue", "close", "42"])) {
-  const issue = state.issues.find((candidate) => String(candidate.number) === args[2]);
-  if (issue) issue.state = "closed";
-  save(); process.exit(0);
-}
-
-if (exact(["api", "repos/{owner}/{repo}/milestones", "--jq", '.[] | select(.title==env.MS) | .due_on']) ||
-    exact(["api", "repos/{owner}/{repo}/milestones", "--jq", '.[] | select(.title==env.MS) | .number'])) {
-  const query = valueAfter("--jq");
-  out(query.includes("due_on") ? "2026-06-30T00:00:00Z\\n" : "7\\n");
-  process.exit(0);
-}
-if (exact(["api", "-X", "PATCH", "repos/{owner}/{repo}/milestones/7", "-f", "state=closed"])) {
-  state.milestoneClosed = true; save(); process.exit(0);
-}
-process.stderr.write("unhandled fake gh argv: " + JSON.stringify(args) + "\\n");
-process.exit(93);
-`);
-  fs.chmodSync(ghPath, 0o755);
-  if (process.platform === "win32") {
-    fs.writeFileSync(`${ghPath}.cmd`, `@echo off\r\n"${process.execPath}" "${ghPath}" %*\r\n`);
-  }
-  const preloadPath = path.join(root, "mock-gh-preload.cjs");
-  fs.writeFileSync(preloadPath, `
-const childProcess = require("node:child_process");
-const original = childProcess.execFileSync;
-childProcess.execFileSync = function (command, args, options) {
-  if (command === "gh") return original(process.execPath, [${JSON.stringify(ghPath)}, ...args], options);
-  return original(command, args, options);
-};
-`);
-  return {
-    env: {
-      ...process.env,
-      PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`,
-      NODE_OPTIONS: `--require=${preloadPath}`,
-      FAKE_GH_STATE: statePath,
-      FAKE_GH_LOG: logPath,
-    },
-    calls: () => fs.existsSync(logPath)
-      ? fs.readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean).map(JSON.parse)
-      : [],
-    state: () => JSON.parse(fs.readFileSync(statePath, "utf8")),
-  };
-}
 
 function prepareGithub(t) {
   const root = makeRoot(t, "tracker-cycle-github-");


### PR DESCRIPTION
Closes #366.

- Inventory of `gh` calls per operation class
- Fake-`gh` `FAKE_GH_FAIL` modes: rate-limit, auth-expired, partial-outage
- Acceptance tests: fail loud, no write, exactly one attempt
- Operator runbook: manual retry only, no automatic backoff

## Test
- `node --test skills/*/scripts/*.test.js` — 500 pass / 1 skip
- `bash skills/dev-backlog/scripts/smoke-test.sh` — 190 pass