### PR TITLE
test: add fail-loud GitHub resilience matrix and operator runbook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ here.
 | File | What it records | Referenced by |
 | --- | --- | --- |
 | [`conformance/`](conformance/) | Dated cross-model conformance runs for prompt-judged surfaces (#367); retention rule in its README. | `conformance/README.md`, #367 |
+| [`github-resilience.md`](github-resilience.md) | Fail-loud GitHub contract (#366): gh call inventory by class, FAKE_GH_FAIL failure modes, operator runbook; decision — no automatic retry, no fallback authority. | #366 |
 
 ## Removed
 

--- a/docs/github-resilience.md
+++ b/docs/github-resilience.md
@@ -4,7 +4,7 @@ Decision (2026-08): **no automatic retry, no fallback authority.** When a `gh`
 call fails — rate limit, expired auth, partial outage — the calling script
 exits non-zero with the provider's stderr surfaced. Nothing silently retries
 and nothing falls back to another source of truth. The operator fixes GitHub
-access and re-runs the command; every command is idempotent enough to re-run.
+access and re-runs the command.
 
 ## gh call inventory
 
@@ -14,14 +14,25 @@ plus the code paths in `github-tracker.js`, `github-milestones.js`,
 
 ### Read class (allowed to keep working during a partial outage)
 
-| Call | Where | Purpose |
-| --- | --- | --- |
-| `gh issue list … --json …` | github-tracker.js `list` | plan/status/next/sync-pull reads |
-| `gh issue view <n> --json …` | github-tracker.js `read`; triage-apply label pre-read | single issue read |
-| `gh api repos/{owner}/{repo}/milestones --jq .due_on/.number` | github-milestones.js `getMilestoneDue` / `closeMilestone` | milestone lookup |
-| `gh api graphql … totalCount` | github-tracker.js `getOpenIssueCount` | default list limit |
-| `gh api graphql` paginated queries | triage-collect.js | snapshot collection (open/closed issues) |
-| `gh api repos/…/issues/<n>/comments` | triage-collect.js `fetchIssueComments` | optional comment hydration |
+| Call | Where | Purpose | gh calls per command run |
+| --- | --- | --- | --- |
+| `gh issue list … --json …` | github-tracker.js `list` | plan/status/next/sync-pull reads | 1 per list |
+| `gh issue view <n> --json …` | github-tracker.js `read`; triage-apply label pre-read | single issue read | 1 per read |
+| `gh api repos/{owner}/{repo}/milestones --jq .due_on` | github-milestones.js `getMilestoneDue` | milestone due-date lookup (sprint-init) | sprint-init total: **2** (due lookup + open-issue list) |
+| `gh api repos/{owner}/{repo}/milestones?state=all --jq '[.number, .state] | @tsv'` | github-milestones.js `closeMilestone` | milestone state lookup (sprint-close) | close-milestone total: **2**, or **1** when the milestone is already closed (lookup only, no PATCH) |
+| `gh api graphql … totalCount` | github-tracker.js `getOpenIssueCount` | default list limit | 1 when the default limit is used |
+| `gh api graphql` paginated queries | triage-collect.js | snapshot collection (open/closed issues) | ≥1 page each for open/closed |
+| `gh api repos/…/issues/<n>/comments` | triage-collect.js `fetchIssueComments` | optional comment hydration | 0–1 per issue |
+
+Per-command totals (healthy run, counted from source):
+
+| Command | gh calls |
+| --- | --- |
+| `sprint-init` | 2 (milestone due lookup + open-issue list) |
+| `sprint-close --close-milestone` | 2 — or 1 if the milestone is already closed (state=all lookup returns `closed`, no PATCH is issued) |
+| tracker create / update / close | 1 mutation each |
+| status list (`tracker-status-list.js`) | 1 (open-issue list) |
+| `triage-apply --apply` | 1 mutation per action (+1 optional view for label pre-reads) |
 
 ### Mutation class (fail loud, exactly once)
 
@@ -31,7 +42,7 @@ plus the code paths in `github-tracker.js`, `github-milestones.js`,
 | `gh issue edit <n> …` | github-tracker.js `update`; triage-apply `set-*` verbs | title/body/labels/milestone edits |
 | `gh issue close <n>` | github-tracker.js `close`; triage-apply `close-issue` | closing semantics |
 | `gh issue comment <n> --body` | comments capability consumers | progress comments |
-| `gh api -X PATCH repos/{owner}/{repo}/milestones/<n> -f state=closed` | sprint-close → `tracker-capability.js close-milestone` → github-milestones.js `closeMilestone` | milestone close |
+| `gh api -X PATCH repos/{owner}/{repo}/milestones/<n> -f state=closed` | sprint-close → `tracker-capability.js close-milestone` → github-milestones.js `closeMilestone` | milestone close (skipped when already closed) |
 
 Every mutation is issued **once**. A non-zero exit propagates as an exception
 (`execFileSync`) or shell failure; there is no retry loop anywhere in these
@@ -61,6 +72,7 @@ scripts.
 | `rate-limit` | every call exits 1, stderr `API rate limit exceeded`; no state write |
 | `auth-expired` | every call exits 1, stderr `HTTP 401` + `authentication required`; no state write |
 | `partial-outage` | reads (issue list/view, `api` without `-X`) succeed; mutations (create/edit/close/comment, `api -X`) exit 1 with `GitHub unavailable`; no state write |
+| `http-502` | every call exits 1, stderr `HTTP 502 Bad Gateway`; no state write |
 
 ## Operator runbook
 
@@ -75,8 +87,13 @@ When a dev-backlog command fails with a gh error:
    - `GitHub unavailable` (mutation only) — check
      [githubstatus.com](https://www.githubstatus.com/); read-only work may
      continue meanwhile.
-3. Fix access, then **re-run the same command**. Commands are safe to re-run:
-   failed mutations never wrote state, so there is nothing to roll back.
+3. Fix access, then **re-run the same command**. Failed mutations that never
+   wrote anything are safe to re-run: the fail-loud ordering guarantees no local
+   file or GitHub state changed before the failure. **Exception:**
+   `gh issue create` is NOT safe to blindly re-run — if the first call may have
+   succeeded server-side (e.g. the failure was in reading the response), a
+   re-run creates a duplicate issue; check GitHub first. Never wrap these
+   commands in retry loops.
 4. For sprint close specifically: after fixing access, re-run
    `bash scripts/sprint-close.sh <backlog-dir> --close-milestone`. The local
    sprint was never marked completed, so one clean run finishes both sides.

--- a/docs/github-resilience.md
+++ b/docs/github-resilience.md
@@ -1,0 +1,84 @@
+# GitHub Resilience — Fail-Loud Contract (#366)
+
+Decision (2026-08): **no automatic retry, no fallback authority.** When a `gh`
+call fails — rate limit, expired auth, partial outage — the calling script
+exits non-zero with the provider's stderr surfaced. Nothing silently retries
+and nothing falls back to another source of truth. The operator fixes GitHub
+access and re-runs the command; every command is idempotent enough to re-run.
+
+## gh call inventory
+
+Counted from `runGithubCycle` argv assertions (`tracker-cycle.acceptance.test.js`)
+plus the code paths in `github-tracker.js`, `github-milestones.js`,
+`sprint-init.js`, `sprint-close.sh`, and `backlog-triage/scripts/triage-{collect,apply}.js`.
+
+### Read class (allowed to keep working during a partial outage)
+
+| Call | Where | Purpose |
+| --- | --- | --- |
+| `gh issue list … --json …` | github-tracker.js `list` | plan/status/next/sync-pull reads |
+| `gh issue view <n> --json …` | github-tracker.js `read`; triage-apply label pre-read | single issue read |
+| `gh api repos/{owner}/{repo}/milestones --jq .due_on/.number` | github-milestones.js `getMilestoneDue` / `closeMilestone` | milestone lookup |
+| `gh api graphql … totalCount` | github-tracker.js `getOpenIssueCount` | default list limit |
+| `gh api graphql` paginated queries | triage-collect.js | snapshot collection (open/closed issues) |
+| `gh api repos/…/issues/<n>/comments` | triage-collect.js `fetchIssueComments` | optional comment hydration |
+
+### Mutation class (fail loud, exactly once)
+
+| Call | Where | Purpose |
+| --- | --- | --- |
+| `gh issue create --title --body` | github-tracker.js `create` | task creation |
+| `gh issue edit <n> …` | github-tracker.js `update`; triage-apply `set-*` verbs | title/body/labels/milestone edits |
+| `gh issue close <n>` | github-tracker.js `close`; triage-apply `close-issue` | closing semantics |
+| `gh issue comment <n> --body` | comments capability consumers | progress comments |
+| `gh api -X PATCH repos/{owner}/{repo}/milestones/<n> -f state=closed` | sprint-close → `tracker-capability.js close-milestone` → github-milestones.js `closeMilestone` | milestone close |
+
+Every mutation is issued **once**. A non-zero exit propagates as an exception
+(`execFileSync`) or shell failure; there is no retry loop anywhere in these
+scripts.
+
+## Fail-loud guarantees
+
+1. **Tracker create/update/close** exit non-zero on rate-limit/auth-expired,
+   surface the gh stderr, make exactly one failing call, and leave GitHub state
+   unchanged. Proven by `github-resilience.acceptance.test.js`.
+2. **Partial outage**: read calls succeed; mutations fail once with
+   "GitHub unavailable" and no state write.
+3. **Sprint init** runs `getMilestoneDue`/`getMilestoneIssues` before any file
+   is written. Previously those helpers swallowed gh errors as `TBD`/`[]`,
+   which silently produced an empty sprint file on a broken provider. They now
+   propagate the error; a failed init leaves no sprint file behind.
+4. **Sprint close --close-milestone** closes the GitHub milestone *before* any
+   local mutation. If the PATCH fails, the local sprint stays `status: active`
+   — never completed-with-open-milestone.
+
+## FAKE_GH_FAIL test harness
+
+`skills/dev-backlog/scripts/fake-gh-fixture.js` + `fake-gh.js` inject failures:
+
+| Mode | Behavior |
+| --- | --- |
+| `rate-limit` | every call exits 1, stderr `API rate limit exceeded`; no state write |
+| `auth-expired` | every call exits 1, stderr `HTTP 401` + `authentication required`; no state write |
+| `partial-outage` | reads (issue list/view, `api` without `-X`) succeed; mutations (create/edit/close/comment, `api -X`) exit 1 with `GitHub unavailable`; no state write |
+
+## Operator runbook
+
+When a dev-backlog command fails with a gh error:
+
+1. **Read the surfaced stderr.** It is passed through verbatim — do not guess.
+2. Diagnose by class:
+   - `API rate limit exceeded` — wait for the limit window to reset
+     (`gh api rate_limit`); do not loop the command.
+   - `HTTP 401 / Bad credentials` — re-authenticate (`gh auth login` or refresh
+     `GH_TOKEN`).
+   - `GitHub unavailable` (mutation only) — check
+     [githubstatus.com](https://www.githubstatus.com/); read-only work may
+     continue meanwhile.
+3. Fix access, then **re-run the same command**. Commands are safe to re-run:
+   failed mutations never wrote state, so there is nothing to roll back.
+4. For sprint close specifically: after fixing access, re-run
+   `bash scripts/sprint-close.sh <backlog-dir> --close-milestone`. The local
+   sprint was never marked completed, so one clean run finishes both sides.
+5. Never wrap these commands in retry scripts or add fallback data sources;
+   silent retries are what this contract exists to prevent.

--- a/docs/github-resilience.md
+++ b/docs/github-resilience.md
@@ -19,7 +19,7 @@ plus the code paths in `github-tracker.js`, `github-milestones.js`,
 | `gh issue list … --json …` | github-tracker.js `list` | plan/status/next/sync-pull reads | 1 per list |
 | `gh issue view <n> --json …` | github-tracker.js `read`; triage-apply label pre-read | single issue read | 1 per read |
 | `gh api repos/{owner}/{repo}/milestones --jq .due_on` | github-milestones.js `getMilestoneDue` | milestone due-date lookup (sprint-init) | sprint-init total: **2** (due lookup + open-issue list) |
-| `gh api repos/{owner}/{repo}/milestones?state=all --jq '[.number, .state] | @tsv'` | github-milestones.js `closeMilestone` | milestone state lookup (sprint-close) | close-milestone total: **2**, or **1** when the milestone is already closed (lookup only, no PATCH) |
+| `gh api --paginate repos/{owner}/{repo}/milestones?state=all&per_page=100 --jq '[.number, .state] | @tsv'` | github-milestones.js `closeMilestone` | milestone state lookup (sprint-close) | close-milestone: **1+ pages** for lookup, plus **1 PATCH** or **0** when already closed |
 | `gh api graphql … totalCount` | github-tracker.js `getOpenIssueCount` | default list limit | 1 when the default limit is used |
 | `gh api graphql` paginated queries | triage-collect.js | snapshot collection (open/closed issues) | ≥1 page each for open/closed |
 | `gh api repos/…/issues/<n>/comments` | triage-collect.js `fetchIssueComments` | optional comment hydration | 0–1 per issue |
@@ -29,7 +29,7 @@ Per-command totals (healthy run, counted from source):
 | Command | gh calls |
 | --- | --- |
 | `sprint-init` | 2 (milestone due lookup + open-issue list) |
-| `sprint-close --close-milestone` | 2 — or 1 if the milestone is already closed (state=all lookup returns `closed`, no PATCH is issued) |
+| `sprint-close --close-milestone` | 1+ paginated lookup pages, plus 1 PATCH — or 0 PATCH if already closed |
 | tracker create / update / close | 1 mutation each |
 | status list (`tracker-status-list.js`) | 1 (open-issue list) |
 | `triage-apply --apply` | 1 mutation per action (+1 optional view for label pre-reads) |

--- a/skills/dev-backlog/scripts/fake-gh-fixture.js
+++ b/skills/dev-backlog/scripts/fake-gh-fixture.js
@@ -1,0 +1,52 @@
+/**
+ * Test fixture: installs the fake gh from fake-gh.js into a temp bin/ dir and
+ * returns env/calls/state accessors. Extracted verbatim from
+ * tracker-cycle.acceptance.test.js (#366); see fake-gh.js for FAKE_GH_FAIL
+ * failure-injection modes.
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { GH_SCRIPT } = require("./fake-gh.js");
+
+function writeGhFixture(root) {
+  const binDir = path.join(root, "bin");
+  const statePath = path.join(root, "gh-state.json");
+  const logPath = path.join(root, "gh-argv.jsonl");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(statePath, JSON.stringify({
+    nextIssue: 42,
+    issues: [],
+    milestoneClosed: false,
+  }));
+  const ghPath = path.join(binDir, "gh");
+  fs.writeFileSync(ghPath, GH_SCRIPT);
+  fs.chmodSync(ghPath, 0o755);
+  if (process.platform === "win32") {
+    fs.writeFileSync(`${ghPath}.cmd`, `@echo off\r\n"${process.execPath}" "${ghPath}" %*\r\n`);
+  }
+  const preloadPath = path.join(root, "mock-gh-preload.cjs");
+  fs.writeFileSync(preloadPath, `
+const childProcess = require("node:child_process");
+const original = childProcess.execFileSync;
+childProcess.execFileSync = function (command, args, options) {
+  if (command === "gh") return original(process.execPath, [${JSON.stringify(ghPath)}, ...args], options);
+  return original(command, args, options);
+};
+`);
+  return {
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`,
+      NODE_OPTIONS: `--require=${preloadPath}`,
+      FAKE_GH_STATE: statePath,
+      FAKE_GH_LOG: logPath,
+    },
+    calls: () => fs.existsSync(logPath)
+      ? fs.readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean).map(JSON.parse)
+      : [],
+    state: () => JSON.parse(fs.readFileSync(statePath, "utf8")),
+  };
+}
+
+module.exports = { writeGhFixture };

--- a/skills/dev-backlog/scripts/fake-gh.js
+++ b/skills/dev-backlog/scripts/fake-gh.js
@@ -107,12 +107,12 @@ if ((exact(["api", "repos/{owner}/{repo}/milestones", "--jq", '.[] | select(.tit
   out(query.includes("due_on") ? "2026-06-30T00:00:00Z\\n" : "7\\n");
   process.exit(0);
 }
-if (args[0] === "api" && args[1] === "repos/{owner}/{repo}/milestones?state=all" &&
-    exact(["api", "repos/{owner}/{repo}/milestones?state=all",
-      "--jq", '.[] | select(.title==env.MS) | [.number, .state] | @tsv'])) {
-  // Honor MS: unknown milestones produce no rows; Cycle Milestone is open.
-  if (process.env.MS !== "Cycle Milestone" || state.milestoneClosed) process.exit(0);
-  out("7\\topen\\n");
+if (exact(["api", "--paginate", "repos/{owner}/{repo}/milestones?state=all&per_page=100",
+    "--jq", '.[] | select(.title==env.MS) | [.number, .state] | @tsv'])) {
+  // Honor MS: unknown titles are empty. Already-closed Cycle Milestone is
+  // still listed with state=closed so closeMilestone can skip the PATCH.
+  if (process.env.MS !== "Cycle Milestone") process.exit(0);
+  out(state.milestoneClosed ? "7\\tclosed\\n" : "7\\topen\\n");
   process.exit(0);
 }
 if (exact(["api", "-X", "PATCH", "repos/{owner}/{repo}/milestones/7", "-f", "state=closed"])) {

--- a/skills/dev-backlog/scripts/fake-gh.js
+++ b/skills/dev-backlog/scripts/fake-gh.js
@@ -13,6 +13,7 @@
  *   partial-outage  reads succeed (issue list/view, non -X api calls);
  *                   mutations (issue create/edit/close/comment, api -X)
  *                   exit 1 with stderr "GitHub unavailable"
+ *   http-502        every call exits 1, stderr "HTTP 502 Bad Gateway"
  */
 
 const GH_SCRIPT = `#!/usr/bin/env node
@@ -27,6 +28,10 @@ const failMode = process.env.FAKE_GH_FAIL || "";
 const isReadCall =
   (args[0] === "issue" && (args[1] === "list" || args[1] === "view")) ||
   (args[0] === "api" && !args.includes("-X"));
+if (failMode === "http-502") {
+  process.stderr.write("gh: HTTP 502 Bad Gateway\\n");
+  process.exit(1);
+}
 if (failMode === "rate-limit" || failMode === "auth-expired") {
   process.stderr.write(failMode === "rate-limit"
     ? "gh: API rate limit exceeded for installation. Please wait and try again.\\n"
@@ -95,10 +100,19 @@ if (exact(["issue", "close", "42"])) {
   save(); process.exit(0);
 }
 
-if (exact(["api", "repos/{owner}/{repo}/milestones", "--jq", '.[] | select(.title==env.MS) | .due_on']) ||
-    exact(["api", "repos/{owner}/{repo}/milestones", "--jq", '.[] | select(.title==env.MS) | .number'])) {
+if ((exact(["api", "repos/{owner}/{repo}/milestones", "--jq", '.[] | select(.title==env.MS) | .due_on']) ||
+    exact(["api", "repos/{owner}/{repo}/milestones", "--jq", '.[] | select(.title==env.MS) | .number'])) &&
+    process.env.MS === "Cycle Milestone") {
   const query = valueAfter("--jq");
   out(query.includes("due_on") ? "2026-06-30T00:00:00Z\\n" : "7\\n");
+  process.exit(0);
+}
+if (args[0] === "api" && args[1] === "repos/{owner}/{repo}/milestones?state=all" &&
+    exact(["api", "repos/{owner}/{repo}/milestones?state=all",
+      "--jq", '.[] | select(.title==env.MS) | [.number, .state] | @tsv'])) {
+  // Honor MS: unknown milestones produce no rows; Cycle Milestone is open.
+  if (process.env.MS !== "Cycle Milestone" || state.milestoneClosed) process.exit(0);
+  out("7\\topen\\n");
   process.exit(0);
 }
 if (exact(["api", "-X", "PATCH", "repos/{owner}/{repo}/milestones/7", "-f", "state=closed"])) {

--- a/skills/dev-backlog/scripts/fake-gh.js
+++ b/skills/dev-backlog/scripts/fake-gh.js
@@ -1,0 +1,111 @@
+/**
+ * Fake `gh` executable script used by GitHub tracker acceptance tests.
+ *
+ * The script is written to a temp bin/ directory by fake-gh-fixture.js and
+ * invoked through node. It records every argv line to FAKE_GH_LOG (jsonl) and
+ * keeps issue/milestone state in FAKE_GH_STATE (json). State is only ever
+ * written after a successful simulated call — a failing call appends to the
+ * log but never mutates state.
+ *
+ * Failure injection (set FAKE_GH_FAIL in the environment):
+ *   rate-limit      every call exits 1, stderr "API rate limit exceeded"
+ *   auth-expired    every call exits 1, stderr "HTTP 401" + "authentication required"
+ *   partial-outage  reads succeed (issue list/view, non -X api calls);
+ *                   mutations (issue create/edit/close/comment, api -X)
+ *                   exit 1 with stderr "GitHub unavailable"
+ */
+
+const GH_SCRIPT = `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+const statePath = process.env.FAKE_GH_STATE;
+const logPath = process.env.FAKE_GH_LOG;
+const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+fs.appendFileSync(logPath, JSON.stringify(args) + "\\n");
+
+const failMode = process.env.FAKE_GH_FAIL || "";
+const isReadCall =
+  (args[0] === "issue" && (args[1] === "list" || args[1] === "view")) ||
+  (args[0] === "api" && !args.includes("-X"));
+if (failMode === "rate-limit" || failMode === "auth-expired") {
+  process.stderr.write(failMode === "rate-limit"
+    ? "gh: API rate limit exceeded for installation. Please wait and try again.\\n"
+    : "gh: HTTP 401: authentication required (Bad credentials)\\n");
+  process.exit(1);
+}
+if (failMode === "partial-outage" && !isReadCall) {
+  process.stderr.write("gh: GitHub unavailable (partial outage affecting mutations)\\n");
+  process.exit(1);
+}
+
+const save = () => fs.writeFileSync(statePath, JSON.stringify(state));
+const valueAfter = (flag) => args[args.indexOf(flag) + 1];
+const out = (value) => process.stdout.write(typeof value === "string" ? value : JSON.stringify(value));
+const exact = (expected) => JSON.stringify(args) === JSON.stringify(expected);
+const exactBodyCall = (head) =>
+  args.length === head.length + 2 &&
+  exact([...head, "--body", args[args.length - 1]]) &&
+  typeof args[args.length - 1] === "string";
+
+if (exactBodyCall(["issue", "create", "--title", args[3]]) && args[3]) {
+  const title = valueAfter("--title");
+  const body = valueAfter("--body") || "";
+  const number = state.nextIssue++;
+  state.issues.push({
+    number, title, body, state: "open", url: "https://github.test/acme/widgets/issues/" + number,
+    labels: [{ name: "priority:high" }], milestone: { title: "Cycle Milestone" }, assignees: [],
+  });
+  save(); out("https://github.test/acme/widgets/issues/" + number + "\\n");
+  process.exit(0);
+}
+
+if (args[0] === "issue" && args[1] === "list") {
+  if (exact(["issue", "list", "--milestone", "Cycle Milestone", "--state", "open", "--json", "number,title,labels"])) {
+    out(state.issues.filter((issue) => issue.state === "open").map(({ number, title, labels }) => ({ number, title, labels })));
+  } else if (exact(["issue", "list", "--state", "open", "--limit", "1", "--json", "number,title,body,labels,milestone,assignees"]) ||
+      exact(["issue", "list", "--state", "closed", "--limit", "20", "--json", "number,title,body,labels,milestone,assignees,createdAt,updatedAt"])) {
+    out(state.issues.filter((issue) => {
+      const requested = valueAfter("--state") || "open";
+      return requested === "all" || issue.state === requested;
+    }));
+  } else {
+    process.stderr.write("unhandled fake gh argv: " + JSON.stringify(args) + "\\n"); process.exit(93);
+  }
+  process.exit(0);
+}
+
+if (exact(["issue", "view", "42", "--json", "number,title,body,labels,milestone,assignees,createdAt,updatedAt"]) ||
+    exact(["issue", "view", "42", "--json", "number,title,body,state,labels,milestone,assignees,createdAt,updatedAt,url"]) ||
+    exact(["issue", "view", "42", "--json", "number,title,body,state,labels,milestone,assignees,createdAt,updatedAt,url,comments"])) {
+  const issue = state.issues.find((candidate) => String(candidate.number) === args[2]);
+  if (!issue) process.exit(4);
+  out(issue); process.exit(0);
+}
+
+if (exact(["issue", "edit", "42", "--title", "Cycle task renamed"])) {
+  const number = Number(args[2]);
+  const issue = state.issues.find((candidate) => candidate.number === number);
+  if (issue) issue.title = valueAfter("--title");
+  save(); process.exit(0);
+}
+
+if (exact(["issue", "close", "42"])) {
+  const issue = state.issues.find((candidate) => String(candidate.number) === args[2]);
+  if (issue) issue.state = "closed";
+  save(); process.exit(0);
+}
+
+if (exact(["api", "repos/{owner}/{repo}/milestones", "--jq", '.[] | select(.title==env.MS) | .due_on']) ||
+    exact(["api", "repos/{owner}/{repo}/milestones", "--jq", '.[] | select(.title==env.MS) | .number'])) {
+  const query = valueAfter("--jq");
+  out(query.includes("due_on") ? "2026-06-30T00:00:00Z\\n" : "7\\n");
+  process.exit(0);
+}
+if (exact(["api", "-X", "PATCH", "repos/{owner}/{repo}/milestones/7", "-f", "state=closed"])) {
+  state.milestoneClosed = true; save(); process.exit(0);
+}
+process.stderr.write("unhandled fake gh argv: " + JSON.stringify(args) + "\\n");
+process.exit(93);
+`;
+
+module.exports = { GH_SCRIPT };

--- a/skills/dev-backlog/scripts/github-capabilities.test.js
+++ b/skills/dev-backlog/scripts/github-capabilities.test.js
@@ -49,7 +49,7 @@ describe("GitHub optional capability transports", () => {
     assert.deepEqual(calls.map((call) => call.args), [
       ["api", "repos/{owner}/{repo}/milestones", "--jq", '.[] | select(.title==env.MS) | .due_on'],
       ["issue", "list", "--milestone", "Batch 4", "--state", "open", "--json", "number,title,labels"],
-      ["api", "repos/{owner}/{repo}/milestones?state=all", "--jq", '.[] | select(.title==env.MS) | [.number, .state] | @tsv'],
+      ["api", "--paginate", "repos/{owner}/{repo}/milestones?state=all&per_page=100", "--jq", '.[] | select(.title==env.MS) | [.number, .state] | @tsv'],
       ["api", "-X", "PATCH", "repos/{owner}/{repo}/milestones/9", "-f", "state=closed"],
     ]);
     assert.equal(calls[0].options.env.MS, "Batch 4");

--- a/skills/dev-backlog/scripts/github-capabilities.test.js
+++ b/skills/dev-backlog/scripts/github-capabilities.test.js
@@ -31,7 +31,7 @@ describe("GitHub optional capability transports", () => {
     const { calls, execFile } = makeExec([
       "2026-07-31T00:00:00Z\n",
       '[{"number":275,"title":"Adapter","labels":[]}]',
-      "9\n",
+      "9\topen\n",
       "",
     ]);
 
@@ -49,7 +49,7 @@ describe("GitHub optional capability transports", () => {
     assert.deepEqual(calls.map((call) => call.args), [
       ["api", "repos/{owner}/{repo}/milestones", "--jq", '.[] | select(.title==env.MS) | .due_on'],
       ["issue", "list", "--milestone", "Batch 4", "--state", "open", "--json", "number,title,labels"],
-      ["api", "repos/{owner}/{repo}/milestones", "--jq", '.[] | select(.title==env.MS) | .number'],
+      ["api", "repos/{owner}/{repo}/milestones?state=all", "--jq", '.[] | select(.title==env.MS) | [.number, .state] | @tsv'],
       ["api", "-X", "PATCH", "repos/{owner}/{repo}/milestones/9", "-f", "state=closed"],
     ]);
     assert.equal(calls[0].options.env.MS, "Batch 4");

--- a/skills/dev-backlog/scripts/github-milestones.js
+++ b/skills/dev-backlog/scripts/github-milestones.js
@@ -3,31 +3,48 @@
 const { execFileSync } = require("child_process");
 const { GH_EXEC_DEFAULTS, normalizeGithubTask } = require("./github-tracker.js");
 
+// Fail-loud for the three provider-failure classes (#366): rate limit,
+// expired auth, and partial outage must propagate. Everything else — missing
+// GitHub remote, unknown milestone — degrades to "TBD" / [] so sprint init
+// works in isolated smoke dirs and for cold adopters.
+function isProviderOutage(error) {
+  const stderr = String(error.stderr || "") + String(error.message || "");
+  return /API rate limit exceeded/.test(stderr)
+    || /HTTP 401/.test(stderr) || /authentication required/.test(stderr)
+    || /GitHub unavailable/.test(stderr);
+}
+
 function getMilestoneDue(milestone, execFile = execFileSync) {
+  let output;
   try {
-    const output = execFile("gh", [
+    output = execFile("gh", [
       "api", "repos/{owner}/{repo}/milestones",
       "--jq", '.[] | select(.title==env.MS) | .due_on',
     ], { ...GH_EXEC_DEFAULTS, env: { ...process.env, MS: milestone } }).trim();
-    return output ? output.slice(0, 10) : "TBD";
-  } catch {
+  } catch (error) {
+    if (isProviderOutage(error)) throw error;
     return "TBD";
   }
+  return output ? output.slice(0, 10) : "TBD";
 }
 
 function getMilestoneIssues(milestone, execFile = execFileSync) {
+  let output;
   try {
-    const output = execFile("gh", [
+    output = execFile("gh", [
       "issue", "list", "--milestone", milestone,
       "--state", "open", "--json", "number,title,labels",
     ], GH_EXEC_DEFAULTS);
-    return JSON.parse(output).map(normalizeGithubTask);
-  } catch {
+  } catch (error) {
+    if (isProviderOutage(error)) throw error;
     return [];
   }
+  return JSON.parse(output).map(normalizeGithubTask);
 }
 
-function closeMilestone(milestone, execFile = execFileSync, onPatchError = () => {}) {
+function closeMilestone(milestone, execFile = execFileSync) {
+  // Fail-loud (#366): a failed lookup throws so sprint-close aborts before
+  // marking the local sprint completed while GitHub stays open.
   const output = execFile("gh", [
     "api", "repos/{owner}/{repo}/milestones",
     "--jq", '.[] | select(.title==env.MS) | .number',
@@ -35,15 +52,13 @@ function closeMilestone(milestone, execFile = execFileSync, onPatchError = () =>
   const numbers = String(output).split(/\r?\n/).map((value) => value.trim()).filter(Boolean);
   let closed = 0;
   for (const number of numbers) {
-    try {
-      execFile("gh", [
-        "api", "-X", "PATCH", `repos/{owner}/{repo}/milestones/${number}`,
-        "-f", "state=closed",
-      ], GH_EXEC_DEFAULTS);
-      closed += 1;
-    } catch (error) {
-      onPatchError(number, error);
-    }
+    // Fail-loud: a failed PATCH throws so sprint-close aborts before marking
+    // the local sprint completed while GitHub stays open.
+    execFile("gh", [
+      "api", "-X", "PATCH", `repos/{owner}/{repo}/milestones/${number}`,
+      "-f", "state=closed",
+    ], GH_EXEC_DEFAULTS);
+    closed += 1;
   }
   return closed;
 }

--- a/skills/dev-backlog/scripts/github-milestones.js
+++ b/skills/dev-backlog/scripts/github-milestones.js
@@ -3,15 +3,16 @@
 const { execFileSync } = require("child_process");
 const { GH_EXEC_DEFAULTS, normalizeGithubTask } = require("./github-tracker.js");
 
-// Fail-loud for the three provider-failure classes (#366): rate limit,
-// expired auth, and partial outage must propagate. Everything else — missing
-// GitHub remote, unknown milestone — degrades to "TBD" / [] so sprint init
-// works in isolated smoke dirs and for cold adopters.
-function isProviderOutage(error) {
+// Isolated-environment failures (#366): the gh call failed because we are not
+// inside a git repository / have no GitHub remote. These degrade to "TBD" / []
+// so sprint init works in isolated smoke dirs and for cold adopters. Provider
+// failures — rate limit, expired auth, partial outage — are NOT isolated and
+// must propagate (fail loud).
+function isIsolatedGithubError(error) {
   const stderr = String(error.stderr || "") + String(error.message || "");
-  return /API rate limit exceeded/.test(stderr)
-    || /HTTP 401/.test(stderr) || /authentication required/.test(stderr)
-    || /GitHub unavailable/.test(stderr);
+  return /unable to expand placeholder in path/.test(stderr)
+    || /no git remotes found/.test(stderr)
+    || /not a git repository/.test(stderr);
 }
 
 function getMilestoneDue(milestone, execFile = execFileSync) {
@@ -22,8 +23,8 @@ function getMilestoneDue(milestone, execFile = execFileSync) {
       "--jq", '.[] | select(.title==env.MS) | .due_on',
     ], { ...GH_EXEC_DEFAULTS, env: { ...process.env, MS: milestone } }).trim();
   } catch (error) {
-    if (isProviderOutage(error)) throw error;
-    return "TBD";
+    if (isIsolatedGithubError(error)) return "TBD";
+    throw error;
   }
   return output ? output.slice(0, 10) : "TBD";
 }
@@ -36,8 +37,8 @@ function getMilestoneIssues(milestone, execFile = execFileSync) {
       "--state", "open", "--json", "number,title,labels",
     ], GH_EXEC_DEFAULTS);
   } catch (error) {
-    if (isProviderOutage(error)) throw error;
-    return [];
+    if (isIsolatedGithubError(error)) return [];
+    throw error;
   }
   return JSON.parse(output).map(normalizeGithubTask);
 }
@@ -46,21 +47,24 @@ function closeMilestone(milestone, execFile = execFileSync) {
   // Fail-loud (#366): a failed lookup throws so sprint-close aborts before
   // marking the local sprint completed while GitHub stays open.
   const output = execFile("gh", [
-    "api", "repos/{owner}/{repo}/milestones",
-    "--jq", '.[] | select(.title==env.MS) | .number',
+    "api", "repos/{owner}/{repo}/milestones?state=all",
+    "--jq", '.[] | select(.title==env.MS) | [.number, .state] | @tsv',
   ], { ...GH_EXEC_DEFAULTS, env: { ...process.env, MS: milestone } });
-  const numbers = String(output).split(/\r?\n/).map((value) => value.trim()).filter(Boolean);
-  let closed = 0;
-  for (const number of numbers) {
-    // Fail-loud: a failed PATCH throws so sprint-close aborts before marking
-    // the local sprint completed while GitHub stays open.
-    execFile("gh", [
-      "api", "-X", "PATCH", `repos/{owner}/{repo}/milestones/${number}`,
-      "-f", "state=closed",
-    ], GH_EXEC_DEFAULTS);
-    closed += 1;
+  const rows = String(output).split(/\r?\n/).map((value) => value.trim()).filter(Boolean);
+  if (rows.length === 0) {
+    throw new Error("milestone not found: " + milestone);
   }
-  return closed;
+  const [number, state] = rows[0].split("\t");
+  if (state === "closed") {
+    return 0; // already closed — no PATCH needed
+  }
+  // Fail-loud: a failed PATCH throws so sprint-close aborts before marking
+  // the local sprint completed while GitHub stays open.
+  execFile("gh", [
+    "api", "-X", "PATCH", `repos/{owner}/{repo}/milestones/${number}`,
+    "-f", "state=closed",
+  ], GH_EXEC_DEFAULTS);
+  return 1;
 }
 
-module.exports = { getMilestoneDue, getMilestoneIssues, closeMilestone };
+module.exports = { getMilestoneDue, getMilestoneIssues, closeMilestone, isIsolatedGithubError };

--- a/skills/dev-backlog/scripts/github-milestones.js
+++ b/skills/dev-backlog/scripts/github-milestones.js
@@ -47,7 +47,7 @@ function closeMilestone(milestone, execFile = execFileSync) {
   // Fail-loud (#366): a failed lookup throws so sprint-close aborts before
   // marking the local sprint completed while GitHub stays open.
   const output = execFile("gh", [
-    "api", "repos/{owner}/{repo}/milestones?state=all",
+    "api", "--paginate", "repos/{owner}/{repo}/milestones?state=all&per_page=100",
     "--jq", '.[] | select(.title==env.MS) | [.number, .state] | @tsv',
   ], { ...GH_EXEC_DEFAULTS, env: { ...process.env, MS: milestone } });
   const rows = String(output).split(/\r?\n/).map((value) => value.trim()).filter(Boolean);

--- a/skills/dev-backlog/scripts/github-resilience.acceptance.test.js
+++ b/skills/dev-backlog/scripts/github-resilience.acceptance.test.js
@@ -345,4 +345,19 @@ describe("fail-loud GitHub resilience: sprint close --close-milestone", () => {
     assert.match(fs.readFileSync(sprintPath, "utf8"), /^status: completed$/m);
     assert.equal(fixture.state().milestoneClosed, true);
   });
+
+  it("already-closed milestone succeeds with no PATCH", (t) => {
+    const fixture = prepareFixture(t, {});
+    fs.writeFileSync(path.join(fixture.root, "gh-state.json"), JSON.stringify({
+      nextIssue: 43, issues: [], milestoneClosed: true,
+    }));
+    const sprintPath = fixture.sprintFile("2026-07-cycle.md", ACTIVE_SPRINT);
+
+    const result = run("bash", [SPRINT_CLOSE_PATH, fixture.backlogDir, "--close-milestone"], fixture);
+    assert.equal(result.status, 0, `already-closed should succeed:\n${result.stdout}\n${result.stderr}`);
+    assert.match(fs.readFileSync(sprintPath, "utf8"), /^status: completed$/m);
+    const patchCalls = fixture.calls().filter((argv) =>
+      JSON.stringify(argv) === JSON.stringify(PATCH_ARGV));
+    assert.equal(patchCalls.length, 0, "already closed must not PATCH");
+  });
 });

--- a/skills/dev-backlog/scripts/github-resilience.acceptance.test.js
+++ b/skills/dev-backlog/scripts/github-resilience.acceptance.test.js
@@ -21,6 +21,7 @@ const path = require("node:path");
 const { spawnSync } = require("node:child_process");
 const { resolveBashExecutable, toBashArgs } = require("./bash-runtime.js");
 const { writeGhFixture } = require("./fake-gh-fixture.js");
+const { isIsolatedGithubError } = require("./github-milestones.js");
 
 const SCRIPTS_DIR = __dirname;
 const TRACKER_PATH = path.join(SCRIPTS_DIR, "tracker.js");
@@ -138,6 +139,108 @@ describe("fail-loud GitHub resilience: rate-limit and auth-expired", () => {
       assert.equal(fixture.state().issues[0].state, "open");
     });
   }
+});
+
+describe("isolated-environment classifier", () => {
+  it("treats only git-isolation errors as isolated", () => {
+    const isolated = [
+      "gh: unable to expand placeholder in path",
+      "gh: no git remotes found",
+      "fatal: not a git repository (or any of the parent directories)",
+    ];
+    for (const stderr of isolated) {
+      assert.equal(isIsolatedGithubError({ stderr }), true, stderr);
+      assert.equal(isIsolatedGithubError(new Error(stderr)), true, stderr);
+    }
+    const providerFailures = [
+      "gh: HTTP 502 Bad Gateway",
+      "gh: secondary rate limit triggered",
+      "gh: API rate limit exceeded",
+      "gh: connection reset by peer",
+    ];
+    for (const stderr of providerFailures) {
+      assert.equal(isIsolatedGithubError({ stderr }), false, stderr);
+      assert.equal(isIsolatedGithubError(new Error(stderr)), false, stderr);
+    }
+  });
+
+  it("http-502: sprint-init fails loud with no sprint file", (t) => {
+    const fixture = prepareFixture(t, { failMode: "http-502" });
+    const result = run(process.execPath, [
+      SPRINT_INIT_PATH, "cycle", "--milestone", "Cycle Milestone", "--json",
+    ], fixture);
+    assert.notEqual(result.status, 0, `sprint init must fail loud:\n${result.stdout}`);
+    assert.match(`${result.stdout}${result.stderr}`, /HTTP 502/);
+    const sprintFiles = fs.existsSync(path.join(fixture.backlogDir, "sprints"))
+      ? fs.readdirSync(path.join(fixture.backlogDir, "sprints")).filter((f) => f.endsWith(".md"))
+      : [];
+    assert.deepEqual(sprintFiles, [], "no sprint file on provider failure");
+  });
+
+  it("unknown milestone: --close-milestone fails loud and leaves the sprint active with no PATCH", (t) => {
+    const fixture = prepareFixture(t, {});
+    const sprintPath = fixture.sprintFile("2026-07-cycle.md", [
+      "---", "milestone: DoesNotExist", "status: active", "started: 2026-07-31", "---", "",
+      "# Resilience cycle", "", "## Plan", "", "## Running Context", "", "## Progress", "",
+    ]);
+
+    const result = run("bash", [SPRINT_CLOSE_PATH, fixture.backlogDir, "--close-milestone"], fixture);
+    assert.notEqual(result.status, 0, `expected failure, got stdout:\n${result.stdout}`);
+    assert.match(`${result.stdout}${result.stderr}`, /milestone not found: DoesNotExist/);
+    assert.match(fs.readFileSync(sprintPath, "utf8"), /^status: active$/m,
+      "local sprint must stay active when the milestone does not exist");
+    const patchCalls = fixture.calls().filter((argv) =>
+      JSON.stringify(argv) === JSON.stringify(PATCH_ARGV));
+    assert.equal(patchCalls.length, 0, "no PATCH for a nonexistent milestone");
+    assert.equal(fixture.state().milestoneClosed, false);
+  });
+
+  it("tracker-status-list.js CLI fails loud on rate-limit instead of printing a fallback row", (t) => {
+    const fixture = prepareFixture(t, { failMode: "rate-limit" });
+    const result = run(process.execPath, [
+      path.join(SCRIPTS_DIR, "tracker-status-list.js"), fixture.backlogDir,
+    ], fixture);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /API rate limit exceeded/);
+    assert.doesNotMatch(result.stdout, /gh not available/);
+  });
+
+  it("triage-apply --apply --yes makes exactly one gh call and leaves state unchanged under rate-limit", (t) => {
+    const fixture = prepareFixture(t, { failMode: "rate-limit" });
+    const report = path.join(fixture.root, "report.md");
+    fs.writeFileSync(report, [
+      "---", "generated: 2026-07-31", "---", "",
+      "<!-- triage:close #42 reason=\"stale cleanup\" -->",
+      "- [x] Close #42 - stale cleanup",
+      "",
+    ].join("\n"));
+    const stateBefore = JSON.stringify(fixture.state());
+
+    const result = run(process.execPath, [
+      path.join(__dirname, "..", "..", "backlog-triage", "scripts", "triage-apply.js"),
+      report, "--apply", "--yes",
+    ], fixture);
+    assert.notEqual(result.status, 0, `expected failure, got stdout:\n${result.stdout}`);
+    assert.match(result.stderr, /API rate limit exceeded/);
+    const calls = fixture.calls();
+    assert.equal(calls.length, 1, "exactly one gh call, no silent retry");
+    assert.deepEqual(calls[0], ["issue", "comment", "42", "-b", "stale cleanup"]);
+    assert.equal(JSON.stringify(fixture.state()), stateBefore, "GitHub state must be unchanged");
+  });
+
+  it("triage-collect --repo fails loud under rate-limit and creates no snapshot cache", (t) => {
+    const fixture = prepareFixture(t, { failMode: "rate-limit" });
+    fs.mkdirSync(path.join(fixture.backlogDir), { recursive: true });
+
+    const result = run(process.execPath, [
+      path.join(__dirname, "..", "..", "backlog-triage", "scripts", "triage-collect.js"),
+      "--repo", "acme/widgets",
+    ], fixture);
+    assert.notEqual(result.status, 0, `expected failure, got stdout:\n${result.stdout}`);
+    assert.match(result.stderr, /API rate limit exceeded/);
+    assert.equal(fs.existsSync(path.join(fixture.backlogDir, "triage", ".cache")), false,
+      "no snapshot cache file created");
+  });
 });
 
 describe("fail-loud GitHub resilience: partial-outage", () => {

--- a/skills/dev-backlog/scripts/github-resilience.acceptance.test.js
+++ b/skills/dev-backlog/scripts/github-resilience.acceptance.test.js
@@ -1,0 +1,245 @@
+/**
+ * GitHub resilience acceptance (#366): fail-loud contract.
+ *
+ * No silent retry, no fallback authority. When gh fails (rate limit, expired
+ * auth, partial outage) every tracker mutation must:
+ *   - exit non-zero with the provider's stderr surfaced,
+ *   - leave GitHub state untouched (fake gh never saves state on failure),
+ *   - make exactly one failing gh call (no automatic retry).
+ *
+ * Read-only paths under partial outage keep working. Sprint init must not
+ * write a sprint file when gh fails, and sprint close --close-milestone must
+ * refuse to mark the local sprint completed while the GitHub milestone stays
+ * open.
+ */
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const { resolveBashExecutable, toBashArgs } = require("./bash-runtime.js");
+const { writeGhFixture } = require("./fake-gh-fixture.js");
+
+const SCRIPTS_DIR = __dirname;
+const TRACKER_PATH = path.join(SCRIPTS_DIR, "tracker.js");
+const SPRINT_INIT_PATH = path.join(SCRIPTS_DIR, "sprint-init.js");
+const SPRINT_CLOSE_PATH = path.join(SCRIPTS_DIR, "sprint-close.sh");
+const CREATE_ARGV = ["issue", "create", "--title", "Cycle task", "--body", "Body"];
+const EDIT_ARGV = ["issue", "edit", "42", "--title", "Cycle task renamed"];
+const CLOSE_ARGV = ["issue", "close", "42"];
+const PATCH_ARGV = ["api", "-X", "PATCH", "repos/{owner}/{repo}/milestones/7", "-f", "state=closed"];
+
+function makeRoot(t, prefix) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+
+function run(command, args, { cwd, env = process.env } = {}) {
+  const executable = command === "bash" ? resolveBashExecutable({ env }) : command;
+  const commandArgs = command === "bash" ? toBashArgs(args) : args;
+  return spawnSync(executable, commandArgs, { cwd, env, encoding: "utf8" });
+}
+
+function writeWorker(root) {
+  const worker = path.join(root, "tracker-worker.cjs");
+  fs.writeFileSync(worker, `
+const tracker = require(${JSON.stringify(TRACKER_PATH)});
+const [backlogDir, action, payload = "{}"] = process.argv.slice(2);
+const resolved = tracker.resolveConfiguredTracker(
+  require(${JSON.stringify(path.join(SCRIPTS_DIR, "lib.js"))}).readConfig(backlogDir),
+  { backlogDir }
+);
+const input = JSON.parse(payload);
+let result;
+if (action === "list") result = resolved.adapter.list(input);
+else if (action === "read") result = resolved.adapter.read(input.selector);
+else if (action === "create") result = resolved.adapter.create(input);
+else if (action === "update") result = resolved.adapter.update(input.selector, input.changes);
+else if (action === "close") result = resolved.adapter.close(input.selector, input.options);
+else throw new Error("unknown worker action: " + action);
+process.stdout.write(JSON.stringify(result));
+`);
+  return worker;
+}
+
+const SEEDED_ISSUE = {
+  number: 42, title: "Cycle task", body: "Body", state: "open",
+  url: "https://github.test/acme/widgets/issues/42",
+  labels: [{ name: "priority:high" }], milestone: { title: "Cycle Milestone" }, assignees: [],
+};
+
+function prepareFixture(t, { failMode, seedIssue = false } = {}) {
+  const root = makeRoot(t, `gh-resilience-${failMode || "ok"}-`);
+  const backlogDir = path.join(root, "backlog");
+  fs.mkdirSync(path.join(backlogDir, "sprints"), { recursive: true });
+  fs.writeFileSync(path.join(backlogDir, ".tracker"), "github\n");
+  const gh = writeGhFixture(root);
+  if (seedIssue) {
+    fs.writeFileSync(path.join(root, "gh-state.json"), JSON.stringify({
+      nextIssue: 43, issues: [SEEDED_ISSUE], milestoneClosed: false,
+    }));
+  }
+  const env = { ...gh.env };
+  if (failMode) env.FAKE_GH_FAIL = failMode;
+  return {
+    root, cwd: root, backlogDir, worker: writeWorker(root),
+    env, calls: gh.calls, state: gh.state,
+    sprintFile: (name, lines) => {
+      const sprintPath = path.join(backlogDir, "sprints", name);
+      fs.writeFileSync(sprintPath, lines.join("\n") + "\n");
+      return sprintPath;
+    },
+  };
+}
+
+// The operation must exit non-zero with the provider stderr surfaced, log
+// exactly one gh call, and leave GitHub state byte-identical.
+function assertFailsLoud(fixture, runOp, expectedArgv, expectedStderr) {
+  const stateBefore = JSON.stringify(fixture.state());
+  const callsBefore = fixture.calls().length;
+  const result = runOp();
+  assert.notEqual(result.status, 0, `expected failure, got stdout:\n${result.stdout}`);
+  assert.match(result.stderr, expectedStderr);
+  const calls = fixture.calls();
+  assert.equal(calls.length - callsBefore, 1, "exactly one gh call, no silent retry");
+  assert.deepEqual(calls[calls.length - 1], expectedArgv);
+  assert.equal(JSON.stringify(fixture.state()), stateBefore, "GitHub state must be unchanged");
+  return result;
+}
+
+describe("fail-loud GitHub resilience: rate-limit and auth-expired", () => {
+  for (const [failMode, expectedStderr] of [
+    ["rate-limit", /API rate limit exceeded/],
+    ["auth-expired", /HTTP 401/, /authentication required/],
+  ]) {
+    it(`${failMode}: tracker create/update/close fail loud, one call, no state write`, (t) => {
+      const fixture = prepareFixture(t, { failMode, seedIssue: true });
+      const match = new RegExp(expectedStderr.source);
+
+      assertFailsLoud(fixture,
+        () => run(process.execPath, [fixture.worker, fixture.backlogDir, "create",
+          JSON.stringify({ title: "Cycle task", body: "Body" })], fixture),
+        CREATE_ARGV, match);
+      assert.deepEqual(fixture.state().issues, [SEEDED_ISSUE]);
+
+      assertFailsLoud(fixture,
+        () => run(process.execPath, [fixture.worker, fixture.backlogDir, "update",
+          JSON.stringify({ selector: "#42", changes: { title: "Cycle task renamed" } })], fixture),
+        EDIT_ARGV, match);
+      assert.equal(fixture.state().issues[0].title, "Cycle task");
+
+      assertFailsLoud(fixture,
+        () => run(process.execPath, [fixture.worker, fixture.backlogDir, "close",
+          JSON.stringify({ selector: "#42" })], fixture),
+        CLOSE_ARGV, match);
+      assert.equal(fixture.state().issues[0].state, "open");
+    });
+  }
+});
+
+describe("fail-loud GitHub resilience: partial-outage", () => {
+  it("reads succeed while mutations fail exactly once with no state write", (t) => {
+    const fixture = prepareFixture(t, { failMode: "partial-outage", seedIssue: true });
+
+    const read = run(process.execPath, [fixture.worker, fixture.backlogDir, "read",
+      JSON.stringify({ selector: "#42" })], fixture);
+    assert.equal(read.status, 0, `read must succeed:\n${read.stderr}`);
+    assert.equal(JSON.parse(read.stdout).title, "Cycle task");
+
+    assertFailsLoud(fixture,
+      () => run(process.execPath, [fixture.worker, fixture.backlogDir, "create",
+        JSON.stringify({ title: "Cycle task", body: "Body" })], fixture),
+      CREATE_ARGV, /GitHub unavailable/);
+
+    assertFailsLoud(fixture,
+      () => run(process.execPath, [fixture.worker, fixture.backlogDir, "update",
+        JSON.stringify({ selector: "#42", changes: { title: "Cycle task renamed" } })], fixture),
+      EDIT_ARGV, /GitHub unavailable/);
+    assert.equal(fixture.state().issues[0].title, "Cycle task");
+
+    // close-milestone legitimately makes two gh calls: a read-only lookup of
+    // the milestone number (succeeds under partial outage) followed by one
+    // failing PATCH. That is not a retry — require exactly two calls total,
+    // exactly one of them the PATCH, with no extra PATCH retry.
+    {
+      const stateBefore = JSON.stringify(fixture.state());
+      const callsBefore = fixture.calls().length;
+      const result = run(process.execPath, [
+        path.join(SCRIPTS_DIR, "tracker-capability.js"),
+        "close-milestone", "milestones", fixture.backlogDir, "Cycle Milestone",
+      ], fixture);
+      assert.notEqual(result.status, 0, `expected failure, got stdout:\n${result.stdout}`);
+      assert.match(result.stderr, /GitHub unavailable/);
+      const calls = fixture.calls();
+      assert.equal(calls.length - callsBefore, 2,
+        "exactly two gh calls: milestone lookup + one failing PATCH");
+      assert.deepEqual(calls[calls.length - 1], PATCH_ARGV,
+        "last call must be the PATCH");
+      const patchCalls = calls.slice(callsBefore).filter((argv) =>
+        JSON.stringify(argv) === JSON.stringify(PATCH_ARGV));
+      assert.equal(patchCalls.length, 1, "exactly one PATCH, no silent retry");
+      assert.equal(JSON.stringify(fixture.state()), stateBefore,
+        "GitHub state must be unchanged");
+    }
+    assert.equal(fixture.state().milestoneClosed, false);
+  });
+});
+
+describe("fail-loud GitHub resilience: sprint init", () => {
+  for (const failMode of ["rate-limit", "auth-expired"]) {
+    it(`${failMode}: no sprint file is written and the command exits non-zero`, (t) => {
+      const fixture = prepareFixture(t, { failMode });
+      const result = run(process.execPath, [
+        SPRINT_INIT_PATH, "cycle", "--milestone", "Cycle Milestone", "--json",
+      ], fixture);
+      assert.notEqual(result.status, 0, `sprint init must fail loud:\n${result.stdout}`);
+      if (failMode === "rate-limit") {
+        assert.match(`${result.stdout}${result.stderr}`, /API rate limit exceeded/);
+      } else {
+        assert.match(`${result.stdout}${result.stderr}`, /HTTP 401/);
+        assert.match(`${result.stdout}${result.stderr}`, /authentication required/);
+      }
+      const sprintFiles = fs.existsSync(path.join(fixture.backlogDir, "sprints"))
+        ? fs.readdirSync(path.join(fixture.backlogDir, "sprints")).filter((f) => f.endsWith(".md"))
+        : [];
+      assert.deepEqual(sprintFiles, [], "no sprint file on provider failure");
+      assert.deepEqual(fixture.state().issues, []);
+    });
+  }
+});
+
+describe("fail-loud GitHub resilience: sprint close --close-milestone", () => {
+  const ACTIVE_SPRINT = [
+    "---", "milestone: Cycle Milestone", "status: active", "started: 2026-07-31", "---", "",
+    "# Resilience cycle", "", "## Plan", "", "- [x] #42 Cycle task", "",
+    "## Running Context", "", "## Progress", "",
+  ];
+
+  it("refuses to mark the sprint completed when the milestone PATCH fails", (t) => {
+    const fixture = prepareFixture(t, { failMode: "partial-outage" });
+    const sprintPath = fixture.sprintFile("2026-07-cycle.md", ACTIVE_SPRINT);
+
+    const result = run("bash", [SPRINT_CLOSE_PATH, fixture.backlogDir, "--close-milestone"], fixture);
+    assert.notEqual(result.status, 0, `sprint close must fail loud:\n${result.stdout}`);
+    assert.match(`${result.stdout}${result.stderr}`, /GitHub unavailable|could not be closed/);
+    assert.match(fs.readFileSync(sprintPath, "utf8"), /^status: active$/m,
+      "local sprint must stay active while the GitHub milestone stays open");
+    assert.equal(fixture.state().milestoneClosed, false);
+    const patchCalls = fixture.calls().filter((argv) =>
+      JSON.stringify(argv) === JSON.stringify(PATCH_ARGV));
+    assert.equal(patchCalls.length, 1, "exactly one failing PATCH, no silent retry");
+  });
+
+  it("positive control: with gh healthy the close completes and closes the milestone", (t) => {
+    const fixture = prepareFixture(t, {});
+    const sprintPath = fixture.sprintFile("2026-07-cycle.md", ACTIVE_SPRINT);
+
+    const result = run("bash", [SPRINT_CLOSE_PATH, fixture.backlogDir, "--close-milestone"], fixture);
+    assert.equal(result.status, 0, `sprint close should succeed:\n${result.stdout}\n${result.stderr}`);
+    assert.match(fs.readFileSync(sprintPath, "utf8"), /^status: completed$/m);
+    assert.equal(fixture.state().milestoneClosed, true);
+  });
+});

--- a/skills/dev-backlog/scripts/isolated-gh-preload.cjs
+++ b/skills/dev-backlog/scripts/isolated-gh-preload.cjs
@@ -1,0 +1,20 @@
+/**
+ * Smoke-only preload: make `execFileSync("gh")` look like an isolated
+ * no-remote failure. Needed because GitHub Actions Windows Node cannot
+ * spawn an extensionless `gh` or `gh.cmd` without `shell: true`.
+ */
+const childProcess = require("node:child_process");
+const original = childProcess.execFileSync;
+
+childProcess.execFileSync = function isolatedGhExecFileSync(command, args, options) {
+  if (command === "gh") {
+    const error = new Error(
+      "Command failed: gh\nunable to expand placeholder in path: no git remotes found"
+    );
+    error.status = 1;
+    error.stdout = "";
+    error.stderr = "unable to expand placeholder in path: no git remotes found\n";
+    throw error;
+  }
+  return original.call(this, command, args, options);
+};

--- a/skills/dev-backlog/scripts/smoke-test.sh
+++ b/skills/dev-backlog/scripts/smoke-test.sh
@@ -79,6 +79,11 @@ exit /b 1
 EOF
 }
 
+ISOLATED_GH_PRELOAD="$SCRIPT_DIR/isolated-gh-preload.cjs"
+isolated_node() {
+NODE_OPTIONS="--require=${ISOLATED_GH_PRELOAD}${NODE_OPTIONS:+ ${NODE_OPTIONS}}" node "$@"
+}
+
 # ============================================================
 # backlog-doctor live-repo smoke test
 # ============================================================
@@ -1176,7 +1181,7 @@ mkdir -p "$COLD_INIT_DIR/backlog/sprints" "$COLD_INIT_DIR/backlog/tasks"
 git -C "$COLD_INIT_DIR" init -q
 install_isolated_gh "$COLD_INIT_DIR"
 set +e
-INIT_JSON=$(cd "$COLD_INIT_DIR" && PATH="$COLD_INIT_DIR/bin:$PATH" node "$SCRIPT_DIR/sprint-init.js" "cold-probe" --dry-run --json 2>/dev/null)
+INIT_JSON=$(cd "$COLD_INIT_DIR" && isolated_node "$SCRIPT_DIR/sprint-init.js" "cold-probe" --dry-run --json 2>/dev/null)
 set -e
 if printf "%s" "$INIT_JSON" | node -e '
 const j = JSON.parse(require("fs").readFileSync(0, "utf8"));
@@ -1340,7 +1345,7 @@ git -C "$MT_LIFE_DIR" init -q
 install_isolated_gh "$MT_LIFE_DIR"
 mt_write_sprint "$MT_LIFE_DIR/backlog/sprints/2026-07-auth.md" "Auth" 1 '["src/auth/**"]'
 set +e
-OUT=$(cd "$MT_LIFE_DIR" && PATH="$MT_LIFE_DIR/bin:$PATH" node "$SCRIPT_DIR/sprint-init.js" "billing" --scope "src/billing/**" --json 2>/dev/null)
+OUT=$(cd "$MT_LIFE_DIR" && isolated_node "$SCRIPT_DIR/sprint-init.js" "billing" --scope "src/billing/**" --json 2>/dev/null)
 STATUS=$?
 set -e
 assert_equals "multi-track #292: disjoint second-track init exit code" "$STATUS" "0"
@@ -1352,7 +1357,7 @@ if (!/^scope: \["src\/billing\/\*\*"\]$/m.test(j.content)) process.exit(1);
 '
 
 set +e
-OUT=$(cd "$MT_LIFE_DIR" && PATH="$MT_LIFE_DIR/bin:$PATH" node "$SCRIPT_DIR/sprint-init.js" "auth-two" --scope "src/auth/api/**" --dry-run 2>&1)
+OUT=$(cd "$MT_LIFE_DIR" && isolated_node "$SCRIPT_DIR/sprint-init.js" "auth-two" --scope "src/auth/api/**" --dry-run 2>&1)
 STATUS=$?
 set -e
 assert_equals "multi-track #292: overlapping-scope init exit code" "$STATUS" "1"
@@ -1364,7 +1369,7 @@ mkdir -p "$MT_INIT_SOLO_DIR/backlog/sprints"
 git -C "$MT_INIT_SOLO_DIR" init -q
 install_isolated_gh "$MT_INIT_SOLO_DIR"
 set +e
-OUT=$(cd "$MT_INIT_SOLO_DIR" && PATH="$MT_INIT_SOLO_DIR/bin:$PATH" node "$SCRIPT_DIR/sprint-init.js" "solo-probe" --dry-run 2>/dev/null)
+OUT=$(cd "$MT_INIT_SOLO_DIR" && isolated_node "$SCRIPT_DIR/sprint-init.js" "solo-probe" --dry-run 2>/dev/null)
 STATUS=$?
 set -e
 assert_equals "multi-track G4 #292: single-track init dry-run exit code" "$STATUS" "0"

--- a/skills/dev-backlog/scripts/smoke-test.sh
+++ b/skills/dev-backlog/scripts/smoke-test.sh
@@ -60,6 +60,25 @@ assert_json_eval() {
 	assert_equals "$label" "$status" "0"
 }
 
+# Isolated gh stub so sprint-init smoke does not call Actions' unauthenticated
+# gh.exe (which prints GH_TOKEN before "no remotes"). Node on Windows resolves
+# gh.cmd; Unix resolves the extensionless script.
+install_isolated_gh() {
+	local dir="$1"
+	mkdir -p "$dir/bin"
+	cat >"$dir/bin/gh" <<'EOF'
+#!/bin/sh
+echo "unable to expand placeholder in path: no git remotes found" >&2
+exit 1
+EOF
+	chmod +x "$dir/bin/gh"
+	cat >"$dir/bin/gh.cmd" <<'EOF'
+@echo off
+echo unable to expand placeholder in path: no git remotes found 1>&2
+exit /b 1
+EOF
+}
+
 # ============================================================
 # backlog-doctor live-repo smoke test
 # ============================================================
@@ -1153,14 +1172,9 @@ if (bad.length !== 0) process.exit(1);
 # Use a fresh spec-less dir with an empty sprints/ so init isn't refused as a
 # second active sprint.
 COLD_INIT_DIR="$TEST_DIR/cold-init"
-mkdir -p "$COLD_INIT_DIR/backlog/sprints" "$COLD_INIT_DIR/backlog/tasks" "$COLD_INIT_DIR/bin"
+mkdir -p "$COLD_INIT_DIR/backlog/sprints" "$COLD_INIT_DIR/backlog/tasks"
 git -C "$COLD_INIT_DIR" init -q
-cat >"$COLD_INIT_DIR/bin/gh" <<'EOF'
-#!/bin/sh
-echo "unable to expand placeholder in path: no git remotes found" >&2
-exit 1
-EOF
-chmod +x "$COLD_INIT_DIR/bin/gh"
+install_isolated_gh "$COLD_INIT_DIR"
 set +e
 INIT_JSON=$(cd "$COLD_INIT_DIR" && PATH="$COLD_INIT_DIR/bin:$PATH" node "$SCRIPT_DIR/sprint-init.js" "cold-probe" --dry-run --json 2>/dev/null)
 set -e
@@ -1321,14 +1335,9 @@ if (!/cannot prove disjoint/.test(c.detail.summary)) process.exit(1);
 # overlapping scope is refused naming the conflicting track. Scope is always
 # explicit via --scope (D2) — never inferred from touched paths.
 MT_LIFE_DIR="$TEST_DIR/mt-lifecycle"
-mkdir -p "$MT_LIFE_DIR/backlog/sprints" "$MT_LIFE_DIR/bin"
+mkdir -p "$MT_LIFE_DIR/backlog/sprints"
 git -C "$MT_LIFE_DIR" init -q
-cat >"$MT_LIFE_DIR/bin/gh" <<'EOF'
-#!/bin/sh
-echo "unable to expand placeholder in path: no git remotes found" >&2
-exit 1
-EOF
-chmod +x "$MT_LIFE_DIR/bin/gh"
+install_isolated_gh "$MT_LIFE_DIR"
 mt_write_sprint "$MT_LIFE_DIR/backlog/sprints/2026-07-auth.md" "Auth" 1 '["src/auth/**"]'
 set +e
 OUT=$(cd "$MT_LIFE_DIR" && PATH="$MT_LIFE_DIR/bin:$PATH" node "$SCRIPT_DIR/sprint-init.js" "billing" --scope "src/billing/**" --json 2>/dev/null)
@@ -1351,14 +1360,9 @@ assert_contains "multi-track #292: overlapping init names the conflicting track"
 
 # G4: first-sprint init (no active sprint yet) keeps today's text and exit code.
 MT_INIT_SOLO_DIR="$TEST_DIR/mt-init-solo"
-mkdir -p "$MT_INIT_SOLO_DIR/backlog/sprints" "$MT_INIT_SOLO_DIR/bin"
+mkdir -p "$MT_INIT_SOLO_DIR/backlog/sprints"
 git -C "$MT_INIT_SOLO_DIR" init -q
-cat >"$MT_INIT_SOLO_DIR/bin/gh" <<'EOF'
-#!/bin/sh
-echo "unable to expand placeholder in path: no git remotes found" >&2
-exit 1
-EOF
-chmod +x "$MT_INIT_SOLO_DIR/bin/gh"
+install_isolated_gh "$MT_INIT_SOLO_DIR"
 set +e
 OUT=$(cd "$MT_INIT_SOLO_DIR" && PATH="$MT_INIT_SOLO_DIR/bin:$PATH" node "$SCRIPT_DIR/sprint-init.js" "solo-probe" --dry-run 2>/dev/null)
 STATUS=$?

--- a/skills/dev-backlog/scripts/smoke-test.sh
+++ b/skills/dev-backlog/scripts/smoke-test.sh
@@ -1153,10 +1153,16 @@ if (bad.length !== 0) process.exit(1);
 # Use a fresh spec-less dir with an empty sprints/ so init isn't refused as a
 # second active sprint.
 COLD_INIT_DIR="$TEST_DIR/cold-init"
-mkdir -p "$COLD_INIT_DIR/backlog/sprints" "$COLD_INIT_DIR/backlog/tasks"
+mkdir -p "$COLD_INIT_DIR/backlog/sprints" "$COLD_INIT_DIR/backlog/tasks" "$COLD_INIT_DIR/bin"
 git -C "$COLD_INIT_DIR" init -q
+cat >"$COLD_INIT_DIR/bin/gh" <<'EOF'
+#!/bin/sh
+echo "unable to expand placeholder in path: no git remotes found" >&2
+exit 1
+EOF
+chmod +x "$COLD_INIT_DIR/bin/gh"
 set +e
-INIT_JSON=$(cd "$COLD_INIT_DIR" && node "$SCRIPT_DIR/sprint-init.js" "cold-probe" --dry-run --json 2>/dev/null)
+INIT_JSON=$(cd "$COLD_INIT_DIR" && PATH="$COLD_INIT_DIR/bin:$PATH" node "$SCRIPT_DIR/sprint-init.js" "cold-probe" --dry-run --json 2>/dev/null)
 set -e
 if printf "%s" "$INIT_JSON" | node -e '
 const j = JSON.parse(require("fs").readFileSync(0, "utf8"));
@@ -1315,11 +1321,17 @@ if (!/cannot prove disjoint/.test(c.detail.summary)) process.exit(1);
 # overlapping scope is refused naming the conflicting track. Scope is always
 # explicit via --scope (D2) — never inferred from touched paths.
 MT_LIFE_DIR="$TEST_DIR/mt-lifecycle"
-mkdir -p "$MT_LIFE_DIR/backlog/sprints"
+mkdir -p "$MT_LIFE_DIR/backlog/sprints" "$MT_LIFE_DIR/bin"
 git -C "$MT_LIFE_DIR" init -q
+cat >"$MT_LIFE_DIR/bin/gh" <<'EOF'
+#!/bin/sh
+echo "unable to expand placeholder in path: no git remotes found" >&2
+exit 1
+EOF
+chmod +x "$MT_LIFE_DIR/bin/gh"
 mt_write_sprint "$MT_LIFE_DIR/backlog/sprints/2026-07-auth.md" "Auth" 1 '["src/auth/**"]'
 set +e
-OUT=$(cd "$MT_LIFE_DIR" && node "$SCRIPT_DIR/sprint-init.js" "billing" --scope "src/billing/**" --json 2>/dev/null)
+OUT=$(cd "$MT_LIFE_DIR" && PATH="$MT_LIFE_DIR/bin:$PATH" node "$SCRIPT_DIR/sprint-init.js" "billing" --scope "src/billing/**" --json 2>/dev/null)
 STATUS=$?
 set -e
 assert_equals "multi-track #292: disjoint second-track init exit code" "$STATUS" "0"
@@ -1331,7 +1343,7 @@ if (!/^scope: \["src\/billing\/\*\*"\]$/m.test(j.content)) process.exit(1);
 '
 
 set +e
-OUT=$(cd "$MT_LIFE_DIR" && node "$SCRIPT_DIR/sprint-init.js" "auth-two" --scope "src/auth/api/**" --dry-run 2>&1)
+OUT=$(cd "$MT_LIFE_DIR" && PATH="$MT_LIFE_DIR/bin:$PATH" node "$SCRIPT_DIR/sprint-init.js" "auth-two" --scope "src/auth/api/**" --dry-run 2>&1)
 STATUS=$?
 set -e
 assert_equals "multi-track #292: overlapping-scope init exit code" "$STATUS" "1"
@@ -1339,10 +1351,16 @@ assert_contains "multi-track #292: overlapping init names the conflicting track"
 
 # G4: first-sprint init (no active sprint yet) keeps today's text and exit code.
 MT_INIT_SOLO_DIR="$TEST_DIR/mt-init-solo"
-mkdir -p "$MT_INIT_SOLO_DIR/backlog/sprints"
+mkdir -p "$MT_INIT_SOLO_DIR/backlog/sprints" "$MT_INIT_SOLO_DIR/bin"
 git -C "$MT_INIT_SOLO_DIR" init -q
+cat >"$MT_INIT_SOLO_DIR/bin/gh" <<'EOF'
+#!/bin/sh
+echo "unable to expand placeholder in path: no git remotes found" >&2
+exit 1
+EOF
+chmod +x "$MT_INIT_SOLO_DIR/bin/gh"
 set +e
-OUT=$(cd "$MT_INIT_SOLO_DIR" && node "$SCRIPT_DIR/sprint-init.js" "solo-probe" --dry-run 2>/dev/null)
+OUT=$(cd "$MT_INIT_SOLO_DIR" && PATH="$MT_INIT_SOLO_DIR/bin:$PATH" node "$SCRIPT_DIR/sprint-init.js" "solo-probe" --dry-run 2>/dev/null)
 STATUS=$?
 set -e
 assert_equals "multi-track G4 #292: single-track init dry-run exit code" "$STATUS" "0"

--- a/skills/dev-backlog/scripts/smoke-test.sh
+++ b/skills/dev-backlog/scripts/smoke-test.sh
@@ -1154,6 +1154,7 @@ if (bad.length !== 0) process.exit(1);
 # second active sprint.
 COLD_INIT_DIR="$TEST_DIR/cold-init"
 mkdir -p "$COLD_INIT_DIR/backlog/sprints" "$COLD_INIT_DIR/backlog/tasks"
+git -C "$COLD_INIT_DIR" init -q
 set +e
 INIT_JSON=$(cd "$COLD_INIT_DIR" && node "$SCRIPT_DIR/sprint-init.js" "cold-probe" --dry-run --json 2>/dev/null)
 set -e
@@ -1315,6 +1316,7 @@ if (!/cannot prove disjoint/.test(c.detail.summary)) process.exit(1);
 # explicit via --scope (D2) — never inferred from touched paths.
 MT_LIFE_DIR="$TEST_DIR/mt-lifecycle"
 mkdir -p "$MT_LIFE_DIR/backlog/sprints"
+git -C "$MT_LIFE_DIR" init -q
 mt_write_sprint "$MT_LIFE_DIR/backlog/sprints/2026-07-auth.md" "Auth" 1 '["src/auth/**"]'
 set +e
 OUT=$(cd "$MT_LIFE_DIR" && node "$SCRIPT_DIR/sprint-init.js" "billing" --scope "src/billing/**" --json 2>/dev/null)
@@ -1338,6 +1340,7 @@ assert_contains "multi-track #292: overlapping init names the conflicting track"
 # G4: first-sprint init (no active sprint yet) keeps today's text and exit code.
 MT_INIT_SOLO_DIR="$TEST_DIR/mt-init-solo"
 mkdir -p "$MT_INIT_SOLO_DIR/backlog/sprints"
+git -C "$MT_INIT_SOLO_DIR" init -q
 set +e
 OUT=$(cd "$MT_INIT_SOLO_DIR" && node "$SCRIPT_DIR/sprint-init.js" "solo-probe" --dry-run 2>/dev/null)
 STATUS=$?

--- a/skills/dev-backlog/scripts/sprint-close.sh
+++ b/skills/dev-backlog/scripts/sprint-close.sh
@@ -105,6 +105,23 @@ if [ "$CB_TODO" -gt 0 ] || [ "$CB_IN_FLIGHT" -gt 0 ]; then
   echo "Warning: $CB_TODO todo, $CB_IN_FLIGHT in-flight items remaining"
 fi
 
+# --- Step 0: Optional provider mutation runs BEFORE any local mutation ---
+# Fail-loud contract (#366): if the GitHub milestone cannot be closed, the
+# local sprint must remain active — never completed-with-open-milestone.
+# There is no automatic retry and no fallback authority: fix GitHub access
+# (rate limit / auth / outage) and re-run the close.
+if $CLOSE_MILESTONE && ! $DRY_RUN; then
+  CLOSE_MILESTONE_NAME=$(grep '^milestone:' "$ACTIVE" | sed 's/^milestone: *//')
+  if [ -z "$CLOSE_MILESTONE_NAME" ]; then
+    echo "No milestone: frontmatter in $ACTIVE; cannot --close-milestone."
+    exit 1
+  fi
+  if ! node "$SCRIPT_DIR/tracker-capability.js" close-milestone milestones "$BACKLOG_DIR" "$CLOSE_MILESTONE_NAME"; then
+    echo "Refusing to mark sprint completed: GitHub milestone '$CLOSE_MILESTONE_NAME' could not be closed."
+    exit 1
+  fi
+fi
+
 # --- Step 1: Run backlog-doctor and compute the close signal ---
 # The doctor runs before the status flip. Its Node close-summary mode receives
 # the closing sprint path and counts that sprint on today's date, so dry-run
@@ -173,7 +190,8 @@ if $CLOSE_MILESTONE; then
     if $DRY_RUN; then
       echo "[dry-run] Would close milestone: $MILESTONE"
     else
-      node "$SCRIPT_DIR/tracker-capability.js" close-milestone milestones "$BACKLOG_DIR" "$MILESTONE" 2>/dev/null
+      # Already closed in Step 0 (before local mutation); confirmation only.
+      echo "Closed milestone: $MILESTONE"
     fi
   fi
 fi

--- a/skills/dev-backlog/scripts/sprint-init.js
+++ b/skills/dev-backlog/scripts/sprint-init.js
@@ -295,7 +295,6 @@ function createSprintFile({
     getDue = getDue || getMilestoneDue;
     getIssues = getIssues || getMilestoneIssues;
   }
-  if (!dryRun) mkdir(sprintsDir);
 
   const datePrefix = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}`;
   const started = today.toISOString().slice(0, 10);
@@ -320,6 +319,10 @@ function createSprintFile({
   const charterPresent = hasCharter ?? detected.hasCharter;
   const capabilitiesPresent = hasCapabilities ?? detected.hasCapabilities;
 
+  // Fail-loud ordering (#366): getDue/getIssues run BEFORE any filesystem
+  // effect so a gh failure leaves no sprint file (or even sprints dir)
+  // behind. Previously getMilestoneDue/getMilestoneIssues swallowed errors
+  // as TBD/[], silently writing an empty sprint on a broken provider.
   const due = existingFile ? "TBD" : getDue(milestone);
   const issues = existingFile ? [] : getIssues(milestone);
   const content = existingFile
@@ -337,6 +340,7 @@ function createSprintFile({
       });
 
   if (!dryRun && !existingFile) {
+    mkdir(sprintsDir);
     writeFile(sprintFile, content);
   }
 

--- a/skills/dev-backlog/scripts/status.sh
+++ b/skills/dev-backlog/scripts/status.sh
@@ -104,8 +104,9 @@ fi
 echo ""
 echo "=== Tracker Tasks ==="
 if command -v column >/dev/null 2>&1; then
-	node "$SCRIPT_DIR/tracker-status-list.js" "$BACKLOG_DIR" | column -t -s $'\t' ||
-		echo "(gh not available)"
+	if ! node "$SCRIPT_DIR/tracker-status-list.js" "$BACKLOG_DIR" | column -t -s $'\t'; then
+		exit 1
+	fi
 else
 	echo "(gh not available)"
 fi

--- a/skills/dev-backlog/scripts/tracker-capability.js
+++ b/skills/dev-backlog/scripts/tracker-capability.js
@@ -19,11 +19,10 @@ function main() {
     const resolved = requireCapability(capability, backlogDir);
     if (operation === "require") return;
     if (operation === "close-milestone") {
-      const count = invokeCapability(resolved, "milestones", () => closeMilestone(
-        value,
-        undefined,
-        () => console.log(`Warning: Could not close milestone: ${value}`)
-      ));
+      // Fail-loud (#366): no swallow-on-PATCH-error callback. A failed
+      // milestone PATCH must exit non-zero so sprint-close refuses to mark
+      // the local sprint completed.
+      const count = invokeCapability(resolved, "milestones", () => closeMilestone(value));
       if (count > 0) console.log(`Closed milestone: ${value}`);
       return;
     }

--- a/skills/dev-backlog/scripts/tracker-cycle.acceptance.test.js
+++ b/skills/dev-backlog/scripts/tracker-cycle.acceptance.test.js
@@ -189,7 +189,7 @@ function runGithubCycle(fixture) {
     ["issue", "view", "42", "--json", "number,title,body,labels,milestone,assignees,createdAt,updatedAt"],
     ["issue", "edit", "42", "--title", "Cycle task renamed"],
     ["issue", "list", "--state", "open", "--limit", "1", "--json", "number,title,body,labels,milestone,assignees"],
-    ["api", "repos/{owner}/{repo}/milestones", "--jq", '.[] | select(.title==env.MS) | .number'],
+    ["api", "repos/{owner}/{repo}/milestones?state=all", "--jq", '.[] | select(.title==env.MS) | [.number, .state] | @tsv'],
     ["api", "-X", "PATCH", "repos/{owner}/{repo}/milestones/7", "-f", "state=closed"],
     ["issue", "close", "42"],
     ["issue", "list", "--state", "closed", "--limit", "20", "--json", "number,title,body,labels,milestone,assignees,createdAt,updatedAt"],

--- a/skills/dev-backlog/scripts/tracker-cycle.acceptance.test.js
+++ b/skills/dev-backlog/scripts/tracker-cycle.acceptance.test.js
@@ -5,6 +5,7 @@ const os = require("node:os");
 const path = require("node:path");
 const { spawnSync } = require("node:child_process");
 const { resolveBashExecutable, toBashArgs } = require("./bash-runtime.js");
+const { writeGhFixture } = require("./fake-gh-fixture.js");
 
 const SCRIPTS_DIR = __dirname;
 const TRACKER_PATH = path.join(SCRIPTS_DIR, "tracker.js");
@@ -65,121 +66,6 @@ function runWorker(fixture, action, payload = {}) {
     run(process.execPath, [fixture.worker, fixture.backlogDir, action, JSON.stringify(payload)], fixture),
     `${fixture.tracker} ${action}`
   );
-}
-
-function writeGhFixture(root) {
-  const binDir = path.join(root, "bin");
-  const statePath = path.join(root, "gh-state.json");
-  const logPath = path.join(root, "gh-argv.jsonl");
-  fs.mkdirSync(binDir, { recursive: true });
-  fs.writeFileSync(statePath, JSON.stringify({
-    nextIssue: 42,
-    issues: [],
-    milestoneClosed: false,
-  }));
-  const ghPath = path.join(binDir, "gh");
-  fs.writeFileSync(ghPath, `#!/usr/bin/env node
-const fs = require("node:fs");
-const args = process.argv.slice(2);
-const statePath = process.env.FAKE_GH_STATE;
-const logPath = process.env.FAKE_GH_LOG;
-const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
-fs.appendFileSync(logPath, JSON.stringify(args) + "\\n");
-const save = () => fs.writeFileSync(statePath, JSON.stringify(state));
-const valueAfter = (flag) => args[args.indexOf(flag) + 1];
-const out = (value) => process.stdout.write(typeof value === "string" ? value : JSON.stringify(value));
-const exact = (expected) => JSON.stringify(args) === JSON.stringify(expected);
-const exactBodyCall = (head) =>
-  args.length === head.length + 2 &&
-  exact([...head, "--body", args[args.length - 1]]) &&
-  typeof args[args.length - 1] === "string";
-
-if (exactBodyCall(["issue", "create", "--title", args[3]]) && args[3]) {
-  const title = valueAfter("--title");
-  const body = valueAfter("--body") || "";
-  const number = state.nextIssue++;
-  state.issues.push({
-    number, title, body, state: "open", url: "https://github.test/acme/widgets/issues/" + number,
-    labels: [{ name: "priority:high" }], milestone: { title: "Cycle Milestone" }, assignees: [],
-  });
-  save(); out("https://github.test/acme/widgets/issues/" + number + "\\n");
-  process.exit(0);
-}
-
-if (args[0] === "issue" && args[1] === "list") {
-  if (exact(["issue", "list", "--milestone", "Cycle Milestone", "--state", "open", "--json", "number,title,labels"])) {
-    out(state.issues.filter((issue) => issue.state === "open").map(({ number, title, labels }) => ({ number, title, labels })));
-  } else if (exact(["issue", "list", "--state", "open", "--limit", "1", "--json", "number,title,body,labels,milestone,assignees"]) ||
-      exact(["issue", "list", "--state", "closed", "--limit", "20", "--json", "number,title,body,labels,milestone,assignees,createdAt,updatedAt"])) {
-    out(state.issues.filter((issue) => {
-      const requested = valueAfter("--state") || "open";
-      return requested === "all" || issue.state === requested;
-    }));
-  } else {
-    process.stderr.write("unhandled fake gh argv: " + JSON.stringify(args) + "\\n"); process.exit(93);
-  }
-  process.exit(0);
-}
-
-if (exact(["issue", "view", "42", "--json", "number,title,body,labels,milestone,assignees,createdAt,updatedAt"]) ||
-    exact(["issue", "view", "42", "--json", "number,title,body,state,labels,milestone,assignees,createdAt,updatedAt,url"]) ||
-    exact(["issue", "view", "42", "--json", "number,title,body,state,labels,milestone,assignees,createdAt,updatedAt,url,comments"])) {
-  const issue = state.issues.find((candidate) => String(candidate.number) === args[2]);
-  if (!issue) process.exit(4);
-  out(issue); process.exit(0);
-}
-
-if (exact(["issue", "edit", "42", "--title", "Cycle task renamed"])) {
-  const number = Number(args[2]);
-  const issue = state.issues.find((candidate) => candidate.number === number);
-  if (issue) issue.title = valueAfter("--title");
-  save(); process.exit(0);
-}
-
-if (exact(["issue", "close", "42"])) {
-  const issue = state.issues.find((candidate) => String(candidate.number) === args[2]);
-  if (issue) issue.state = "closed";
-  save(); process.exit(0);
-}
-
-if (exact(["api", "repos/{owner}/{repo}/milestones", "--jq", '.[] | select(.title==env.MS) | .due_on']) ||
-    exact(["api", "repos/{owner}/{repo}/milestones", "--jq", '.[] | select(.title==env.MS) | .number'])) {
-  const query = valueAfter("--jq");
-  out(query.includes("due_on") ? "2026-06-30T00:00:00Z\\n" : "7\\n");
-  process.exit(0);
-}
-if (exact(["api", "-X", "PATCH", "repos/{owner}/{repo}/milestones/7", "-f", "state=closed"])) {
-  state.milestoneClosed = true; save(); process.exit(0);
-}
-process.stderr.write("unhandled fake gh argv: " + JSON.stringify(args) + "\\n");
-process.exit(93);
-`);
-  fs.chmodSync(ghPath, 0o755);
-  if (process.platform === "win32") {
-    fs.writeFileSync(`${ghPath}.cmd`, `@echo off\r\n"${process.execPath}" "${ghPath}" %*\r\n`);
-  }
-  const preloadPath = path.join(root, "mock-gh-preload.cjs");
-  fs.writeFileSync(preloadPath, `
-const childProcess = require("node:child_process");
-const original = childProcess.execFileSync;
-childProcess.execFileSync = function (command, args, options) {
-  if (command === "gh") return original(process.execPath, [${JSON.stringify(ghPath)}, ...args], options);
-  return original(command, args, options);
-};
-`);
-  return {
-    env: {
-      ...process.env,
-      PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`,
-      NODE_OPTIONS: `--require=${preloadPath}`,
-      FAKE_GH_STATE: statePath,
-      FAKE_GH_LOG: logPath,
-    },
-    calls: () => fs.existsSync(logPath)
-      ? fs.readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean).map(JSON.parse)
-      : [],
-    state: () => JSON.parse(fs.readFileSync(statePath, "utf8")),
-  };
 }
 
 function prepareGithub(t) {

--- a/skills/dev-backlog/scripts/tracker-cycle.acceptance.test.js
+++ b/skills/dev-backlog/scripts/tracker-cycle.acceptance.test.js
@@ -189,7 +189,7 @@ function runGithubCycle(fixture) {
     ["issue", "view", "42", "--json", "number,title,body,labels,milestone,assignees,createdAt,updatedAt"],
     ["issue", "edit", "42", "--title", "Cycle task renamed"],
     ["issue", "list", "--state", "open", "--limit", "1", "--json", "number,title,body,labels,milestone,assignees"],
-    ["api", "repos/{owner}/{repo}/milestones?state=all", "--jq", '.[] | select(.title==env.MS) | [.number, .state] | @tsv'],
+    ["api", "--paginate", "repos/{owner}/{repo}/milestones?state=all&per_page=100", "--jq", '.[] | select(.title==env.MS) | [.number, .state] | @tsv'],
     ["api", "-X", "PATCH", "repos/{owner}/{repo}/milestones/7", "-f", "state=closed"],
     ["issue", "close", "42"],
     ["issue", "list", "--state", "closed", "--limit", "20", "--json", "number,title,body,labels,milestone,assignees,createdAt,updatedAt"],

--- a/skills/dev-backlog/scripts/tracker-status-list.js
+++ b/skills/dev-backlog/scripts/tracker-status-list.js
@@ -18,11 +18,21 @@ function listStatusRows(backlogDir = "backlog", { execFile } = {}) {
   ].join("\t"));
 }
 
+function isStatusFallbackError(error) {
+  if (isIsolatedGithubError(error) || error.tracker || error.name === "TrackerConfigurationError") {
+    return true;
+  }
+  const text = String(error.stderr || "") + String(error.message || "");
+  return /GH_TOKEN/.test(text)
+    || /To use GitHub CLI in a GitHub Actions workflow/.test(text)
+    || /gh auth login/.test(text);
+}
+
 function main() {
   try {
     process.stdout.write(`${listStatusRows(process.argv[2]).join("\n")}\n`);
   } catch (error) {
-    if (isIsolatedGithubError(error) || error.tracker || error.name === "TrackerConfigurationError") {
+    if (isStatusFallbackError(error)) {
       process.stdout.write("(gh not available)\n");
       return;
     }
@@ -34,4 +44,4 @@ function main() {
 
 if (require.main === module) main();
 
-module.exports = { listStatusRows };
+module.exports = { listStatusRows, isStatusFallbackError };

--- a/skills/dev-backlog/scripts/tracker-status-list.js
+++ b/skills/dev-backlog/scripts/tracker-status-list.js
@@ -2,6 +2,7 @@
 
 const { readConfig } = require("./lib.js");
 const { resolveConfiguredTracker } = require("./tracker.js");
+const { isIsolatedGithubError } = require("./github-milestones.js");
 
 function listStatusRows(backlogDir = "backlog", { execFile } = {}) {
   const resolved = resolveConfiguredTracker(readConfig(backlogDir), { execFile, backlogDir });
@@ -21,10 +22,13 @@ function main() {
   try {
     process.stdout.write(`${listStatusRows(process.argv[2]).join("\n")}\n`);
   } catch (error) {
-    const message = error?.tracker
-      ? `(tracker unavailable: ${error.message})`
-      : "(gh not available)";
-    process.stdout.write(`${message}\n`);
+    if (isIsolatedGithubError(error) || error.tracker || error.name === "TrackerConfigurationError") {
+      process.stdout.write("(gh not available)\n");
+      return;
+    }
+    // Fail loud (#366): provider failures surface stderr and exit non-zero.
+    process.stderr.write(String(error.stderr || error.message) + "\n");
+    process.exitCode = 1;
   }
 }
 

--- a/skills/dev-backlog/scripts/tracker-status-list.js
+++ b/skills/dev-backlog/scripts/tracker-status-list.js
@@ -19,7 +19,7 @@ function listStatusRows(backlogDir = "backlog", { execFile } = {}) {
 }
 
 function isStatusFallbackError(error) {
-  if (isIsolatedGithubError(error) || error.tracker || error.name === "TrackerConfigurationError") {
+  if (isIsolatedGithubError(error) || error.name === "TrackerConfigurationError") {
     return true;
   }
   const text = String(error.stderr || "") + String(error.message || "");

--- a/skills/dev-backlog/scripts/tracker-status-list.test.js
+++ b/skills/dev-backlog/scripts/tracker-status-list.test.js
@@ -3,6 +3,7 @@ const { spawnSync } = require("node:child_process");
 const path = require("node:path");
 const fs = require("node:fs");
 const os = require("node:os");
+const { isStatusFallbackError } = require("./tracker-status-list.js");
 
 const script = path.join(__dirname, "tracker-status-list.js");
 
@@ -14,6 +15,21 @@ const script = path.join(__dirname, "tracker-status-list.js");
   assert.equal(res.status, 0, `exit ${res.status}: ${res.stderr}`);
   assert.equal(res.stdout, "(gh not available)\n");
   fs.rmSync(dir, { recursive: true, force: true });
+}
+
+{
+  assert.equal(isStatusFallbackError({
+    stderr: "gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.",
+  }), true);
+  assert.equal(isStatusFallbackError({
+    message: "To get started with GitHub CLI, please run:  gh auth login",
+  }), true);
+  assert.equal(isStatusFallbackError({
+    stderr: "gh: API rate limit exceeded for installation.",
+  }), false);
+  assert.equal(isStatusFallbackError({
+    stderr: "gh: HTTP 401: authentication required (Bad credentials)",
+  }), false);
 }
 
 console.log("tracker-status-list.test.js: ok");

--- a/skills/dev-backlog/scripts/tracker-status-list.test.js
+++ b/skills/dev-backlog/scripts/tracker-status-list.test.js
@@ -1,0 +1,19 @@
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const path = require("node:path");
+const fs = require("node:fs");
+const os = require("node:os");
+
+const script = path.join(__dirname, "tracker-status-list.js");
+
+{
+  // A local (unconfigured) .tracker must fall back to "(gh not available)", exit 0.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tsl-test-"));
+  fs.writeFileSync(path.join(dir, ".tracker"), "local\n", { flag: "wx" });
+  const res = spawnSync(process.execPath, [script, dir], { encoding: "utf8" });
+  assert.equal(res.status, 0, `exit ${res.status}: ${res.stderr}`);
+  assert.equal(res.stdout, "(gh not available)\n");
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+console.log("tracker-status-list.test.js: ok");


### PR DESCRIPTION
Closes #366.

pi OpenRouter `stealth/ox-alpha` implementation (not OpenCode Zen, not Hermes).

- Inventory + operator runbook in `docs/github-resilience.md`
- Fake-`gh` `FAKE_GH_FAIL`: rate-limit, auth-expired, partial-outage
- Sprint init fail-loud on those three classes; isolated/no-remote still TBD/[]
- Sprint close `--close-milestone` mutates GitHub before local status flip
- No silent retry

## Test
- `node --test skills/*/scripts/*.test.js` — 502 pass / 1 skip
- `bash skills/dev-backlog/scripts/smoke-test.sh` — 190 pass

Supersedes #389 (Hermes-authored, changes_requested).